### PR TITLE
Add OpenAPI 3.1 spec generation from zod schemas

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,0 +1,887 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Receipt Assistant API",
+    "version": "1.0.0",
+    "description": "REST API for uploading receipts, polling extraction jobs, and querying spending. All endpoints accept an optional Bearer token (configured via AUTH_TOKEN env)."
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Local dev"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "example": "Not found"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "HealthResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok"
+            ]
+          },
+          "service": {
+            "type": "string",
+            "example": "receipt-assistant"
+          },
+          "version": {
+            "type": "string",
+            "example": "1.0.0"
+          }
+        },
+        "required": [
+          "status",
+          "service",
+          "version"
+        ]
+      },
+      "ExtractionMeta": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "quality": {
+            "type": "object",
+            "properties": {
+              "confidence_score": {
+                "type": "number"
+              },
+              "missing_fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "warnings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "confidence_score",
+              "missing_fields",
+              "warnings"
+            ]
+          },
+          "business": {
+            "type": "object",
+            "properties": {
+              "is_reimbursable": {
+                "type": "boolean"
+              },
+              "is_tax_deductible": {
+                "type": "boolean"
+              },
+              "is_recurring": {
+                "type": "boolean"
+              },
+              "is_split_bill": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "is_reimbursable",
+              "is_tax_deductible",
+              "is_recurring",
+              "is_split_bill"
+            ]
+          }
+        },
+        "required": [
+          "quality",
+          "business"
+        ]
+      },
+      "Receipt": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "merchant": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "description": "ISO date YYYY-MM-DD",
+            "example": "2026-04-19"
+          },
+          "total": {
+            "type": "number"
+          },
+          "currency": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "category": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "payment_method": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tax": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "tip": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "raw_text": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "image_path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "address": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "longitude": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "place_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "processing",
+              "done",
+              "error"
+            ]
+          },
+          "extraction_meta": {
+            "$ref": "#/components/schemas/ExtractionMeta"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "merchant",
+          "date",
+          "total"
+        ]
+      },
+      "ReceiptItem": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "unit_price": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "total_price": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "category": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "ReceiptWithItems": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Receipt"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ReceiptItem"
+                }
+              }
+            },
+            "required": [
+              "items"
+            ]
+          }
+        ]
+      },
+      "JobUploadResponse": {
+        "type": "object",
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "receiptId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "processing"
+            ]
+          },
+          "stream": {
+            "type": "string",
+            "example": "/jobs/abc/stream"
+          },
+          "poll": {
+            "type": "string",
+            "example": "/jobs/abc"
+          }
+        },
+        "required": [
+          "jobId",
+          "receiptId",
+          "status",
+          "stream",
+          "poll"
+        ]
+      },
+      "JobStatus": {
+        "type": "string",
+        "enum": [
+          "queued",
+          "processing",
+          "done",
+          "error"
+        ]
+      },
+      "JobStatusResponse": {
+        "type": "object",
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "receiptId": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/JobStatus"
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "jobId",
+          "receiptId",
+          "status",
+          "error"
+        ]
+      },
+      "SpendingSummaryItem": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "count": {
+            "type": "integer"
+          },
+          "total_spent": {
+            "type": "number"
+          },
+          "avg_per_receipt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "category",
+          "count",
+          "total_spent",
+          "avg_per_receipt"
+        ]
+      },
+      "SpendingSummary": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/SpendingSummaryItem"
+        }
+      },
+      "AskRequest": {
+        "type": "object",
+        "properties": {
+          "question": {
+            "type": "string",
+            "example": "How much did I spend on groceries last month?"
+          }
+        },
+        "required": [
+          "question"
+        ]
+      },
+      "AskResponse": {
+        "type": "object",
+        "properties": {
+          "answer": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "answer"
+        ]
+      },
+      "UploadReceiptForm": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "string",
+            "format": "binary"
+          },
+          "notes": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "image"
+        ]
+      },
+      "DeleteReceiptResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "id"
+        ]
+      }
+    },
+    "parameters": {}
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health check",
+        "tags": [
+          "meta"
+        ],
+        "responses": {
+          "200": {
+            "description": "Service is up",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/receipt": {
+      "post": {
+        "summary": "Upload a receipt JPG and start async extraction",
+        "tags": [
+          "receipts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadReceiptForm"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Job submitted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobUploadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid image",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/jobs/{id}": {
+      "get": {
+        "summary": "Poll job status",
+        "tags": [
+          "jobs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current job status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobStatusResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/jobs/{id}/stream": {
+      "get": {
+        "summary": "Server-Sent Events stream for job progress",
+        "description": "Emits `processing`, `done`, or `error` events. Connection closes after terminal event.",
+        "tags": [
+          "jobs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE stream",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/receipts": {
+      "get": {
+        "summary": "List receipts with optional filters",
+        "tags": [
+          "receipts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "description": "ISO date YYYY-MM-DD",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "description": "ISO date YYYY-MM-DD",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "category",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "example": 50
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Receipts ordered by date desc",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Receipt"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/receipt/{id}": {
+      "get": {
+        "summary": "Get one receipt with line items",
+        "tags": [
+          "receipts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Receipt detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptWithItems"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Receipt not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a receipt (cascades to line items)",
+        "tags": [
+          "receipts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteReceiptResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Receipt not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/receipt/{id}/image": {
+      "get": {
+        "summary": "Serve the original receipt image file",
+        "tags": [
+          "receipts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JPEG image bytes",
+            "content": {
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Image not found on disk or in DB",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/summary": {
+      "get": {
+        "summary": "Spending summary grouped by category",
+        "tags": [
+          "analytics"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "description": "ISO date YYYY-MM-DD",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "description": "ISO date YYYY-MM-DD",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "One row per category, ordered by total_spent desc",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpendingSummary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ask": {
+      "post": {
+        "summary": "Free-form question answered by Claude over your receipts",
+        "tags": [
+          "analytics"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AskRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Claude's answer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AskResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing question",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "webhooks": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "receipt-assistant",
       "version": "1.0.0",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^7.3.4",
         "@types/pg": "^8.20.0",
         "dotenv": "^17.4.2",
         "express": "^5.1.0",
@@ -15,6 +16,7 @@
         "heic-convert": "^2.1.0",
         "multer": "^2.0.0",
         "pg": "^8.20.0",
+        "swagger-ui-express": "^5.0.1",
         "uuid": "^11.1.0",
         "zod": "^3.24.0"
       },
@@ -23,9 +25,22 @@
         "@types/express": "^5.0.0",
         "@types/multer": "^1.4.0",
         "@types/node": "^22.0.0",
+        "@types/swagger-ui-express": "^4.1.8",
         "@types/uuid": "^10.0.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.3.4.tgz",
+      "integrity": "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.20.2"
       }
     },
     "node_modules/@borewit/text-codec": {
@@ -541,6 +556,13 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -714,6 +736,17 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/uuid": {
@@ -1296,7 +1329,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1748,7 +1780,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2308,6 +2339,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
     "node_modules/parse-ms": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
@@ -2353,7 +2393,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -2943,6 +2982,30 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tldjs": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
@@ -3216,6 +3279,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "db:init": "node dist/db.js"
+    "db:init": "node dist/db.js",
+    "openapi:generate": "tsx scripts/generate-openapi.ts"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^7.3.4",
     "@types/pg": "^8.20.0",
     "dotenv": "^17.4.2",
     "express": "^5.1.0",
@@ -15,6 +17,7 @@
     "heic-convert": "^2.1.0",
     "multer": "^2.0.0",
     "pg": "^8.20.0",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^11.1.0",
     "zod": "^3.24.0"
   },
@@ -23,6 +26,7 @@
     "@types/express": "^5.0.0",
     "@types/multer": "^1.4.0",
     "@types/node": "^22.0.0",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^10.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env tsx
+/**
+ * Regenerate openapi/openapi.json from the in-code zod registry.
+ * Run via `npm run openapi:generate`.
+ *
+ * The committed openapi.json is the source of truth for SDK codegen
+ * and PR review — keep it in sync after every schema/route change.
+ */
+import { writeFileSync, mkdirSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import { buildOpenApiDocument } from "../src/openapi.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outPath = resolve(__dirname, "..", "openapi", "openapi.json");
+
+mkdirSync(dirname(outPath), { recursive: true });
+
+const doc = buildOpenApiDocument();
+writeFileSync(outPath, JSON.stringify(doc, null, 2) + "\n", "utf8");
+
+console.log(`✓ Wrote ${outPath}`);
+console.log(`  ${Object.keys(doc.paths ?? {}).length} paths, ` +
+            `${Object.keys((doc.components as any)?.schemas ?? {}).length} schemas`);

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,0 +1,243 @@
+import {
+  OpenAPIRegistry,
+  OpenApiGeneratorV31,
+} from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+
+import { ErrorResponse, IdParam } from "./schemas/common.js";
+import { HealthResponse } from "./schemas/health.js";
+import {
+  Receipt,
+  ReceiptWithItems,
+  ListReceiptsQuery,
+  UploadReceiptForm,
+  DeleteReceiptResponse,
+} from "./schemas/receipt.js";
+import { JobUploadResponse, JobStatusResponse } from "./schemas/job.js";
+import { SummaryQuery, SpendingSummary } from "./schemas/summary.js";
+import { AskRequest, AskResponse } from "./schemas/ask.js";
+
+export function buildRegistry(): OpenAPIRegistry {
+  const registry = new OpenAPIRegistry();
+
+  // Register named schemas so they appear under components/schemas
+  registry.register("ErrorResponse", ErrorResponse);
+  registry.register("HealthResponse", HealthResponse);
+  registry.register("Receipt", Receipt);
+  registry.register("ReceiptWithItems", ReceiptWithItems);
+  registry.register("JobUploadResponse", JobUploadResponse);
+  registry.register("JobStatusResponse", JobStatusResponse);
+  registry.register("SpendingSummary", SpendingSummary);
+  registry.register("AskRequest", AskRequest);
+  registry.register("AskResponse", AskResponse);
+
+  // Optional bearer-token auth (only enforced when AUTH_TOKEN env is set)
+  const bearerAuth = registry.registerComponent("securitySchemes", "bearerAuth", {
+    type: "http",
+    scheme: "bearer",
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/health",
+    summary: "Health check",
+    tags: ["meta"],
+    responses: {
+      200: {
+        description: "Service is up",
+        content: { "application/json": { schema: HealthResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/receipt",
+    summary: "Upload a receipt JPG and start async extraction",
+    tags: ["receipts"],
+    security: [{ [bearerAuth.name]: [] }],
+    request: {
+      body: {
+        content: {
+          "multipart/form-data": { schema: UploadReceiptForm },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Job submitted",
+        content: { "application/json": { schema: JobUploadResponse } },
+      },
+      400: {
+        description: "Missing or invalid image",
+        content: { "application/json": { schema: ErrorResponse } },
+      },
+      500: {
+        description: "Server error",
+        content: { "application/json": { schema: ErrorResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/jobs/{id}",
+    summary: "Poll job status",
+    tags: ["jobs"],
+    request: { params: IdParam },
+    responses: {
+      200: {
+        description: "Current job status",
+        content: { "application/json": { schema: JobStatusResponse } },
+      },
+      404: {
+        description: "Job not found",
+        content: { "application/json": { schema: ErrorResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/jobs/{id}/stream",
+    summary: "Server-Sent Events stream for job progress",
+    description: "Emits `processing`, `done`, or `error` events. Connection closes after terminal event.",
+    tags: ["jobs"],
+    request: { params: IdParam },
+    responses: {
+      200: {
+        description: "SSE stream",
+        content: { "text/event-stream": { schema: z.string() } },
+      },
+      404: {
+        description: "Job not found",
+        content: { "application/json": { schema: ErrorResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/receipts",
+    summary: "List receipts with optional filters",
+    tags: ["receipts"],
+    request: { query: ListReceiptsQuery },
+    responses: {
+      200: {
+        description: "Receipts ordered by date desc",
+        content: { "application/json": { schema: z.array(Receipt) } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/receipt/{id}",
+    summary: "Get one receipt with line items",
+    tags: ["receipts"],
+    request: { params: IdParam },
+    responses: {
+      200: {
+        description: "Receipt detail",
+        content: { "application/json": { schema: ReceiptWithItems } },
+      },
+      404: {
+        description: "Receipt not found",
+        content: { "application/json": { schema: ErrorResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/receipt/{id}",
+    summary: "Delete a receipt (cascades to line items)",
+    tags: ["receipts"],
+    request: { params: IdParam },
+    responses: {
+      200: {
+        description: "Deleted",
+        content: { "application/json": { schema: DeleteReceiptResponse } },
+      },
+      404: {
+        description: "Receipt not found",
+        content: { "application/json": { schema: ErrorResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/receipt/{id}/image",
+    summary: "Serve the original receipt image file",
+    tags: ["receipts"],
+    request: { params: IdParam },
+    responses: {
+      200: {
+        description: "JPEG image bytes",
+        content: { "image/jpeg": { schema: z.string().openapi({ format: "binary" }) } },
+      },
+      404: {
+        description: "Image not found on disk or in DB",
+        content: { "application/json": { schema: ErrorResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/summary",
+    summary: "Spending summary grouped by category",
+    tags: ["analytics"],
+    request: { query: SummaryQuery },
+    responses: {
+      200: {
+        description: "One row per category, ordered by total_spent desc",
+        content: { "application/json": { schema: SpendingSummary } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/ask",
+    summary: "Free-form question answered by Claude over your receipts",
+    tags: ["analytics"],
+    request: {
+      body: { content: { "application/json": { schema: AskRequest } } },
+    },
+    responses: {
+      200: {
+        description: "Claude's answer",
+        content: { "application/json": { schema: AskResponse } },
+      },
+      400: {
+        description: "Missing question",
+        content: { "application/json": { schema: ErrorResponse } },
+      },
+      500: {
+        description: "Server error",
+        content: { "application/json": { schema: ErrorResponse } },
+      },
+    },
+  });
+
+  return registry;
+}
+
+export function buildOpenApiDocument() {
+  const registry = buildRegistry();
+  const generator = new OpenApiGeneratorV31(registry.definitions);
+
+  return generator.generateDocument({
+    openapi: "3.1.0",
+    info: {
+      title: "Receipt Assistant API",
+      version: "1.0.0",
+      description:
+        "REST API for uploading receipts, polling extraction jobs, and querying spending. " +
+        "All endpoints accept an optional Bearer token (configured via AUTH_TOKEN env).",
+    },
+    servers: [{ url: "http://localhost:3000", description: "Local dev" }],
+  });
+}

--- a/src/schemas/ask.ts
+++ b/src/schemas/ask.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import "./common.js";
+
+export const AskRequest = z
+  .object({
+    question: z.string().openapi({ example: "How much did I spend on groceries last month?" }),
+  })
+  .openapi("AskRequest");
+
+export const AskResponse = z
+  .object({
+    answer: z.string(),
+  })
+  .openapi("AskResponse");

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+
+extendZodWithOpenApi(z);
+
+export const ErrorResponse = z
+  .object({
+    error: z.string().openapi({ example: "Not found" }),
+  })
+  .openapi("ErrorResponse");
+
+export const DateString = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .openapi({ example: "2026-04-19", description: "ISO date YYYY-MM-DD" });
+
+export const IdParam = z.object({
+  id: z.string().openapi({ param: { name: "id", in: "path" }, example: "abc123" }),
+});

--- a/src/schemas/health.ts
+++ b/src/schemas/health.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import "./common.js";
+
+export const HealthResponse = z
+  .object({
+    status: z.literal("ok"),
+    service: z.string().openapi({ example: "receipt-assistant" }),
+    version: z.string().openapi({ example: "1.0.0" }),
+  })
+  .openapi("HealthResponse");

--- a/src/schemas/job.ts
+++ b/src/schemas/job.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import "./common.js";
+
+export const JobStatus = z
+  .enum(["queued", "processing", "done", "error"])
+  .openapi("JobStatus");
+
+export const JobUploadResponse = z
+  .object({
+    jobId: z.string(),
+    receiptId: z.string(),
+    status: z.literal("processing"),
+    stream: z.string().openapi({ example: "/jobs/abc/stream" }),
+    poll: z.string().openapi({ example: "/jobs/abc" }),
+  })
+  .openapi("JobUploadResponse");
+
+export const JobStatusResponse = z
+  .object({
+    jobId: z.string(),
+    receiptId: z.string(),
+    status: JobStatus,
+    error: z.string().nullable(),
+  })
+  .openapi("JobStatusResponse");

--- a/src/schemas/receipt.ts
+++ b/src/schemas/receipt.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import { DateString } from "./common.js";
+
+export const ExtractionMeta = z
+  .object({
+    quality: z.object({
+      confidence_score: z.number(),
+      missing_fields: z.array(z.string()),
+      warnings: z.array(z.string()),
+    }),
+    business: z.object({
+      is_reimbursable: z.boolean(),
+      is_tax_deductible: z.boolean(),
+      is_recurring: z.boolean(),
+      is_split_bill: z.boolean(),
+    }),
+  })
+  .openapi("ExtractionMeta");
+
+export const ReceiptItem = z
+  .object({
+    name: z.string(),
+    quantity: z.number().nullable().optional(),
+    unit_price: z.number().nullable().optional(),
+    total_price: z.number().nullable().optional(),
+    category: z.string().nullable().optional(),
+  })
+  .openapi("ReceiptItem");
+
+export const Receipt = z
+  .object({
+    id: z.string(),
+    merchant: z.string(),
+    date: DateString,
+    total: z.number(),
+    currency: z.string().nullable().optional(),
+    category: z.string().nullable().optional(),
+    payment_method: z.string().nullable().optional(),
+    tax: z.number().nullable().optional(),
+    tip: z.number().nullable().optional(),
+    notes: z.string().nullable().optional(),
+    raw_text: z.string().nullable().optional(),
+    image_path: z.string().nullable().optional(),
+    address: z.string().nullable().optional(),
+    latitude: z.number().nullable().optional(),
+    longitude: z.number().nullable().optional(),
+    place_id: z.string().nullable().optional(),
+    status: z.enum(["processing", "done", "error"]).optional(),
+    extraction_meta: ExtractionMeta.nullable().optional(),
+    created_at: z.string().optional(),
+    updated_at: z.string().optional(),
+  })
+  .openapi("Receipt");
+
+export const ReceiptWithItems = Receipt.extend({
+  items: z.array(ReceiptItem),
+}).openapi("ReceiptWithItems");
+
+export const ListReceiptsQuery = z.object({
+  from: DateString.optional().openapi({ param: { name: "from", in: "query" } }),
+  to: DateString.optional().openapi({ param: { name: "to", in: "query" } }),
+  category: z
+    .string()
+    .optional()
+    .openapi({ param: { name: "category", in: "query" } }),
+  limit: z
+    .coerce.number()
+    .int()
+    .positive()
+    .optional()
+    .openapi({ param: { name: "limit", in: "query" }, example: 50 }),
+});
+
+export const UploadReceiptForm = z
+  .object({
+    image: z.string().openapi({ type: "string", format: "binary" }),
+    notes: z.string().optional(),
+  })
+  .openapi("UploadReceiptForm");
+
+export const DeleteReceiptResponse = z
+  .object({
+    success: z.literal(true),
+    id: z.string(),
+  })
+  .openapi("DeleteReceiptResponse");

--- a/src/schemas/summary.ts
+++ b/src/schemas/summary.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { DateString } from "./common.js";
+
+export const SummaryQuery = z.object({
+  from: DateString.optional().openapi({ param: { name: "from", in: "query" } }),
+  to: DateString.optional().openapi({ param: { name: "to", in: "query" } }),
+});
+
+export const SpendingSummaryItem = z
+  .object({
+    category: z.string().nullable(),
+    count: z.number().int(),
+    total_spent: z.number(),
+    avg_per_receipt: z.number(),
+  })
+  .openapi("SpendingSummaryItem");
+
+export const SpendingSummary = z.array(SpendingSummaryItem).openapi("SpendingSummary");


### PR DESCRIPTION
## Summary

- Adds a code-first OpenAPI 3.1 contract layer derived from zod schemas via `@asteasolutions/zod-to-openapi` (v7, pinned to keep zod v3).
- Spec is committed as a build artifact at `openapi/openapi.json` so PR diffs surface API changes and SDK codegen does not require a running server.
- Zero behavior change in this PR — `server.ts` is untouched. Handlers, routes, and validation are unchanged.

## Why

Frontend and macOS currently hand-write `fetch` / `URLSession` calls against the API. As soon as a third client appears (iOS, Android, CLI, etc.) this scales poorly. With a published OpenAPI spec, every client can codegen typed bindings (TS via `openapi-typescript`, Swift via Apple's `swift-openapi-generator`) and break-on-mismatch at build time.

Code-first chosen over spec-first: schemas live next to handlers, AI agents and humans only edit one place, tsc gives instant feedback on cross-cutting changes. See conversation in claude session for the comparison.

## Structure

```
src/schemas/
  common.ts    — ErrorResponse, DateString, IdParam
  health.ts    — HealthResponse
  receipt.ts   — Receipt, ReceiptItem, ReceiptWithItems, queries, upload form
  job.ts       — JobStatus, JobUploadResponse, JobStatusResponse
  summary.ts   — SpendingSummaryItem, SpendingSummary
  ask.ts       — AskRequest, AskResponse
src/openapi.ts          — OpenAPIRegistry: registers all 9 paths
scripts/generate-openapi.ts — emits openapi/openapi.json
openapi/openapi.json    — committed artifact
```

`npm run openapi:generate` regenerates the spec.

## Verification

- `npx tsc --noEmit` — clean.
- `openapi-spec-validator openapi/openapi.json` — valid OpenAPI 3.1.
- All 10 method+path pairs and 15 component schemas present in output.

## Follow-ups (not in this PR)

1. Mount `swagger-ui-express` at `/docs` and serve `/openapi.json` from the running server.
2. Replace ad-hoc `req.body` / `req.query` parsing with `Schema.parse()` in handlers (real runtime validation).
3. Frontend prebuild script: `curl /openapi.json | openapi-typescript > api-types.ts`, then refactor `src/lib/api.ts` to use `openapi-fetch`.
4. macOS: integrate `swift-openapi-generator` SwiftPM plugin.
5. Pre-commit hook to regenerate spec when schemas change (prevent drift).
6. Future: zod v3 → v4 migration to unlock zod-to-openapi v8.

## Test plan

- [ ] Reviewer pulls branch, runs `npm install && npm run openapi:generate`, confirms `openapi/openapi.json` matches what's committed (no drift).
- [ ] Reviewer opens `openapi/openapi.json` in https://editor.swagger.io and visually confirms all 10 endpoints look right.
- [ ] Confirm `npm run build` still succeeds.
- [ ] Confirm `node dist/server.js` (or container) still starts and serves /health unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)