### PR TITLE
Validate handler inputs with zod Schema.parse()

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -31,6 +31,41 @@
           "error"
         ]
       },
+      "ValidationErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "Invalid request"
+            ]
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "example": "limit"
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Expected number, received string"
+                }
+              },
+              "required": [
+                "path",
+                "message"
+              ]
+            }
+          }
+        },
+        "required": [
+          "error",
+          "issues"
+        ]
+      },
       "HealthResponse": {
         "type": "object",
         "properties": {
@@ -663,6 +698,16 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid query parameter (e.g. malformed date, non-numeric limit)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -829,6 +874,16 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid query parameter (e.g. malformed date)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -860,11 +915,11 @@
             }
           },
           "400": {
-            "description": "Missing question",
+            "description": "Missing or invalid `question` field",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
                 }
               }
             }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -4,7 +4,7 @@ import {
 } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 
-import { ErrorResponse, IdParam } from "./schemas/common.js";
+import { ErrorResponse, IdParam, ValidationErrorResponse } from "./schemas/common.js";
 import { HealthResponse } from "./schemas/health.js";
 import {
   Receipt,
@@ -22,6 +22,7 @@ export function buildRegistry(): OpenAPIRegistry {
 
   // Register named schemas so they appear under components/schemas
   registry.register("ErrorResponse", ErrorResponse);
+  registry.register("ValidationErrorResponse", ValidationErrorResponse);
   registry.register("HealthResponse", HealthResponse);
   registry.register("Receipt", Receipt);
   registry.register("ReceiptWithItems", ReceiptWithItems);
@@ -127,6 +128,10 @@ export function buildRegistry(): OpenAPIRegistry {
         description: "Receipts ordered by date desc",
         content: { "application/json": { schema: z.array(Receipt) } },
       },
+      400: {
+        description: "Invalid query parameter (e.g. malformed date, non-numeric limit)",
+        content: { "application/json": { schema: ValidationErrorResponse } },
+      },
     },
   });
 
@@ -195,6 +200,10 @@ export function buildRegistry(): OpenAPIRegistry {
         description: "One row per category, ordered by total_spent desc",
         content: { "application/json": { schema: SpendingSummary } },
       },
+      400: {
+        description: "Invalid query parameter (e.g. malformed date)",
+        content: { "application/json": { schema: ValidationErrorResponse } },
+      },
     },
   });
 
@@ -212,8 +221,8 @@ export function buildRegistry(): OpenAPIRegistry {
         content: { "application/json": { schema: AskResponse } },
       },
       400: {
-        description: "Missing question",
-        content: { "application/json": { schema: ErrorResponse } },
+        description: "Missing or invalid `question` field",
+        content: { "application/json": { schema: ValidationErrorResponse } },
       },
       500: {
         description: "Server error",

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -9,9 +9,27 @@ export const ErrorResponse = z
   })
   .openapi("ErrorResponse");
 
+export const ValidationErrorResponse = z
+  .object({
+    error: z.literal("Invalid request"),
+    issues: z.array(
+      z.object({
+        path: z.string().openapi({ example: "limit" }),
+        message: z.string().openapi({ example: "Expected number, received string" }),
+      })
+    ),
+  })
+  .openapi("ValidationErrorResponse");
+
 export const DateString = z
   .string()
-  .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD")
+  .refine((s) => {
+    // Reject impossible calendar values like 2026-13-99 by round-tripping
+    // through Date and confirming no auto-correction occurred.
+    const d = new Date(s + "T00:00:00Z");
+    return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+  }, "Not a valid calendar date")
   .openapi({ example: "2026-04-19", description: "ISO date YYYY-MM-DD" });
 
 export const IdParam = z.object({

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,10 @@ import { askClaude } from "./claude.js";
 import { getReceipt, listReceipts, getSpendingSummary, initSchema } from "./db.js";
 import { submitJob, getJob, subscribeJob } from "./jobs.js";
 import { buildOpenApiDocument } from "./openapi.js";
+import { parseOr400 } from "./validate.js";
+import { ListReceiptsQuery } from "./schemas/receipt.js";
+import { SummaryQuery } from "./schemas/summary.js";
+import { AskRequest } from "./schemas/ask.js";
 
 const PORT = parseInt(process.env.PORT || "3000");
 const MCP_PORT = parseInt(process.env.MCP_PORT || "3001");
@@ -252,11 +256,9 @@ app.get("/jobs/:id/stream", (req: Request, res: Response) => {
 
 // GET /receipts — list receipts
 app.get("/receipts", async (req: Request, res: Response) => {
-  const { from, to, category, limit } = req.query as Record<string, string>;
-  const results = await listReceipts({
-    from, to, category,
-    limit: limit ? parseInt(limit) : undefined,
-  });
+  const query = parseOr400(ListReceiptsQuery, req.query, res);
+  if (!query) return;
+  const results = await listReceipts(query);
   res.json(results);
 });
 
@@ -300,23 +302,20 @@ app.get("/receipt/:id/image", async (req: Request, res: Response) => {
 
 // GET /summary — spending summary
 app.get("/summary", async (req: Request, res: Response) => {
-  const { from, to } = req.query as Record<string, string>;
-  const summary = await getSpendingSummary(from, to);
+  const query = parseOr400(SummaryQuery, req.query, res);
+  if (!query) return;
+  const summary = await getSpendingSummary(query.from, query.to);
   res.json(summary);
 });
 
 // POST /ask — free-form question
 app.post("/ask", async (req: Request, res: Response) => {
+  const body = parseOr400(AskRequest, req.body, res);
+  if (!body) return;
   try {
-    const { question } = req.body;
-    if (!question) {
-      res.status(400).json({ error: "Missing 'question' field" });
-      return;
-    }
-    // Reuse the MCP tool logic
     const recent = await listReceipts({ limit: 30 });
     const summary = await getSpendingSummary();
-    const prompt = `You are a personal finance assistant. Recent receipts:\n${JSON.stringify(recent)}\nSummary:\n${JSON.stringify(summary)}\nQuestion: ${question}`;
+    const prompt = `You are a personal finance assistant. Recent receipts:\n${JSON.stringify(recent)}\nSummary:\n${JSON.stringify(summary)}\nQuestion: ${body.question}`;
     const answer = await askClaude(prompt);
     res.json({ answer });
   } catch (err: any) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,31 @@
+/**
+ * Centralized zod → HTTP 400 mapping for Express handlers.
+ *
+ * Use `parseOr400(schema, data, res)` in handlers; on validation failure
+ * it writes a 400 response and returns null. On success it returns the
+ * typed parsed value. Caller should `if (!parsed) return;` and use it.
+ */
+import type { Response } from "express";
+import { ZodError, type ZodTypeAny, type infer as zInfer } from "zod";
+
+export function parseOr400<S extends ZodTypeAny>(
+  schema: S,
+  data: unknown,
+  res: Response
+): zInfer<S> | null {
+  const result = schema.safeParse(data);
+  if (result.success) return result.data;
+
+  res.status(400).json({
+    error: "Invalid request",
+    issues: formatZodIssues(result.error),
+  });
+  return null;
+}
+
+function formatZodIssues(err: ZodError): { path: string; message: string }[] {
+  return err.issues.map((i) => ({
+    path: i.path.join("."),
+    message: i.message,
+  }));
+}


### PR DESCRIPTION
## Summary

Three handlers swap ad-hoc parsing for `parseOr400(Schema, data, res)`:

| Endpoint | Before | After |
|---|---|---|
| `GET /receipts` | `parseInt(limit)` swallows garbage | `ListReceiptsQuery.safeParse(req.query)` |
| `GET /summary` | raw query strings to SQL | `SummaryQuery.safeParse(req.query)` |
| `POST /ask` | `if (!question)` allows wrong types | `AskRequest.safeParse(req.body)` |

Failure → structured 400 with per-field `issues: { path, message }[]`.

## Bug fixed in passing

`DateString` regex only checked digit count, so `/summary?to=2026-13-99` silently returned all rows (lexicographic SQL comparison). New `.refine()` round-trips through `Date` and rejects impossible calendar values (Feb 30, month 13, etc.).

## Spec parity

- New `ValidationErrorResponse` schema (`error: "Invalid request"` + `issues[]`)
- Registered as the 400 response on the three validated endpoints
- Spec regenerated; 9 paths, **16 schemas** (was 15)

## What didn't change

Path-param GETs (`/receipt/:id`, `/jobs/:id`, etc.) still use ad-hoc checks — wrapping `id: string` in zod would be ceremony with no value. Multipart upload still validated by multer.

## Smoke test (container rebuilt)

```
✓ GET /receipts?limit=5           → 200 (real data)
✓ GET /receipts?limit=abc         → 400 {issues:[{path:"limit",message:"Expected number, received nan"}]}
✓ GET /receipts?from=not-a-date   → 400 {issues:[{path:"from",message:"Must be YYYY-MM-DD"}]}
✓ GET /summary?to=2026-13-99      → 400 {issues:[{path:"to",message:"Not a valid calendar date"}]}
✓ GET /summary?to=2026-02-30      → 400 (Feb 30 caught)
✓ GET /summary?to=2026-04-19      → 200
✓ POST /ask {}                    → 400 {issues:[{path:"question",message:"Required"}]}
✓ POST /ask {question:123}        → 400 {issues:[{path:"question",message:"Expected string, received number"}]}
```

## Test plan

- [ ] `docker compose up -d --build receipt-assistant`
- [ ] Reproduce the 8 cases above
- [ ] Open http://localhost:3000/docs, confirm the 3 endpoints now show a 400 ValidationErrorResponse in their response list

🤖 Generated with [Claude Code](https://claude.com/claude-code)