### PR TITLE
Fix /receipt/:id/image 404 when image_path is relative

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -274,10 +274,12 @@ app.get("/receipt/:id/image", async (req: Request, res: Response) => {
     res.status(404).json({ error: "Image not found" });
     return;
   }
+  const absPath = path.resolve(receipt.image_path);
   try {
-    await fs.access(receipt.image_path);
-    res.sendFile(receipt.image_path);
-  } catch {
+    await fs.access(absPath);
+    res.sendFile(absPath);
+  } catch (err) {
+    console.error(`[/receipt/${req.params.id}/image] failed:`, err);
     res.status(404).json({ error: "Image file not found on disk" });
   }
 });


### PR DESCRIPTION
## Bug

`GET /receipt/:id/image` returns 404 with `{"error":"Image file not found on disk"}` even when the file is visibly present at the path in `receipts.image_path`.

## Root cause

`res.sendFile()` requires an absolute path and throws synchronously when given a relative one:
```
TypeError: path must be absolute or specify root to res.sendFile
```

The endpoint previously was:
```ts
try {
  await fs.access(receipt.image_path);   // works with relative (uses cwd)
  res.sendFile(receipt.image_path);       // throws on relative
} catch {
  res.status(404).json({ error: "Image file not found on disk" });
}
```

`fs.access` happily resolves relative paths against `process.cwd()`, so it succeeds. `res.sendFile` then throws synchronously, the bare `catch {}` swallows it, and the endpoint responds 404 with a message that suggests the file is missing — when in fact the file is there and the path format is the problem.

## Trigger

The bug surfaces whenever `UPLOAD_DIR` is configured as a relative path. In host-mode local development with `UPLOAD_DIR=./data/uploads`:

1. Multer saves the file and sets `req.file.path = "data/uploads/<uuid>.jpg"` (relative)
2. This path is stored in `receipts.image_path` as-is
3. Frontend requests `/api/receipt/<id>/image`, backend fails with a misleading 404
4. `ReceiptDetail.tsx` Receipt Image section shows a blank box

Receipts uploaded before host-mode — when `UPLOAD_DIR` defaulted to the Dockerfile's `/data/uploads` or was set to another absolute path — all have absolute paths in `image_path` and are unaffected.

## Reproduction

```bash
UPLOAD_DIR=./data/uploads npm run dev
curl -X POST http://localhost:3000/receipt -F "image=@receipt.jpg;type=image/jpeg"
# Wait for processing to complete
curl -i http://localhost:3000/receipt/<id>/image
# HTTP/1.1 404 Not Found
# {"error":"Image file not found on disk"}
```

## Fix

Wrap `receipt.image_path` in `path.resolve()` before both `fs.access()` and `res.sendFile()`. `path.resolve()` is a no-op on already-absolute paths, so old absolute-path rows are unaffected, and relative paths from newer configurations now work.

Also upgrades the catch block to log the underlying error to stderr, so future surprises in this endpoint don't get masked by the generic 404 message.

## Testing

Reproduced locally with one pre-existing receipt that had a relative `image_path` in the DB, plus one freshly uploaded receipt:

| Scenario | Before | After |
|---|---|---|
| Existing receipt, relative `image_path`, file present on disk | `404 "Image file not found on disk"` | `200` + JPEG bytes (3.4 MB) |
| Fresh upload, relative `image_path` | `404 "Image file not found on disk"` | `200` + JPEG bytes (4.0 MB) |
| Nonexistent receipt id | `404 "Image not found"` | `404 "Image not found"` (unchanged — early return) |

## Related

This was spotted while debugging why `ReceiptDetail.tsx` showed a blank Receipt Image section. Surfaced by the geocoding PR (#15) which introduced host-mode local development with a relative `UPLOAD_DIR`.