### PR TITLE
Mark multipart body required + return summary aggregates as numbers

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -512,6 +512,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {

--- a/src/db.ts
+++ b/src/db.ts
@@ -309,12 +309,16 @@ export async function getSpendingSummary(from?: string, to?: string): Promise<an
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
+  // Cast aggregates to float8 so pg returns JS numbers, not strings.
+  // Without the cast, ROUND(...)::numeric is serialized as a string by
+  // node-postgres' default parser (numeric has no exact JS representation),
+  // which silently breaks any client that expects total_spent: number.
   const result = await p.query(
     `SELECT
       category,
       COUNT(*)::int as count,
-      ROUND(SUM(total)::numeric, 2) as total_spent,
-      ROUND(AVG(total)::numeric, 2) as avg_per_receipt
+      ROUND(SUM(total)::numeric, 2)::float8 as total_spent,
+      ROUND(AVG(total)::numeric, 2)::float8 as avg_per_receipt
     FROM receipts
     ${where}
     GROUP BY category

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -59,6 +59,7 @@ export function buildRegistry(): OpenAPIRegistry {
     security: [{ [bearerAuth.name]: [] }],
     request: {
       body: {
+        required: true,
         content: {
           "multipart/form-data": { schema: UploadReceiptForm },
         },


### PR DESCRIPTION
## Summary

Two small contract / serialization fixes surfaced while wiring up swift-openapi-generator on macOS ([receipt-assistant-macos#2](https://github.com/TINKPA/receipt-assistant-macos/pull/2)). Both are silent client-codegen blockers.

| # | Change | Why it matters |
|---|---|---|
| 1 | `POST /receipt` requestBody now has `required: true` | swift-openapi-generator skips multipart bodies that aren't required — the macOS app couldn't get a generated `client.postReceipt()` method until this was set. The request was de facto required (the handler 400s on missing image), the spec just didn't say so. |
| 2 | `getSpendingSummary` returns `total_spent` / `avg_per_receipt` as JS numbers, not strings | node-postgres serializes pg's `numeric` type as a string by default. Schema already declares `z.number()` — this fixes the runtime to match the contract, not the other way around. Cast to `::float8` after rounding to keep 2-decimal precision. |

## Verification

```
tsc --noEmit                                          → clean
openapi.json regenerated → /receipt requestBody.required: true ✓
GET /summary live → total_spent: 173.41 (number), was "117.39" (string)
macOS xcodebuild → no more "Multipart request bodies must always be required" warning
```

## Impact on clients

- **Frontend** (`openapi-fetch`): no code change required — the typed signature already said `number`, the runtime was lying. Now they match.
- **macOS** ([#2](https://github.com/TINKPA/receipt-assistant-macos/pull/2)): after this merges, run `./scripts/refresh-openapi.sh` and the next build will produce a generated `postReceipt` method, removing the blocker for the eventual full APIClient migration.

## Test plan

- [ ] `docker compose up -d --build receipt-assistant`
- [ ] `curl http://localhost:3000/summary | jq '.[0].total_spent | type'` → `"number"`
- [ ] `curl http://localhost:3000/openapi.json | jq '.paths."/receipt".post.requestBody.required'` → `true`
- [ ] Open http://localhost:3000/docs, confirm "Try it out" on `POST /receipt` shows the body as required

🤖 Generated with [Claude Code](https://claude.com/claude-code)