### PR TITLE
Expose Langfuse postgres on host port 5433 for host-mode development

### DIFF
--- a/langfuse/docker-compose.yml
+++ b/langfuse/docker-compose.yml
@@ -120,6 +120,8 @@ services:
   postgres:
     image: docker.io/postgres:17
     restart: always
+    ports:
+      - "5433:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Adds `ports: ["5433:5432"]` to the `postgres` service in `langfuse/docker-compose.yml`, mapping the container's Postgres port to the host.

## Why

The canonical deployment path in the README runs the receipt-assistant backend as a Docker container inside the `langfuse_default` network, where it reaches Postgres via `postgres:5432` through Docker's internal DNS. No host port exposure needed.

When running the backend in **host mode** (`npm run dev` on the developer machine instead of building a Docker image for every iteration), the backend is outside the Docker network and needs to connect to Postgres via `localhost:<port>`. Without a port mapping on the container, that's not possible.

Port `5433` is chosen to avoid collision with `5432`, which is commonly already in use by a host-native Postgres install or another project.

## Impact

- **Docker-mode users**: unaffected. The existing `postgres:5432` internal-network hostname still resolves via Docker DNS. Adding a host port mapping doesn't change internal networking.
- **Host-mode developers**: can now set `DATABASE_URL=postgresql://postgres:postgres@localhost:5433/receipts` in their `.env` and run `npm run dev` directly.
- **Developers with an existing service already bound to host `5433`**: `docker compose up` will fail on a port collision. This is a breaking change for that (likely rare) configuration.

## Alternatives considered

- **Keep it out of the committed compose file, document `docker-compose.override.yml` instead**: more idiomatic docker-compose pattern (local overrides don't need to live in the canonical file), and avoids the port-collision risk. Slightly more friction for new contributors doing host-mode development. Worth revisiting if port collision complaints arise.

## Related

- Paired with #15 (geocoding), which is the first backend feature that made host-mode development practical (the `CLAUDE_MODEL` env var needs to be tweakable without rebuilding a Docker image when Claude quota limits hit a specific model).