### PR TITLE
Decouple receipt-assistant from Langfuse, make observability optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # Copy this file to .env and fill in the values. .env is gitignored.
+# docker compose reads .env automatically at `up` time.
+
+# ── Required ────────────────────────────────────────────────────────
 #
 # CLAUDE_CODE_OAUTH_TOKEN
 #   OAuth access token for the Claude Code CLI. On macOS it lives in the
@@ -12,5 +15,27 @@
 #
 #   Tokens expire periodically — rerun the script when claude -p calls
 #   start failing with auth errors.
-
 CLAUDE_CODE_OAUTH_TOKEN=
+
+# ── Optional ────────────────────────────────────────────────────────
+# Everything below has sensible defaults; only override when needed.
+
+# Parallel receipt extraction jobs. Each job spawns a claude subprocess,
+# so increasing this raises memory + API load. Default: 3.
+# MAX_CLAUDE_CONCURRENCY=3
+
+# Claude model used for extraction. Default: sonnet.
+# CLAUDE_MODEL=sonnet
+
+# Bearer token for the HTTP API. When unset, the API is open (fine for
+# localhost; set this for any deployment reachable from the network).
+# AUTH_TOKEN=
+
+# Google Maps Server API key for merchant geocoding (lat/lng + address
+# lookup). Geocoding is skipped silently when this is unset.
+# GOOGLE_MAPS_SERVER_KEY=
+
+# HTTP + MCP server ports. Defaults: 3000 / 3001. Also update the
+# `ports:` mapping in docker-compose.yml if you change these.
+# PORT=3000
+# MCP_PORT=3001

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,5 +67,9 @@ USER node
 EXPOSE 3000 3001
 VOLUME ["/data"]
 
+# depends_on: service_healthy in docker-compose.yml relies on this.
+HEALTHCHECK --interval=15s --timeout=5s --start-period=20s --retries=3 \
+  CMD curl -fsS http://localhost:3000/health || exit 1
+
 ENTRYPOINT ["/app/docker/entrypoint.sh"]
 CMD ["node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -54,9 +54,16 @@ Every extraction includes metadata stored as PostgreSQL JSONB:
 
 ## Quick Start
 
-The entire stack (Langfuse + receipt-assistant) is orchestrated by a single
-root `docker-compose.yml`. Everything runs in Docker — there is no `npm run
-dev` on the host.
+Two independent units live in the root `docker-compose.yml`:
+
+1. **receipt-assistant + its own postgres** — the app and its database,
+   deployable on their own.
+2. **Langfuse stack** (postgres, clickhouse, minio, redis, web, worker) —
+   optional developer observability, pulled in via `include:`. Comment out
+   the `include:` line in `docker-compose.yml` to run the app without it;
+   trace ingestion fails silently when Langfuse is unreachable.
+
+Everything runs in Docker — there is no `npm run dev` on the host.
 
 ### Prerequisites
 
@@ -79,10 +86,25 @@ failing with auth errors — tokens expire periodically.
 docker compose up -d --build
 ```
 
-This single command:
-- starts the full Langfuse stack (postgres, clickhouse, minio, redis, web, worker)
-- builds the receipt-assistant image (multi-stage: tsc in a builder stage, lean runtime)
-- runs receipt-assistant on ports 3000 (REST) and 3001 (MCP)
+What happens:
+- dedicated `receipts-postgres` starts and auto-creates the `receipts` database
+- the receipt-assistant image is built (multi-stage: tsc in a builder stage, lean runtime)
+- receipt-assistant starts on ports 3000 (REST) and 3001 (MCP)
+- the Langfuse stack starts in parallel
+
+First-time pull of the Langfuse images is 2–3 GB; expect 3–5 minutes on a
+fresh machine. Follow progress with:
+
+```bash
+docker compose logs -f
+```
+
+Once everything is up:
+
+```bash
+curl http://localhost:3000/health
+# { "status": "ok", "service": "receipt-assistant", "version": "1.0.0" }
+```
 
 Langfuse dashboard: http://localhost:3333 (admin@local.dev / admin123)
 
@@ -92,7 +114,7 @@ Langfuse dashboard: http://localhost:3333 (admin@local.dev / admin123)
 docker compose up -d --build receipt-assistant
 ```
 
-Only the app is rebuilt; the Langfuse stack keeps running. Layer caching in
+Only the app is rebuilt; the DB and Langfuse keep running. Layer caching in
 the Dockerfile means unchanged `package.json` skips the `npm ci` step, so
 rebuilds are typically 10–20 seconds.
 
@@ -114,7 +136,7 @@ curl http://localhost:3000/jobs/<jobId>
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/receipt` | Upload receipt image, returns jobId for async processing |
-| `GET` | `/jobs/:id` | Poll job status (queued → quick_done → processing_full → done) |
+| `GET` | `/jobs/:id` | Poll job status (`queued` → `done` or `error`) |
 | `GET` | `/jobs/:id/stream` | SSE stream for real-time progress |
 | `GET` | `/receipts` | List receipts (`?from=&to=&category=&limit=`) |
 | `GET` | `/receipt/:id` | Get single receipt with line items |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,12 @@
 #
 #   docker compose up -d --build
 #
-# Langfuse (postgres, clickhouse, minio, redis, web, worker) is pulled in
-# verbatim from langfuse/docker-compose.yml via `include:` so we don't have
-# to duplicate its config here. receipt-assistant shares langfuse's postgres
-# instance (different database) for local dev simplicity.
+# Two independent units:
+#   1. receipt-assistant + receipts-postgres (the app + its own DB)
+#   2. Langfuse stack (optional developer observability, pulled in via
+#      `include:`). Comment out the `include:` block below to run the app
+#      without Langfuse — trace ingestion fails silently when the Langfuse
+#      host is unreachable, so nothing else breaks.
 #
 # Requires Docker Compose v2.20+ for `include:` support.
 
@@ -13,6 +15,28 @@ include:
   - path: langfuse/docker-compose.yml
 
 services:
+  # ── Main app database ──────────────────────────────────────────────
+  # Dedicated postgres for receipt-assistant. Kept separate from
+  # Langfuse's postgres so the two stacks can be deployed independently.
+  receipts-postgres:
+    image: docker.io/postgres:17
+    container_name: receipts-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: receipts           # auto-created on first boot
+      TZ: UTC
+      PGTZ: UTC
+    volumes:
+      - receipts-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d receipts"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+
+  # ── Main app ───────────────────────────────────────────────────────
   receipt-assistant:
     build:
       context: .
@@ -20,10 +44,8 @@ services:
     image: receipt-assistant:local
     container_name: receipt-assistant
     depends_on:
-      postgres:
+      receipts-postgres:
         condition: service_healthy
-      langfuse-web:
-        condition: service_started
     ports:
       - "3000:3000"
       - "3001:3001"
@@ -31,7 +53,10 @@ services:
       # Fail fast if the OAuth token isn't set in .env — better to error at
       # `compose up` than to discover it after a failed claude -p call.
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:?set CLAUDE_CODE_OAUTH_TOKEN in .env (run scripts/refresh-token.sh)}
-      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/receipts
+      DATABASE_URL: postgresql://postgres:postgres@receipts-postgres:5432/receipts
+      # Langfuse is optional. If the Langfuse stack isn't running, the app
+      # still works — trace ingestion is fire-and-forget and tolerates
+      # connection failures.
       LANGFUSE_HOST: http://langfuse-web:3000
       LANGFUSE_PUBLIC_KEY: pk-receipt-local
       LANGFUSE_SECRET_KEY: sk-receipt-local
@@ -41,3 +66,4 @@ services:
 
 volumes:
   receipt-data:
+  receipts-postgres-data:


### PR DESCRIPTION
## Summary

Refactored the Docker Compose setup to make Langfuse optional and decouple the receipt-assistant application from the observability stack. The app now has its own dedicated PostgreSQL instance, allowing both stacks to be deployed independently while maintaining graceful degradation when Langfuse is unavailable.

## Key Changes

- **Dedicated database**: Added `receipts-postgres` service so receipt-assistant no longer shares Langfuse's PostgreSQL instance. This enables independent deployment and scaling of the two stacks.

- **Optional Langfuse**: Removed hard dependency on Langfuse services. The `langfuse-web` service is no longer a blocking dependency in `depends_on`, and trace ingestion is documented as fire-and-forget with silent failure tolerance.

- **Health checks**: Added HEALTHCHECK to the Dockerfile for the receipt-assistant service, enabling Docker Compose to verify service readiness before dependent services start.

- **Documentation improvements**:
  - Clarified the two independent units in docker-compose.yml comments
  - Updated README with clearer Quick Start instructions, including expected startup times and verification steps
  - Added guidance on running the app without Langfuse by commenting out the `include:` block
  - Updated `.env.example` with organized sections for required vs. optional configuration variables with descriptions

- **API documentation**: Corrected the job status flow in the API table from `queued → quick_done → processing_full → done` to the actual `queued → done or error` states.

## Implementation Details

- The `receipts-postgres` service uses PostgreSQL 17 with UTC timezone configuration and includes a health check that waits for the database to be ready before the app starts.
- Langfuse connection failures are tolerated by design—the app continues functioning normally if the Langfuse host is unreachable.
- Database URL in environment variables updated to reference the new `receipts-postgres` service name.
- Volume management clarified with separate `receipts-postgres-data` volume for the dedicated database.

https://claude.ai/code/session_01DHjViMZRzvYF1QMGpNAH3w