### PR TITLE
Mount Swagger UI at /docs and serve /openapi.json

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3,12 +3,14 @@ import { FastMCP } from "fastmcp";
 import { z } from "zod";
 import express, { type Request, type Response, type NextFunction } from "express";
 import multer from "multer";
+import swaggerUi from "swagger-ui-express";
 import { v4 as uuidv4 } from "uuid";
 import path from "path";
 import fs from "fs/promises";
 import { askClaude } from "./claude.js";
 import { getReceipt, listReceipts, getSpendingSummary, initSchema } from "./db.js";
 import { submitJob, getJob, subscribeJob } from "./jobs.js";
+import { buildOpenApiDocument } from "./openapi.js";
 
 const PORT = parseInt(process.env.PORT || "3000");
 const MCP_PORT = parseInt(process.env.MCP_PORT || "3001");
@@ -116,6 +118,17 @@ Answer concisely and helpfully.`;
 
 const app = express();
 app.use(express.json());
+
+// API contract — served before auth so /docs is always discoverable.
+// The spec is already public on GitHub; exposing it here is no extra leak.
+const openApiDoc = buildOpenApiDocument();
+app.get("/openapi.json", (_req: Request, res: Response) => {
+  res.json(openApiDoc);
+});
+app.use("/docs", swaggerUi.serve, swaggerUi.setup(openApiDoc, {
+  customSiteTitle: "Receipt Assistant API",
+  swaggerOptions: { persistAuthorization: true },
+}));
 
 // Auth middleware (simple bearer token)
 const AUTH_TOKEN = process.env.AUTH_TOKEN;
@@ -344,6 +357,8 @@ async function main() {
    GET  /summary          — spending summary (?from=&to=)
    POST /ask              — ask a question about spending
    GET  /health           — health check
+   GET  /openapi.json     — OpenAPI 3.1 spec
+   GET  /docs             — interactive Swagger UI
 
 🔌 MCP tools:
    process_receipt, list_receipts, spending_summary,


### PR DESCRIPTION
## Summary

- Adds two routes:
  - `GET /openapi.json` — serves the OpenAPI 3.1 spec at runtime
  - `GET /docs` — interactive Swagger UI rendered from the same spec
- Both registered **before** `authMiddleware` so docs are always discoverable. The spec is already public on GitHub (`openapi/openapi.json`), so exposing it on the running server is no extra leak — same as Stripe / Twilio / Linear.

## Smoke test (against running container)

```
GET /health        → 200
GET /openapi.json  → 200, body matches committed openapi/openapi.json
GET /docs/         → 200, Swagger UI HTML loads
```

Open http://localhost:3000/docs in a browser to interactively try every endpoint.

## Why this is small

`buildOpenApiDocument()` is called once at boot and reused for both routes — no per-request regen cost. Spec rebuild only happens when the server restarts.

## Follow-ups (separate PRs)

- handler runtime validation with `Schema.parse()` (next)
- frontend `openapi-fetch` typed client
- macOS `swift-openapi-generator` SwiftPM plugin

## Test plan

- [ ] `docker compose up -d --build receipt-assistant`
- [ ] `curl http://localhost:3000/openapi.json | jq .info.title` → "Receipt Assistant API"
- [ ] Open http://localhost:3000/docs in browser, confirm all 10 endpoints render

🤖 Generated with [Claude Code](https://claude.com/claude-code)