### PR TITLE
Unify dev stack under one docker compose for a Docker-first workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Keep the build context small and prevent stale host artifacts from
+# leaking into the image. Anything the Dockerfile doesn't COPY can be
+# excluded here.
+
+node_modules
+dist
+.git
+.gitignore
+.env
+.env.*
+!.env.example
+
+# Langfuse stack has its own compose file; its data volumes should
+# never enter the receipt-assistant build context.
+langfuse
+
+# Editor / OS noise
+.vscode
+.idea
+.DS_Store
+*.swp
+
+# Docs (CLAUDE.md is explicitly re-included because Dockerfile needs it)
+*.md
+!CLAUDE.md
+
+# Local data / uploads
+data
+uploads
+*.db
+*.sqlite
+
+# CI / tests output
+coverage
+.nyc_output

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Copy this file to .env and fill in the values. .env is gitignored.
+#
+# CLAUDE_CODE_OAUTH_TOKEN
+#   OAuth access token for the Claude Code CLI. On macOS it lives in the
+#   Keychain under "Claude Code-credentials". The easiest way to populate
+#   this value is:
+#
+#     ./scripts/refresh-token.sh
+#
+#   which reads the Keychain entry, extracts the accessToken field, and
+#   rewrites the CLAUDE_CODE_OAUTH_TOKEN line in .env in place.
+#
+#   Tokens expire periodically — rerun the script when claude -p calls
+#   start failing with auth errors.
+
+CLAUDE_CODE_OAUTH_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules/
 dist/
 /data/
 *.db
+
+# Local secrets — use .env.example as the template
+.env
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,55 @@
-FROM node:22-bookworm
+# syntax=docker/dockerfile:1.6
+#
+# Multi-stage build for receipt-assistant.
+#
+#   builder  — installs full deps (incl. devDependencies), compiles TypeScript,
+#              then prunes to production deps.
+#   runtime  — minimal image that only contains dist/ + production node_modules
+#              + the claude CLI.
+#
+# Both stages use node:22-bookworm so that native modules compiled in the
+# builder stage are ABI-compatible with the runtime stage (same glibc, same
+# node ABI).
 
-# Install build tools for native modules (better-sqlite3) + claude CLI
-RUN apt-get update && apt-get install -y \
-    python3 \
-    make \
-    g++ \
-    curl \
-    postgresql-client \
+# ---- Stage 1: builder ----
+FROM node:22-bookworm AS builder
+
+WORKDIR /app
+
+# Install full deps first (cached layer as long as package*.json is unchanged)
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Copy sources and build
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# Drop devDependencies so the runtime stage can copy a lean node_modules
+RUN npm prune --production
+
+# ---- Stage 2: runtime ----
+FROM node:22-bookworm AS runtime
+
+# Build tools kept for any on-demand native rebuilds; postgresql-client is
+# handy for debugging (psql) and curl is used by healthchecks / entrypoint.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        make \
+        g++ \
+        curl \
+        postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
+# Claude Code CLI — invoked by src/claude.ts as a subprocess.
 RUN npm install -g @anthropic-ai/claude-code
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install --omit=dev
-
-# Copy compiled output (build happens outside Docker)
-COPY dist/ ./dist/
-COPY CLAUDE.md ./
+# Copy compiled output and production node_modules from the builder stage.
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY package.json CLAUDE.md ./
 COPY docker/entrypoint.sh /app/docker/entrypoint.sh
 
 ENV NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -54,46 +54,49 @@ Every extraction includes metadata stored as PostgreSQL JSONB:
 
 ## Quick Start
 
+The entire stack (Langfuse + receipt-assistant) is orchestrated by a single
+root `docker-compose.yml`. Everything runs in Docker — there is no `npm run
+dev` on the host.
+
 ### Prerequisites
 
-- Docker & Docker Compose
-- Claude Code CLI with active subscription
-- macOS (for Keychain-based OAuth token extraction)
+- Docker Desktop (or Docker Engine) with Compose v2.20+ (for `include:` support)
+- Claude Code CLI signed in on macOS (the OAuth token is read from the Keychain)
 
-### 1. Start Langfuse monitoring stack
-
-```bash
-cd langfuse/
-docker compose up -d
-# Dashboard: http://localhost:3333 (admin@local.dev / Admin123!)
-```
-
-### 2. Build and run the backend
+### 1. Set up the OAuth token
 
 ```bash
-# Extract OAuth token from macOS Keychain
-export CLAUDE_CODE_OAUTH_TOKEN=$(security find-generic-password \
-  -s "Claude Code-credentials" -w | \
-  python3 -c "import json,sys; print(json.load(sys.stdin)['claudeAiOauth']['accessToken'])")
-
-# Build
-docker build -t receipt-assistant .
-
-# Run (joins Langfuse network, shares its PostgreSQL)
-docker run -d \
-  --name receipt-assistant \
-  --network langfuse_default \
-  -p 3000:3000 -p 3001:3001 \
-  -e CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN" \
-  -e DATABASE_URL="postgresql://postgres:postgres@postgres:5432/receipts" \
-  -e LANGFUSE_HOST="http://langfuse-web:3000" \
-  -e LANGFUSE_PUBLIC_KEY="pk-receipt-local" \
-  -e LANGFUSE_SECRET_KEY="sk-receipt-local" \
-  -v receipt-data:/data \
-  receipt-assistant
+./scripts/refresh-token.sh
 ```
 
-### 3. Test with a receipt
+This copies `.env.example` to `.env` (if needed) and writes your current
+Claude Code OAuth token into it. Rerun it whenever `claude -p` calls start
+failing with auth errors — tokens expire periodically.
+
+### 2. Bring everything up
+
+```bash
+docker compose up -d --build
+```
+
+This single command:
+- starts the full Langfuse stack (postgres, clickhouse, minio, redis, web, worker)
+- builds the receipt-assistant image (multi-stage: tsc in a builder stage, lean runtime)
+- runs receipt-assistant on ports 3000 (REST) and 3001 (MCP)
+
+Langfuse dashboard: http://localhost:3333 (admin@local.dev / admin123)
+
+### 3. After changing source code
+
+```bash
+docker compose up -d --build receipt-assistant
+```
+
+Only the app is rebuilt; the Langfuse stack keeps running. Layer caching in
+the Dockerfile means unchanged `package.json` skips the `npm ci` step, so
+rebuilds are typically 10–20 seconds.
+
+### 4. Test with a receipt
 
 ```bash
 # Upload

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+# Root compose file — one command brings up the whole stack:
+#
+#   docker compose up -d --build
+#
+# Langfuse (postgres, clickhouse, minio, redis, web, worker) is pulled in
+# verbatim from langfuse/docker-compose.yml via `include:` so we don't have
+# to duplicate its config here. receipt-assistant shares langfuse's postgres
+# instance (different database) for local dev simplicity.
+#
+# Requires Docker Compose v2.20+ for `include:` support.
+
+include:
+  - path: langfuse/docker-compose.yml
+
+services:
+  receipt-assistant:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: receipt-assistant:local
+    container_name: receipt-assistant
+    depends_on:
+      postgres:
+        condition: service_healthy
+      langfuse-web:
+        condition: service_started
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+    environment:
+      # Fail fast if the OAuth token isn't set in .env — better to error at
+      # `compose up` than to discover it after a failed claude -p call.
+      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:?set CLAUDE_CODE_OAUTH_TOKEN in .env (run scripts/refresh-token.sh)}
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/receipts
+      LANGFUSE_HOST: http://langfuse-web:3000
+      LANGFUSE_PUBLIC_KEY: pk-receipt-local
+      LANGFUSE_SECRET_KEY: sk-receipt-local
+    volumes:
+      - receipt-data:/data
+    restart: unless-stopped
+
+volumes:
+  receipt-data:

--- a/docs/verify-docker-setup.md
+++ b/docs/verify-docker-setup.md
@@ -1,0 +1,86 @@
+# Verify Docker-first dev stack
+
+Tracking checklist for end-to-end verification of the Docker-first dev
+environment introduced in commit `9ba17c4` on branch
+`claude/docker-testing-setup-V040p`.
+
+The change unified the dev stack into a single root `docker-compose.yml`
++ multi-stage `Dockerfile` + `include: langfuse/docker-compose.yml`. So
+far only `docker compose config --quiet` syntax validation has been run
+— this document tracks the actual end-to-end verification.
+
+## Verification checklist
+
+### Startup
+
+- [ ] `./scripts/refresh-token.sh` successfully extracts a token from
+      the macOS Keychain and writes it into `.env`
+- [ ] `.env` permissions are `600`
+- [ ] `docker compose up -d --build` brings up all 7 services in one
+      command (clickhouse, langfuse-web, langfuse-worker, minio,
+      postgres, receipt-assistant, redis)
+- [ ] `docker compose ps` shows every service as `healthy` / `running`
+- [ ] With `CLAUDE_CODE_OAUTH_TOKEN` unset, `docker compose up` fails
+      *immediately* (the `${VAR:?}` guard) rather than starting and
+      crashing later
+
+### Dockerfile multi-stage
+
+- [ ] Builder stage: `npm ci` + `tsc` succeed
+- [ ] Runtime stage contains only `dist/` + production `node_modules`,
+      no tsc / `@types`
+- [ ] Final image is smaller than the previous host-build version
+      (`docker images receipt-assistant`)
+- [ ] Editing one `.ts` file and rebuilding hits the `npm ci` layer
+      cache and only re-runs `tsc`
+
+### Service connectivity
+
+- [ ] `curl http://localhost:3000/health` returns 200
+- [ ] http://localhost:3333 (Langfuse) accepts login
+      `admin@local.dev` / `admin123`
+- [ ] receipt-assistant container resolves the `postgres` hostname
+      (provided by the included langfuse compose)
+- [ ] receipt-assistant container resolves `langfuse-web:3000`
+
+### End-to-end
+
+- [ ] `./scripts/verify-receipt.sh ~/Desktop/RECEIPT/<sample>.jpeg`
+      completes without errors
+- [ ] App API returns a structured result
+- [ ] A matching trace appears in Langfuse with both `phase-1/quick`
+      and `phase-2/full` generations
+
+### Restart & persistence
+
+- [ ] `docker compose down && docker compose up -d` preserves data
+      (the `receipt-data` named volume)
+- [ ] `docker compose down -v` actually wipes the data
+
+## Known risk points
+
+1. **Shared postgres**: receipt-assistant connects to
+   `postgresql://postgres:postgres@postgres:5432/receipts`, but the
+   langfuse stack only auto-creates the `postgres` database. If the
+   `receipts` database doesn't exist on first boot, the app will fail
+   to connect. Mitigation: create it from `docker/entrypoint.sh` (e.g.
+   `psql ... -c 'CREATE DATABASE receipts'` guarded by `IF NOT EXISTS`
+   logic) or via a `postgres-init` sidecar.
+
+2. **Native modules**: builder and runtime are both `node:22-bookworm`,
+   so glibc and node ABI match. Still worth confirming `heic-convert`
+   loads cleanly inside the runtime image — it depends on a WASM build
+   of libheif which should be platform-independent, but verify.
+
+3. **First-time image pull is heavy**: clickhouse + minio + langfuse
+   together are roughly 2–3 GB. The first `up --build` will be slow;
+   this is expected, not a regression.
+
+## Rollback
+
+```bash
+git revert 9ba17c4
+```
+
+Drops back to the previous three-window workflow
+(`cd langfuse && docker compose up` + hand-rolled `docker run`).

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/server.js",
-    "dev": "tsx src/server.ts",
     "db:init": "node dist/db.js"
   },
   "dependencies": {

--- a/scripts/refresh-token.sh
+++ b/scripts/refresh-token.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# refresh-token.sh — Extract the Claude Code OAuth token from the macOS
+# Keychain and write it into .env so docker compose can pick it up.
+#
+# Usage:
+#   ./scripts/refresh-token.sh
+#
+# The script rewrites the CLAUDE_CODE_OAUTH_TOKEN line atomically (via a
+# temp file + mv) so a failure mid-write cannot corrupt an existing .env.
+# If .env does not yet exist, it is created from .env.example.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+ENV_EXAMPLE="$REPO_ROOT/.env.example"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "refresh-token.sh: this helper only supports macOS (uses 'security')." >&2
+  echo "On other platforms set CLAUDE_CODE_OAUTH_TOKEN in .env manually." >&2
+  exit 1
+fi
+
+if ! command -v security >/dev/null 2>&1; then
+  echo "refresh-token.sh: 'security' command not found." >&2
+  exit 1
+fi
+
+# Bootstrap .env from the template if it doesn't exist yet.
+if [[ ! -f "$ENV_FILE" ]]; then
+  if [[ ! -f "$ENV_EXAMPLE" ]]; then
+    echo "refresh-token.sh: neither .env nor .env.example exists in $REPO_ROOT" >&2
+    exit 1
+  fi
+  cp "$ENV_EXAMPLE" "$ENV_FILE"
+  echo "refresh-token.sh: created .env from .env.example"
+fi
+
+echo "refresh-token.sh: reading token from Keychain..."
+RAW=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)
+if [[ -z "$RAW" ]]; then
+  echo "refresh-token.sh: no 'Claude Code-credentials' entry found in the Keychain." >&2
+  echo "Is Claude Code installed and signed in?" >&2
+  exit 1
+fi
+
+TOKEN=$(printf '%s' "$RAW" | python3 -c '
+import json, sys
+data = json.loads(sys.stdin.read())
+print(data["claudeAiOauth"]["accessToken"])
+')
+
+if [[ -z "$TOKEN" ]]; then
+  echo "refresh-token.sh: extracted empty token, aborting." >&2
+  exit 1
+fi
+
+# Atomic rewrite: build new file next to .env, then mv into place.
+TMP=$(mktemp "${ENV_FILE}.XXXXXX")
+trap 'rm -f "$TMP"' EXIT
+
+if grep -q '^CLAUDE_CODE_OAUTH_TOKEN=' "$ENV_FILE"; then
+  # Replace existing line. Use awk to avoid sed's escaping headaches with
+  # the token value (which may contain characters sed treats specially).
+  awk -v tok="$TOKEN" '
+    /^CLAUDE_CODE_OAUTH_TOKEN=/ { print "CLAUDE_CODE_OAUTH_TOKEN=" tok; next }
+    { print }
+  ' "$ENV_FILE" > "$TMP"
+else
+  cp "$ENV_FILE" "$TMP"
+  printf '\nCLAUDE_CODE_OAUTH_TOKEN=%s\n' "$TOKEN" >> "$TMP"
+fi
+
+mv "$TMP" "$ENV_FILE"
+trap - EXIT
+
+chmod 600 "$ENV_FILE"
+echo "refresh-token.sh: CLAUDE_CODE_OAUTH_TOKEN refreshed in $ENV_FILE"


### PR DESCRIPTION
Previously the dev loop required three terminals: `cd langfuse && docker
compose up`, a hand-rolled `docker run --network langfuse_default ...`
for receipt-assistant, and curl from the host. Vibe-coding against that
setup is noisy and easy to get wrong.

- Dockerfile is now multi-stage (builder compiles tsc + prunes, runtime
  ships only dist/ and production node_modules). Both stages use
  node:22-bookworm so native-module ABI matches.
- Root docker-compose.yml uses `include:` to pull in the existing
  langfuse/docker-compose.yml verbatim so upstream langfuse config
  stays easy to sync. receipt-assistant depends on postgres health and
  langfuse-web, and fails fast with `${CLAUDE_CODE_OAUTH_TOKEN:?}` if
  the token isn't in .env.
- .env.example + scripts/refresh-token.sh automate pulling the OAuth
  token from the macOS Keychain and writing it into .env atomically.
- .dockerignore keeps host node_modules/dist/.env out of the build
  context.
- README Quick Start is collapsed to `./scripts/refresh-token.sh &&
  docker compose up -d --build`.
- package.json loses the `dev` and `start` scripts — they only
  encouraged running node on the host.