### PR TITLE
Geocode receipt locations with Google Maps (closes #12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@types/pg": "^8.20.0",
+        "dotenv": "^17.4.2",
         "express": "^5.1.0",
         "fastmcp": "^3.34.0",
         "heic-convert": "^2.1.0",
@@ -1076,6 +1077,18 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1283,6 +1296,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1734,6 +1748,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2338,6 +2353,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@types/pg": "^8.20.0",
+    "dotenv": "^17.4.2",
     "express": "^5.1.0",
     "fastmcp": "^3.34.0",
     "heic-convert": "^2.1.0",

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -117,6 +117,7 @@ RULES:
 - payment_method: MUST be one of: credit_card|debit_card|cash|mobile_pay|other
 - tax: tax amount if visible
 - tip: tip amount if visible (watch for handwritten tips)
+- address: full printed street address of the merchant if visible on the receipt (e.g. "11727 Olympic Blvd, Los Angeles, CA 90064"). Combine street, city, state, zip into one string. Use NULL if not visible — do NOT guess.
 - raw_text: full transcription of the receipt text
 - For each line item: name, quantity (default 1), unit_price, total_price
 
@@ -124,7 +125,7 @@ DATABASE — run SQL via:
 ${psqlCmd} "<SQL>"
 
 UPDATE the existing receipt row:
-UPDATE receipts SET merchant='...', date='...', total=<num>, currency='...', category='...', payment_method='...', tax=<num_or_null>, tip=<num_or_null>, raw_text='...', status='done', updated_at=NOW() WHERE id='${receiptId}';
+UPDATE receipts SET merchant='...', date='...', total=<num>, currency='...', category='...', payment_method='...', tax=<num_or_null>, tip=<num_or_null>, address=<'...'_or_NULL>, raw_text='...', status='done', updated_at=NOW() WHERE id='${receiptId}';
 
 For each line item:
 INSERT INTO receipt_items (receipt_id, name, quantity, unit_price, total_price) VALUES ('${receiptId}', '...', <qty>, <price>, <total>);

--- a/src/db.ts
+++ b/src/db.ts
@@ -37,6 +37,10 @@ export interface ReceiptData {
   notes?: string;
   raw_text?: string;
   image_path?: string;
+  address?: string;
+  latitude?: number;
+  longitude?: number;
+  place_id?: string;
   extraction_meta?: ExtractionMeta;
   items?: {
     name: string;
@@ -100,6 +104,12 @@ export async function initSchema(): Promise<void> {
 
   // Add status column for async processing (placeholder → done/error)
   await p.query(`ALTER TABLE receipts ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'done'`);
+
+  // Geocoding columns (populated by post-extraction geocode step)
+  await p.query(`ALTER TABLE receipts ADD COLUMN IF NOT EXISTS address TEXT`);
+  await p.query(`ALTER TABLE receipts ADD COLUMN IF NOT EXISTS latitude REAL`);
+  await p.query(`ALTER TABLE receipts ADD COLUMN IF NOT EXISTS longitude REAL`);
+  await p.query(`ALTER TABLE receipts ADD COLUMN IF NOT EXISTS place_id TEXT`);
 
   await p.query(`CREATE INDEX IF NOT EXISTS idx_receipts_date ON receipts(date)`);
   await p.query(`CREATE INDEX IF NOT EXISTS idx_receipts_merchant ON receipts(merchant)`);
@@ -198,6 +208,28 @@ export async function updateReceiptStatus(
   await p.query(
     `UPDATE receipts SET status = $1, notes = COALESCE($2, notes), updated_at = NOW() WHERE id = $3`,
     [status, error ?? null, id]
+  );
+}
+
+/**
+ * Update geocoding fields for a receipt. Called after the extraction
+ * pipeline finishes. Fails silently if the receipt is gone.
+ */
+export async function updateReceiptGeocode(
+  id: string,
+  geo: { address?: string | null; latitude: number; longitude: number; place_id: string }
+): Promise<void> {
+  const p = getPool();
+  await initSchema();
+  await p.query(
+    `UPDATE receipts
+     SET address = COALESCE($1, address),
+         latitude = $2,
+         longitude = $3,
+         place_id = $4,
+         updated_at = NOW()
+     WHERE id = $5`,
+    [geo.address ?? null, geo.latitude, geo.longitude, geo.place_id, id]
   );
 }
 

--- a/src/geocode.ts
+++ b/src/geocode.ts
@@ -1,0 +1,80 @@
+/**
+ * Resolve a receipt's merchant location to lat/lng using Google APIs.
+ *
+ * Strategy:
+ *   1. Geocoding API on the printed address (free tier covers typical use).
+ *   2. Places "Find Place from Text" fallback on the merchant name when
+ *      there is no address or the address fails to geocode.
+ *
+ * Never throws — returns null on any failure so the extraction pipeline
+ * cannot be broken by a Google API outage, quota exhaustion, or bad key.
+ */
+
+const GEOCODING_URL = "https://maps.googleapis.com/maps/api/geocode/json";
+const FIND_PLACE_URL = "https://maps.googleapis.com/maps/api/place/findplacefromtext/json";
+const TIMEOUT_MS = 5000;
+
+export interface GeocodeResult {
+  latitude: number;
+  longitude: number;
+  place_id: string;
+}
+
+async function fetchJson(url: string): Promise<any | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function geocodeAddress(address: string, key: string): Promise<GeocodeResult | null> {
+  const url = `${GEOCODING_URL}?address=${encodeURIComponent(address)}&key=${key}`;
+  const data = await fetchJson(url);
+  if (!data || data.status !== "OK" || !data.results?.length) return null;
+  const top = data.results[0];
+  const loc = top.geometry?.location;
+  if (!loc || typeof loc.lat !== "number" || typeof loc.lng !== "number") return null;
+  return { latitude: loc.lat, longitude: loc.lng, place_id: top.place_id ?? "" };
+}
+
+async function findPlaceByMerchant(merchant: string, key: string): Promise<GeocodeResult | null> {
+  const params = new URLSearchParams({
+    input: merchant,
+    inputtype: "textquery",
+    fields: "place_id,geometry",
+    key,
+  });
+  const data = await fetchJson(`${FIND_PLACE_URL}?${params.toString()}`);
+  if (!data || data.status !== "OK" || !data.candidates?.length) return null;
+  const top = data.candidates[0];
+  const loc = top.geometry?.location;
+  if (!loc || typeof loc.lat !== "number" || typeof loc.lng !== "number") return null;
+  return { latitude: loc.lat, longitude: loc.lng, place_id: top.place_id ?? "" };
+}
+
+export async function geocodeReceipt(params: {
+  address?: string | null;
+  merchant?: string | null;
+}): Promise<GeocodeResult | null> {
+  const key = process.env.GOOGLE_MAPS_SERVER_KEY;
+  if (!key) return null;
+
+  if (params.address && params.address.trim()) {
+    const hit = await geocodeAddress(params.address.trim(), key);
+    if (hit) return hit;
+  }
+
+  if (params.merchant && params.merchant.trim()) {
+    const hit = await findPlaceByMerchant(params.merchant.trim(), key);
+    if (hit) return hit;
+  }
+
+  return null;
+}

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,8 +1,9 @@
 import { EventEmitter } from "events";
 import { v4 as uuidv4 } from "uuid";
 import { processReceipt, getSessionJsonlPath } from "./claude.js";
-import { insertReceiptPlaceholder, updateReceiptStatus, getReceipt } from "./db.js";
+import { insertReceiptPlaceholder, updateReceiptStatus, getReceipt, updateReceiptGeocode } from "./db.js";
 import { ingestSession } from "./langfuse.js";
+import { geocodeReceipt } from "./geocode.js";
 
 // ── Job Store + Event Bus ────────────────────────────────────────────
 
@@ -51,6 +52,23 @@ function emit(jobId: string, event: JobEvent) {
   bus.emit(jobId, event);
 }
 
+/**
+ * Geocode the merchant location and persist it. Runs after the
+ * extraction pipeline has already marked the receipt as 'done'.
+ * Failures are swallowed — this must never flip status back to error.
+ */
+async function runGeocode(receiptId: string): Promise<void> {
+  try {
+    const row = await getReceipt(receiptId) as any;
+    if (!row) return;
+    const hit = await geocodeReceipt({ address: row.address, merchant: row.merchant });
+    if (!hit) return;
+    await updateReceiptGeocode(receiptId, { ...hit, address: row.address });
+  } catch {
+    // Geocoding failures never affect core pipeline
+  }
+}
+
 // ── Pipeline ─────────────────────────────────────────────────────────
 
 async function runJob(jobId: string) {
@@ -62,6 +80,9 @@ async function runJob(jobId: string) {
 
     emit(jobId, { type: "done", data: { receiptId: job.receiptId } });
 
+    // Fire-and-forget: geocode after extraction, persist lat/lng
+    runGeocode(job.receiptId);
+
     // Langfuse: ingest session trace (fire-and-forget)
     ingestSession(getSessionJsonlPath(sessionId), ["single-call", "receipt"]).catch(() => {});
   } catch (err: any) {
@@ -71,6 +92,7 @@ async function runJob(jobId: string) {
     if (receipt && receipt.status === "done") {
       // Claude finished the DB write — treat as success
       emit(jobId, { type: "done", data: { receiptId: job.receiptId } });
+      runGeocode(job.receiptId);
     } else {
       job.error = err.message;
       await updateReceiptStatus(job.receiptId, "error", err.message).catch(() => {});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { FastMCP } from "fastmcp";
 import { z } from "zod";
 import express, { type Request, type Response, type NextFunction } from "express";


### PR DESCRIPTION
Closes #12.

## Summary

Adds Google Maps geocoding as a post-extraction step. After Claude
parses a receipt and marks it `status='done'`, a fire-and-forget task
resolves the merchant's location to lat/lng and writes it back to the
same row. The frontend (paired PR) renders a Google Map on the detail
view when lat/lng is present.

## Resolution strategy

Two-layer address resolution, per the issue design:

1. **Primary** — Geocoding API on the `address` field Claude extracted
   from the printed receipt. Free tier covers typical use.
2. **Fallback** — Places "Find Place from Text" on the merchant name,
   triggered when there's no address or the Geocoding call returns
   nothing.

`geocodeReceipt()` never throws. Any failure — 5s timeout, quota
exhaustion, bad key, no results — returns `null` and the receipt
ships without lat/lng. The frontend hides the map section cleanly
in that case.

## Changes

### `src/geocode.ts` (new)
- Single export: `geocodeReceipt({ address, merchant })` → `{ latitude, longitude, place_id } | null`
- 5s `AbortController` timeout per Google API call
- Three layers of defense: try/catch around `fetch`, abort timeout, `null` return for any non-success path

### `src/db.ts`
- Schema migration via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`:
  - `address TEXT`
  - `latitude REAL`
  - `longitude REAL`
  - `place_id TEXT`
- `updateReceiptGeocode(id, geo)` — `COALESCE`s address so Claude's extracted value wins over anything Google returns, but lat/lng/place_id are overwritten
- `ReceiptData` interface extended with the 4 new fields

### `src/claude.ts`
- Extraction prompt now includes an `address` rule asking Claude to extract the full printed street address as one string, with explicit guidance to use `NULL` rather than guess if it's not visible
- `UPDATE receipts` SQL template includes the new `address` column

### `src/jobs.ts`
- Private `runGeocode(receiptId)` helper that re-fetches the row, calls `geocodeReceipt`, and persists via `updateReceiptGeocode`
- Called fire-and-forget after both the happy path AND the "max turns but DB write succeeded" recovery branch in `runJob`
- Geocoding errors are swallowed — they cannot flip job status back to error

### `src/server.ts`
- Single-line addition: `import "dotenv/config"` at the top so `GOOGLE_MAPS_SERVER_KEY` loads from a local `.env` file in dev
- No endpoint changes

### `package.json`
- Adds `dotenv ^17.4.2` as a runtime dependency

## New environment variable

| Name | Required | Description |
|---|---|---|
| `GOOGLE_MAPS_SERVER_KEY` | Yes (for geocoding to work) | Server-side key. Needs Geocoding API + Places API enabled in GCP. Should be IP-restricted. |

When unset, `geocodeReceipt` returns `null` on every call and receipts
ship without lat/lng. No error, no crash.

## Testing

Verified on a fresh local DB with two real receipts uploaded via the
existing `POST /receipt` flow:

| Merchant | Address extracted | Lat | Lng | Notes |
|---|---|---|---|---|
| Yoshinoya | `2260 Pico Blvd, Santa Monica, CA 90405` | 34.020794 | -118.46659 | Primary Geocoding path — full address → clean lat/lng |
| Le Yuen BBQ | `118 W. Valley Blvd., San Gabriel` | 34.07949 | -118.100426 | Incomplete address (no state/zip) still geocoded successfully |

Both rows have `place_id` populated.

- [x] DB migration runs cleanly (`initSchema` re-invoked on existing table, 4 new columns present)
- [x] Core extraction pipeline still completes `status='done'` end-to-end
- [x] Receipt row is visible in `GET /receipt/:id` with new fields
- [ ] Places "Find Place" fallback — **not yet tested** with a no-address receipt (e.g. Costco gas). Filing as a follow-up to smoke-test once the PR is up.
- [ ] Behavior with `GOOGLE_MAPS_SERVER_KEY` unset — reviewed in code (explicit null-check, early return), not exercised at runtime yet.

## Out of scope (per #12)

- Map tab with clustered pins for all receipts
- Spending-by-location heatmap
- Location bias on the Places fallback
- Retroactive geocoding script for existing receipts

## Related

- **Frontend counterpart**: TINKPA/receipt-assistant-frontend#1
- **Paired bug fix** found during development: #16 (unrelated to #12 — a pre-existing `res.sendFile` + relative path bug surfaced by host-mode dev)
- **Optional infra follow-up**: #17 (draft — exposes Langfuse postgres on host port 5433 for host-mode development)
- Builds on #11 (async pipeline) — no new schema conflicts, uses the same `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` pattern established there