### PR TITLE
v1 ledger API: accounts + transactions + postings + documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .env
 .env.*
 !.env.example
+/scripts/smoke-v1-ingest.report.json

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -89,6 +89,1098 @@
           "service",
           "version"
         ]
+      },
+      "Violation": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "code"
+        ]
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "instance": {
+            "type": "string"
+          },
+          "trace_id": {
+            "type": "string"
+          },
+          "violations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Violation"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "title",
+          "status"
+        ]
+      },
+      "Account": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "workspace_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "parent_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "code": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "asset",
+              "liability",
+              "equity",
+              "income",
+              "expense"
+            ]
+          },
+          "subtype": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "institution": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last4": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "opening_balance_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "closed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {},
+            "description": "User-defined JSON object; not schema-validated."
+          },
+          "version": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "workspace_id",
+          "parent_id",
+          "code",
+          "name",
+          "type",
+          "subtype",
+          "currency",
+          "institution",
+          "last4",
+          "opening_balance_minor",
+          "closed_at",
+          "version",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CreateAccountRequest": {
+        "type": "object",
+        "properties": {
+          "parent_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "asset",
+              "liability",
+              "equity",
+              "income",
+              "expense"
+            ]
+          },
+          "subtype": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "institution": {
+            "type": "string"
+          },
+          "last4": {
+            "type": "string"
+          },
+          "opening_balance_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {},
+            "description": "User-defined JSON object; not schema-validated."
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ]
+      },
+      "UpdateAccountRequest": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "subtype": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "institution": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last4": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "parent_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "closed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {},
+            "description": "User-defined JSON object; not schema-validated."
+          }
+        }
+      },
+      "AccountBalance": {
+        "type": "object",
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "as_of": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "balance_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "posting_count": {
+            "type": "integer"
+          },
+          "includes_children": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "account_id",
+          "as_of",
+          "balance_minor",
+          "currency",
+          "posting_count",
+          "includes_children"
+        ]
+      },
+      "RegisterCounterPosting": {
+        "type": "object",
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "name": {
+            "type": "string"
+          },
+          "amount_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          }
+        },
+        "required": [
+          "account_id",
+          "name",
+          "amount_minor"
+        ]
+      },
+      "RegisterDocumentRef": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "kind": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "kind"
+        ]
+      },
+      "RegisterItem": {
+        "type": "object",
+        "properties": {
+          "posting_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "transaction_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "transaction_version": {
+            "type": "integer"
+          },
+          "occurred_on": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "payee": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "narration": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "amount_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "running_balance_after_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "counter_postings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RegisterCounterPosting"
+            }
+          },
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RegisterDocumentRef"
+            }
+          }
+        },
+        "required": [
+          "posting_id",
+          "transaction_id",
+          "transaction_version",
+          "occurred_on",
+          "payee",
+          "narration",
+          "amount_minor",
+          "currency",
+          "running_balance_after_minor",
+          "counter_postings",
+          "documents"
+        ]
+      },
+      "AccountRegister": {
+        "type": "object",
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RegisterItem"
+            }
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "account_id",
+          "items",
+          "next_cursor"
+        ]
+      },
+      "Posting": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "transaction_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "amount_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "fx_rate": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "amount_base_minor": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "memo": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "transaction_id",
+          "account_id",
+          "amount_minor",
+          "currency",
+          "fx_rate",
+          "amount_base_minor",
+          "memo",
+          "created_at"
+        ]
+      },
+      "TransactionDocumentRef": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "kind": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "kind"
+        ]
+      },
+      "Transaction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "workspace_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "occurred_on": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "occurred_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "payee": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "narration": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "posted",
+              "voided",
+              "reconciled",
+              "error"
+            ]
+          },
+          "voided_by_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "source_ingest_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "trip_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {},
+            "description": "User-defined JSON object; not schema-validated."
+          },
+          "version": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "postings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Posting"
+            }
+          },
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransactionDocumentRef"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "workspace_id",
+          "occurred_on",
+          "occurred_at",
+          "payee",
+          "narration",
+          "status",
+          "voided_by_id",
+          "source_ingest_id",
+          "trip_id",
+          "version",
+          "created_at",
+          "updated_at",
+          "postings",
+          "documents"
+        ]
+      },
+      "BulkResultItem": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "integer"
+          },
+          "body": {}
+        },
+        "required": [
+          "index",
+          "status"
+        ]
+      },
+      "BulkResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkResultItem"
+            }
+          }
+        },
+        "required": [
+          "results"
+        ]
+      },
+      "Document": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "workspace_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "receipt_image",
+              "receipt_email",
+              "receipt_pdf",
+              "statement_pdf",
+              "other"
+            ]
+          },
+          "file_path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "mime_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sha256": {
+            "type": "string"
+          },
+          "ocr_text": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "extraction_meta": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {}
+          },
+          "source_ingest_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "workspace_id",
+          "kind",
+          "file_path",
+          "mime_type",
+          "sha256",
+          "ocr_text",
+          "extraction_meta",
+          "source_ingest_id",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "DocumentKind": {
+        "type": "string",
+        "enum": [
+          "receipt_image",
+          "receipt_email",
+          "receipt_pdf",
+          "statement_pdf",
+          "other"
+        ]
+      },
+      "UploadDocumentForm": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "receipt_image",
+              "receipt_email",
+              "receipt_pdf",
+              "statement_pdf",
+              "other"
+            ]
+          }
+        }
+      },
+      "CreateDocumentLinkRequest": {
+        "type": "object",
+        "properties": {
+          "transaction_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          }
+        },
+        "required": [
+          "transaction_id"
+        ]
+      },
+      "NewPosting": {
+        "type": "object",
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "amount_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "fx_rate": {
+            "type": "string"
+          },
+          "amount_base_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "memo": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "account_id",
+          "amount_minor"
+        ]
+      },
+      "CreateTransactionRequest": {
+        "type": "object",
+        "properties": {
+          "occurred_on": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "occurred_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "payee": {
+            "type": "string"
+          },
+          "narration": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "posted",
+              "voided",
+              "reconciled",
+              "error"
+            ]
+          },
+          "postings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NewPosting"
+            },
+            "minItems": 2
+          },
+          "document_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            }
+          },
+          "trip_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {},
+            "description": "User-defined JSON object; not schema-validated."
+          }
+        },
+        "required": [
+          "occurred_on",
+          "postings"
+        ]
+      },
+      "UpdateTransactionRequest": {
+        "type": "object",
+        "properties": {
+          "occurred_on": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "occurred_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "payee": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "narration": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "trip_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {},
+            "description": "User-defined JSON object; not schema-validated."
+          }
+        }
+      },
+      "VoidTransactionRequest": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "BulkRequest": {
+        "type": "object",
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "op": {
+                      "type": "string",
+                      "enum": [
+                        "update"
+                      ]
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+                    },
+                    "if_match": {
+                      "type": "string"
+                    },
+                    "patch": {
+                      "$ref": "#/components/schemas/UpdateTransactionRequest"
+                    }
+                  },
+                  "required": [
+                    "op",
+                    "id",
+                    "if_match",
+                    "patch"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "op": {
+                      "type": "string",
+                      "enum": [
+                        "void"
+                      ]
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+                    },
+                    "if_match": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "op",
+                    "id",
+                    "if_match"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "op": {
+                      "type": "string",
+                      "enum": [
+                        "reconcile"
+                      ]
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+                    },
+                    "if_match": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "op",
+                    "id",
+                    "if_match"
+                  ]
+                }
+              ]
+            },
+            "minItems": 1,
+            "maxItems": 100
+          }
+        },
+        "required": [
+          "operations"
+        ]
+      },
+      "UpdatePostingRequest": {
+        "type": "object",
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "amount_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "fx_rate": {
+            "type": "string"
+          },
+          "amount_base_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "memo": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
       }
     },
     "parameters": {}
@@ -107,6 +1199,1635 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/accounts": {
+      "get": {
+        "summary": "List accounts (tree by default, flat with ?flat=true)",
+        "tags": [
+          "accounts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "required": false,
+            "name": "flat",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "required": false,
+            "name": "include_closed",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account list (flat: array of Account; default: array of AccountTreeNode roots)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Account"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new account",
+        "tags": [
+          "accounts"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAccountRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Account created",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Parent account not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/accounts/{id}": {
+      "get": {
+        "summary": "Get one account",
+        "tags": [
+          "accounts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account",
+            "headers": {
+              "ETag": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified (If-None-Match matched)"
+          },
+          "404": {
+            "description": "Account not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Patch account (rename / re-parent / close)",
+        "tags": [
+          "accounts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAccountRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Account updated",
+            "headers": {
+              "ETag": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Version mismatch (If-Match)",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "Precondition required (If-Match missing)",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Hard-delete an unused account",
+        "tags": [
+          "accounts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "404": {
+            "description": "Account not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Account has postings; soft-close instead",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Version mismatch",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "Precondition required (If-Match missing)",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/accounts/{id}/balance": {
+      "get": {
+        "summary": "Account balance as of a date",
+        "tags": [
+          "accounts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "as_of",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{3}$",
+              "example": "USD"
+            },
+            "required": false,
+            "name": "currency",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "required": false,
+            "name": "include_children",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balance summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/accounts/{id}/register": {
+      "get": {
+        "summary": "Register (checkbook view) with running balance",
+        "tags": [
+          "accounts"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "required": false,
+            "name": "include_voided",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated register",
+            "headers": {
+              "Link": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountRegister"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/transactions": {
+      "post": {
+        "summary": "Create a transaction",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "Idempotency-Key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTransactionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Idempotency conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "Idempotency-Key required",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "List transactions",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "occurred_from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "occurred_to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "required": false,
+            "name": "amount_min_minor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "required": false,
+            "name": "amount_max_minor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": false,
+            "name": "account_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "payee_contains",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "posted",
+                "voided",
+                "reconciled",
+                "error"
+              ]
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": false,
+            "name": "trip_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "required": false,
+            "name": "has_document",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": false,
+            "name": "source_ingest_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "occurred_on",
+                "amount",
+                "created_at"
+              ]
+            },
+            "required": false,
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "required": false,
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Transaction"
+                      }
+                    },
+                    "next_cursor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "next_cursor"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/transactions/{id}": {
+      "get": {
+        "summary": "Get a transaction",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Patch transaction head fields",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "If-Match",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTransactionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Version mismatch",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "If-Match required",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete draft/error transaction",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "If-Match",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "409": {
+            "description": "Must void instead",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/transactions/{id}/void": {
+      "post": {
+        "summary": "Void a posted transaction",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "If-Match",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VoidTransactionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Mirror transaction created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/transactions/{id}/reconcile": {
+      "post": {
+        "summary": "Reconcile a posted transaction",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "If-Match",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/transactions/bulk": {
+      "post": {
+        "summary": "Bulk update/void/reconcile",
+        "tags": [
+          "transactions"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Per-op results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/transactions/{id}/postings": {
+      "post": {
+        "summary": "Add a posting to a transaction",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "If-Match",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewPosting"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Posting added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Posting"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Imbalance",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/transactions/{tid}/postings/{pid}": {
+      "patch": {
+        "summary": "Update a posting",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "tid",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "pid",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "If-Match",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePostingRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Posting"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a posting",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "tid",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "pid",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "If-Match",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "422": {
+            "description": "Would leave <2 postings",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/postings": {
+      "get": {
+        "summary": "List postings",
+        "tags": [
+          "postings"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": false,
+            "name": "transaction_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": false,
+            "name": "account_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Posting"
+                      }
+                    },
+                    "next_cursor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "next_cursor"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/postings/{id}": {
+      "get": {
+        "summary": "Get a posting",
+        "tags": [
+          "postings"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Posting"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/documents": {
+      "post": {
+        "summary": "Upload a document (multipart, sha256 content-dedup)",
+        "tags": [
+          "documents"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadDocumentForm"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Duplicate upload detected — returns the existing document row",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Document created",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/documents/{id}": {
+      "get": {
+        "summary": "Get document metadata",
+        "tags": [
+          "documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Document",
+            "headers": {
+              "ETag": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Not modified (If-None-Match matched)"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Hard-delete a document (only if it has no links)",
+        "tags": [
+          "documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Document has links — unlink first",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/documents/{id}/content": {
+      "get": {
+        "summary": "Stream document binary content",
+        "tags": [
+          "documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Raw file bytes",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/documents/{id}/links": {
+      "post": {
+        "summary": "Link a document to a transaction (idempotent)",
+        "tags": [
+          "documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDocumentLinkRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Linked (or already linked — idempotent)"
+          },
+          "404": {
+            "description": "Document or transaction not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/documents/{id}/links/{txn_id}": {
+      "delete": {
+        "summary": "Unlink a document from a transaction",
+        "tags": [
+          "documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "txn_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Unlinked"
+          },
+          "404": {
+            "description": "Link not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }

--- a/scripts/smoke-v1-ingest.md
+++ b/scripts/smoke-v1-ingest.md
@@ -1,0 +1,74 @@
+# smoke-v1-ingest — host-side `/v1/*` API ingestion smoke test
+
+Black-box end-to-end test of the new `/v1/*` ledger API against the already-running Docker stack. Uploads N real receipt images, extracts structured fields with host-side `claude -p` (plain-text + fenced JSON, **no** `--json-schema`), creates balanced 2-posting transactions, links the documents, and reports extraction accuracy against ground truth parsed from filenames.
+
+## Prerequisites
+
+- `receipt-assistant` container running on `localhost:3000` and `receipts-postgres` healthy. Check with `docker ps`.
+- Accounts seeded (`Expenses:Groceries`, `Expenses:Dining`, `Expenses:Transport`, `Expenses:Other`, `Liabilities:Credit Card`). Run `npm run db:seed` once if the target DB is fresh.
+- `claude` CLI v2.x on host PATH, logged in (subscription auth).
+- Node 22 (for built-in `fetch`, `FormData`, `Blob`).
+
+## Run
+
+From the inner repo (`~/Developer/receipt-assistant/`):
+
+```bash
+npx tsx scripts/smoke-v1-ingest.ts
+```
+
+### Args
+
+| Flag                  | Default                                 | Meaning                                      |
+|-----------------------|-----------------------------------------|----------------------------------------------|
+| `--base=<url>`        | `http://localhost:3000`                 | API base URL                                 |
+| `--files=<glob>`      | hard-coded 15 diverse receipts          | Override file selection (e.g. `/path/*.jpeg`)|
+| `--concurrency=<n>`   | `3`                                     | Parallel `claude -p` workers                 |
+| `--limit=<n>`         | `15`                                    | Cap the number processed                     |
+
+## What it asserts
+
+For each receipt:
+
+1. `POST /v1/documents` with multipart `file`, `kind=receipt_image` — 201 on new, 200 on dedup.
+2. `claude -p` extracts `{payee, occurred_on, total_minor, category_hint}` — plain text reasoning, trailing ` ```json ` fence parsed by the harness.
+3. `category_hint` → expense account (groceries/dining/cafe/retail/transport/other). Fallback is `Expenses:Other`. "cafe" folds into `Expenses:Dining` (no dedicated cafe seed).
+4. `POST /v1/transactions` with a balanced pair (expense debit, credit-card credit) and a deterministic `Idempotency-Key: smoke-<sha256(filename|file-sha256)[:24]>`. Re-running the harness on the same receipts is therefore idempotent — the tx is not duplicated.
+5. `POST /v1/documents/:id/links` — exercises the explicit link endpoint even though `document_ids` on the transaction already links it. Must return 204.
+
+### Idempotent reruns — 409 recovery
+
+Claude's extraction is non-deterministic. On a rerun, if the extracted body differs from the body the server already stored under the same `Idempotency-Key`, `POST /v1/transactions` correctly returns `409 idempotency-conflict`. The harness treats that response as "already ingested" — it falls back to `GET /v1/transactions?limit=200` filtered by `metadata.ground_truth_file`, recovers the prior transaction id, and re-exercises the `/links` endpoint against it. The row is tagged `[reused prior tx]` in the output and the first-run extraction values are retained for accuracy tallying. This keeps the harness safely re-runnable without operator cleanup between invocations.
+
+## Accuracy metrics
+
+Ground truth is parsed from the filename:
+
+```
+YYYY-MM-DD_Receipt_<Merchant>_<description>_<TOTAL>.jpeg
+```
+
+- **date_match** — exact string equality vs `occurred_on`.
+- **total_match** — exact integer equality in minor units. Filenames without a trailing total (e.g. `..._groceries.jpeg`) are skipped from the denominator.
+- **payee_match** — any CamelCase token from `<Merchant>` (split on case boundaries) appears, case-insensitive, as a substring of the extracted payee.
+
+## Output
+
+Stdout shows one line per receipt plus an aggregate table:
+
+```
+Receipts processed : 15 / 15
+Extractions parsed : 15 / 15
+Date matches       : 14 / 15  (93%)
+Total matches      : 13 / 15  (87%)
+Payee substring    : 15 / 15  (100%)
+Round-trip success : 15 / 15
+```
+
+Plus a `Failures` section with raw Claude output tail for any extraction errors, and a machine-readable JSON report at `scripts/smoke-v1-ingest.report.json` for diffing future runs.
+
+## Non-goals
+
+- Not a DB-level integrity test — for that, see `src/routes/transactions.service.ts` + the vitest suite.
+- Not a Langfuse trace check — extraction happens on the host, not in the container, so the Langfuse trace volume is not written.
+- Not a load test. 15 receipts, concurrency 3, ~15–60s per extraction.

--- a/scripts/smoke-v1-ingest.ts
+++ b/scripts/smoke-v1-ingest.ts
@@ -1,0 +1,736 @@
+/**
+ * smoke-v1-ingest.ts — host-side ingestion harness for the `/v1/*` ledger API.
+ *
+ * Runs an end-to-end extraction + ingestion round-trip against the already-
+ * running Docker stack (receipt-assistant on :3000). For each receipt file:
+ *
+ *   1. POST /v1/documents            (multipart upload, sha256-dedupes)
+ *   2. claude -p on the host         (plain-text reasoning + fenced JSON)
+ *   3. POST /v1/transactions         (balanced 2-posting, Idempotency-Key'd)
+ *   4. POST /v1/documents/:id/links  (explicit, idempotent — matches spec)
+ *   5. Accuracy check vs ground truth parsed from filename
+ *
+ * This script DOES NOT touch the API source (`src/**`), the DB, or any
+ * schema files — it is a pure black-box smoke test.
+ *
+ * Key invariant: NO `--json-schema`. Structured output degrades OCR
+ * (documented in CLAUDE.md). The fenced-JSON-at-end convention keeps us
+ * in plain-text mode while still making parsing trivial.
+ *
+ * Run:   npx tsx scripts/smoke-v1-ingest.ts
+ * Args:  --files=<glob>           Override file selection (unquoted glob)
+ *        --base=<url>             API base URL (default http://localhost:3000)
+ *        --concurrency=<n>        Parallel workers (default 3)
+ *        --limit=<n>              Cap processed count (default 15)
+ */
+import { spawn } from "child_process";
+import { randomUUID, createHash } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+
+// ── CLI args ───────────────────────────────────────────────────────────
+
+type Args = {
+  files: string[];
+  base: string;
+  concurrency: number;
+  limit: number;
+};
+
+function parseArgs(argv: string[]): Args {
+  const args: Record<string, string> = {};
+  for (const a of argv.slice(2)) {
+    const m = /^--([^=]+)=(.*)$/.exec(a);
+    if (m) args[m[1]!] = m[2]!;
+  }
+  const base = args.base ?? "http://localhost:3000";
+  const concurrency = Number(args.concurrency ?? "3");
+  const limit = Number(args.limit ?? "15");
+
+  const files = args.files
+    ? expandGlob(args.files)
+    : DEFAULT_SELECTION.map((f) =>
+        path.resolve("/Users/danieltang/Desktop/RECEIPT", f),
+      );
+
+  return { files: files.slice(0, limit), base, concurrency, limit };
+}
+
+function expandGlob(pattern: string): string[] {
+  // Minimal glob expansion — we only need *.jpeg behaviour here.
+  const dir = path.dirname(pattern);
+  const base = path.basename(pattern);
+  if (!base.includes("*")) {
+    return fs.existsSync(pattern) ? [path.resolve(pattern)] : [];
+  }
+  const rx = new RegExp(
+    "^" + base.replace(/\./g, "\\.").replace(/\*/g, ".*") + "$",
+  );
+  return fs
+    .readdirSync(dir)
+    .filter((f) => rx.test(f))
+    .map((f) => path.resolve(dir, f))
+    .sort();
+}
+
+// Hard-coded diverse 15 (dates Sep 2025 → Apr 2026, mixed categories,
+// including the CLAUDE.md-flagged hard cases: Costco gas, AYCE).
+const DEFAULT_SELECTION = [
+  "2025-09-29_Receipt_UrthCaffe_brunch_93.03.jpeg",
+  "2025-09-30_Receipt_Wilson_wristband_classic_navy_x2_26.28.jpeg",
+  "2025-10-18_Receipt_LeYuenBBQ_bbq_63.91.jpeg",
+  "2025-10-22_Receipt_Yoshinoya_beef_combo_bowls_21.03.jpeg",
+  "2025-10-27_Receipt_TraderJoes_milk_cinnamon_pumpkin_10.58.jpeg",
+  "2025-11-02_Receipt_KellysCoffeeAndFudge_cafe_latte_5.75.jpeg",
+  "2025-11-04_Receipt_Costco_groceries_47.17.jpeg",
+  "2025-11-14_Receipt_SunriseNoodleHouse_cantonese_clay_pot_69.94.jpeg",
+  "2025-11-16_Receipt_InNOut_double_double_8.90.jpeg",
+  "2025-12-01_Receipt_Marukai_groceries_97.72.jpeg",
+  "2025-12-07_Receipt_CircleK_fuel_unleaded_70.79.jpeg",
+  "2026-02-22_Receipt_TraderJoes_groceries_29.36.jpeg",
+  "2026-03-06_Receipt_Costco_gas_marina_del_rey_73.78.jpeg",
+  "2026-03-25_Receipt_EuclidCoffee_iced_latte_8.00.jpeg",
+  "2026-04-07_Receipt_SushiAYCE_ayce_dinner_130.30.jpeg",
+];
+
+// ── Ground truth from filename ─────────────────────────────────────────
+
+type GroundTruth = {
+  filename: string;
+  date: string;                 // YYYY-MM-DD
+  merchant: string;             // CamelCase token from filename
+  merchantTokens: string[];     // lowercased split
+  total_dollars: number | null; // null when filename has no trailing total
+  total_minor: number | null;
+};
+
+function parseGroundTruth(absPath: string): GroundTruth {
+  const filename = path.basename(absPath);
+  // YYYY-MM-DD_Receipt_<Merchant>_<description>_<TOTAL>.jpeg
+  // or      ... _<description>.jpeg  (no total)
+  const m = /^(\d{4}-\d{2}-\d{2})_Receipt_([^_]+)_(.+?)(?:_(-?\d+\.\d{2}))?\.jpe?g$/i.exec(
+    filename,
+  );
+  if (!m) {
+    throw new Error(`Unparseable filename: ${filename}`);
+  }
+  const date = m[1]!;
+  const merchant = m[2]!;
+  const totalStr = m[4];
+  const dollars = totalStr != null ? Number(totalStr) : null;
+  const totalMinor = dollars != null ? Math.round(dollars * 100) : null;
+
+  // "WingOnMarket" → ["wing", "on", "market"]
+  // Keeps runs of the same case: lower-then-upper boundary only.
+  const tokens = merchant
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .split(/\s+/)
+    .map((t) => t.toLowerCase())
+    .filter((t) => t.length > 0);
+
+  return {
+    filename,
+    date,
+    merchant,
+    merchantTokens: tokens,
+    total_dollars: dollars,
+    total_minor: totalMinor,
+  };
+}
+
+// ── Claude host invocation ─────────────────────────────────────────────
+
+type Extracted = {
+  payee: string;
+  occurred_on: string;
+  total_minor: number;
+  category_hint: string;
+};
+
+function buildPrompt(absImagePath: string): string {
+  return `Read the receipt image at ${absImagePath}
+
+Extract these fields and think out loud before giving a final answer:
+- merchant (business name as printed on the receipt header/logo)
+- date (YYYY-MM-DD; read from the receipt, NEVER use today's date as a fallback)
+- total amount in cents (integer; FINAL amount paid, after tax and tip — include any handwritten tip)
+- brief category hint (one of: groceries, dining, cafe, retail, transport, other)
+
+End your response with a fenced JSON block like:
+\`\`\`json
+{"payee": "...", "occurred_on": "YYYY-MM-DD", "total_minor": 12345, "category_hint": "groceries"}
+\`\`\``;
+}
+
+/**
+ * Pull the LAST ```json ... ``` fenced block from stdout. Using the last
+ * one is deliberate — Claude may include examples of the format mid-
+ * reasoning (e.g. in "like this: {...}" asides). The final answer is
+ * always the trailing block.
+ */
+function extractLastJsonFence(raw: string): string | null {
+  const re = /```json\s*([\s\S]*?)```/g;
+  let last: string | null = null;
+  for (;;) {
+    const m = re.exec(raw);
+    if (!m) break;
+    last = m[1]!.trim();
+  }
+  return last;
+}
+
+async function runClaudeOnImage(
+  absImagePath: string,
+  timeoutMs = 180_000,
+): Promise<{ raw: string; parsed: Extracted | null; parseError?: string; sessionId: string }> {
+  const sessionId = randomUUID();
+  const prompt = buildPrompt(absImagePath);
+  const args = [
+    "-p",
+    prompt,
+    "--output-format",
+    "text",
+    "--dangerously-skip-permissions",
+    "--session-id",
+    sessionId,
+  ];
+
+  // Clear env quirks that break nested sessions (same as src/claude.ts).
+  const env = { ...process.env };
+  delete env.CLAUDECODE;
+  delete env.ANTHROPIC_API_KEY;
+
+  const raw = await new Promise<string>((resolve, reject) => {
+    const child = spawn("claude", args, { env, stdio: ["ignore", "pipe", "pipe"] });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (c: Buffer) => (out += c.toString()));
+    child.stderr.on("data", (c: Buffer) => (err += c.toString()));
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`claude -p timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) reject(new Error(err || out || `exit ${code}`));
+      else resolve(out);
+    });
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+
+  const fence = extractLastJsonFence(raw);
+  if (!fence) return { raw, parsed: null, parseError: "no ```json fence found", sessionId };
+  try {
+    const obj = JSON.parse(fence) as Extracted;
+    if (
+      typeof obj.payee !== "string" ||
+      typeof obj.occurred_on !== "string" ||
+      typeof obj.total_minor !== "number" ||
+      typeof obj.category_hint !== "string"
+    ) {
+      return { raw, parsed: null, parseError: `shape mismatch: ${fence}`, sessionId };
+    }
+    return { raw, parsed: obj, sessionId };
+  } catch (e) {
+    return { raw, parsed: null, parseError: `JSON parse: ${(e as Error).message}`, sessionId };
+  }
+}
+
+// ── HTTP helpers (native fetch / FormData / Blob) ──────────────────────
+
+type AccountsMap = {
+  groceries: string;
+  dining: string;
+  cafe: string;
+  retail: string;
+  transport: string;
+  other: string;
+  credit_card: string;
+};
+
+async function fetchAccountsMap(base: string): Promise<AccountsMap> {
+  const resp = await fetch(`${base}/v1/accounts?flat=true`);
+  if (!resp.ok) throw new Error(`GET /v1/accounts failed: ${resp.status}`);
+  const accounts = (await resp.json()) as Array<{
+    id: string;
+    name: string;
+    type: string;
+    subtype: string | null;
+  }>;
+
+  const find = (pred: (a: (typeof accounts)[number]) => boolean, label: string) => {
+    const a = accounts.find(pred);
+    if (!a) throw new Error(`seeded account missing: ${label}`);
+    return a.id;
+  };
+
+  const groceries = find((a) => a.type === "expense" && a.name === "Groceries", "Expenses:Groceries");
+  const dining = find((a) => a.type === "expense" && a.name === "Dining", "Expenses:Dining");
+  const transport = find((a) => a.type === "expense" && a.name === "Transport", "Expenses:Transport");
+  // There are two "Other" rows (one expense, one income); pick the expense side.
+  const other = find((a) => a.type === "expense" && a.name === "Other", "Expenses:Other");
+  const creditCard = find(
+    (a) => a.type === "liability" && a.subtype === "credit_card",
+    "Liabilities:Credit Card",
+  );
+
+  return {
+    groceries,
+    dining,
+    cafe: dining, // no dedicated cafe account — fold into Dining
+    retail: other,
+    transport,
+    other,
+    credit_card: creditCard,
+  };
+}
+
+function pickExpenseAccount(accounts: AccountsMap, category_hint: string): {
+  id: string;
+  resolved: keyof Omit<AccountsMap, "credit_card">;
+} {
+  const h = (category_hint || "").toLowerCase().trim();
+  if (h === "groceries") return { id: accounts.groceries, resolved: "groceries" };
+  if (h === "dining") return { id: accounts.dining, resolved: "dining" };
+  if (h === "cafe") return { id: accounts.cafe, resolved: "cafe" };
+  if (h === "retail") return { id: accounts.retail, resolved: "retail" };
+  if (h === "transport") return { id: accounts.transport, resolved: "transport" };
+  return { id: accounts.other, resolved: "other" };
+}
+
+type DocRow = { id: string; sha256: string; kind: string; file_path?: string };
+
+async function uploadDocument(
+  base: string,
+  absPath: string,
+): Promise<{ doc: DocRow; status: number }> {
+  const bytes = fs.readFileSync(absPath);
+  const form = new FormData();
+  // Node 22's global Blob works here — the API streams via multer memory.
+  form.append("file", new Blob([bytes], { type: "image/jpeg" }), path.basename(absPath));
+  form.append("kind", "receipt_image");
+  const resp = await fetch(`${base}/v1/documents`, { method: "POST", body: form });
+  const body = (await resp.json()) as DocRow;
+  if (!resp.ok) {
+    throw new Error(`POST /v1/documents [${resp.status}]: ${JSON.stringify(body)}`);
+  }
+  return { doc: body, status: resp.status };
+}
+
+type Transaction = { id: string; version: number; [k: string]: unknown };
+
+async function createTransaction(
+  base: string,
+  idempotencyKey: string,
+  body: unknown,
+): Promise<{ tx: Transaction; reused: boolean }> {
+  const resp = await fetch(`${base}/v1/transactions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": idempotencyKey,
+    },
+    body: JSON.stringify(body),
+  });
+  const json = await resp.json();
+  if (resp.ok) return { tx: json as Transaction, reused: false };
+
+  // 409 "Idempotency-Key replayed with different body" means a prior
+  // smoke-run with this (filename, sha256) already created a tx, and
+  // Claude's extraction today drifted. Recover gracefully by fetching
+  // the existing tx via the ground_truth_file metadata marker — a
+  // re-run should still count as a valid round-trip so the harness
+  // can be invoked idempotently without operator cleanup.
+  const isReplay =
+    resp.status === 409 &&
+    typeof (json as { type?: string })?.type === "string" &&
+    (json as { type: string }).type.includes("idempotency-conflict");
+  if (isReplay) {
+    const ground = (body as { metadata?: { ground_truth_file?: string } })
+      ?.metadata?.ground_truth_file;
+    if (ground) {
+      const found = await findExistingTx(base, ground);
+      if (found) return { tx: found, reused: true };
+    }
+  }
+  throw new Error(`POST /v1/transactions [${resp.status}]: ${JSON.stringify(json)}`);
+}
+
+async function findExistingTx(
+  base: string,
+  groundTruthFile: string,
+): Promise<Transaction | null> {
+  // Search by metadata via payee_contains — cheap heuristic: the
+  // filename's merchant fragment nearly always appears in the extracted
+  // payee. Fall back to full list scan on first 100 if no hit.
+  const url = `${base}/v1/transactions?limit=200`;
+  const resp = await fetch(url);
+  if (!resp.ok) return null;
+  const data = (await resp.json()) as { items: Transaction[] };
+  for (const t of data.items) {
+    const gt = (t as { metadata?: { ground_truth_file?: string } })?.metadata
+      ?.ground_truth_file;
+    if (gt === groundTruthFile) return t;
+  }
+  return null;
+}
+
+async function linkDocument(
+  base: string,
+  documentId: string,
+  transactionId: string,
+): Promise<number> {
+  const resp = await fetch(`${base}/v1/documents/${documentId}/links`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ transaction_id: transactionId }),
+  });
+  if (!resp.ok) {
+    const txt = await resp.text();
+    throw new Error(`POST /v1/documents/:id/links [${resp.status}]: ${txt}`);
+  }
+  return resp.status;
+}
+
+// ── Per-receipt pipeline ───────────────────────────────────────────────
+
+type RowResult = {
+  filename: string;
+  ground_truth: GroundTruth;
+  extracted?: Extracted;
+  accounts_resolved_to?: string;
+  tx_id?: string;
+  doc_id?: string;
+  doc_status?: number;
+  link_status?: number;
+  session_id?: string;
+  date_match?: boolean;
+  total_match?: boolean;
+  payee_match?: boolean;
+  error?: string;
+  raw_claude_tail?: string;
+  started_at: string;
+  finished_at: string;
+  duration_ms: number;
+};
+
+function short(s: string, max = 12) {
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+function checkAccuracy(gt: GroundTruth, ext: Extracted): {
+  date_match: boolean;
+  total_match: boolean | null;
+  payee_match: boolean;
+} {
+  const date_match = ext.occurred_on === gt.date;
+  const total_match = gt.total_minor == null ? null : ext.total_minor === gt.total_minor;
+  const payeeLower = ext.payee.toLowerCase();
+  const payee_match = gt.merchantTokens.some((t) => payeeLower.includes(t));
+  return { date_match, total_match, payee_match };
+}
+
+async function processOne(
+  absPath: string,
+  base: string,
+  accounts: AccountsMap,
+): Promise<RowResult> {
+  const started = Date.now();
+  const started_at = new Date(started).toISOString();
+  const gt = parseGroundTruth(absPath);
+
+  try {
+    // 1. Upload
+    const { doc, status: docStatus } = await uploadDocument(base, absPath);
+
+    // 2. Extract via claude -p
+    const claudeRes = await runClaudeOnImage(absPath);
+    if (!claudeRes.parsed) {
+      return {
+        filename: gt.filename,
+        ground_truth: gt,
+        doc_id: doc.id,
+        doc_status: docStatus,
+        session_id: claudeRes.sessionId,
+        error: `extract: ${claudeRes.parseError ?? "unknown"}`,
+        raw_claude_tail: claudeRes.raw.slice(-800),
+        started_at,
+        finished_at: new Date().toISOString(),
+        duration_ms: Date.now() - started,
+      };
+    }
+    const ext = claudeRes.parsed;
+
+    // 3. Resolve category -> expense account
+    const picked = pickExpenseAccount(accounts, ext.category_hint);
+    const amount = ext.total_minor;
+
+    // 4. POST transaction (expense debit + CC credit)
+    //    sign convention: negative amount_minor == "money out" of that
+    //    account balance — matches the probe call that succeeded.
+    const idemKey = `smoke-${createHash("sha256")
+      .update(gt.filename + "|" + doc.sha256)
+      .digest("hex")
+      .slice(0, 24)}`;
+    const txBody = {
+      occurred_on: ext.occurred_on,
+      payee: ext.payee,
+      narration: "Smoke test v1-ledger-api",
+      postings: [
+        {
+          account_id: picked.id,
+          amount_minor: amount,
+          currency: "USD",
+          amount_base_minor: amount,
+        },
+        {
+          account_id: accounts.credit_card,
+          amount_minor: -amount,
+          currency: "USD",
+          amount_base_minor: -amount,
+        },
+      ],
+      document_ids: [doc.id],
+      metadata: {
+        source: "smoke-v1-ingest",
+        ground_truth_file: gt.filename,
+        category_hint: ext.category_hint,
+        expense_account: picked.resolved,
+      },
+    };
+    const { tx, reused } = await createTransaction(base, idemKey, txBody);
+
+    // 5. Explicit link POST (idempotent — the inline document_ids above
+    //    already linked it; this exercises the /links endpoint as the
+    //    task spec requires and proves idempotency).
+    const linkStatus = await linkDocument(base, doc.id, tx.id);
+    if (reused) {
+      // Accuracy was already evaluated on the first run; on a rerun,
+      // trust the first-run extraction stored in the transaction.
+      // Flag it visibly in the row so operators know it wasn't
+      // re-extracted today.
+      (ext as Extracted & { __reused?: boolean }).__reused = true;
+    }
+
+    // 6. Accuracy
+    const acc = checkAccuracy(gt, ext);
+
+    return {
+      filename: gt.filename,
+      ground_truth: gt,
+      extracted: ext,
+      accounts_resolved_to: picked.resolved,
+      tx_id: tx.id,
+      doc_id: doc.id,
+      doc_status: docStatus,
+      link_status: linkStatus,
+      session_id: claudeRes.sessionId,
+      date_match: acc.date_match,
+      total_match: acc.total_match ?? undefined,
+      payee_match: acc.payee_match,
+      started_at,
+      finished_at: new Date().toISOString(),
+      duration_ms: Date.now() - started,
+    };
+  } catch (e) {
+    return {
+      filename: gt.filename,
+      ground_truth: gt,
+      error: (e as Error).message,
+      started_at,
+      finished_at: new Date().toISOString(),
+      duration_ms: Date.now() - started,
+    };
+  }
+}
+
+// ── Pretty row line ────────────────────────────────────────────────────
+
+function fmtDollar(cents: number | null | undefined): string {
+  if (cents == null) return "   ?   ";
+  const sign = cents < 0 ? "-" : "";
+  const abs = Math.abs(cents);
+  return `${sign}$${(abs / 100).toFixed(2)}`;
+}
+
+function formatRow(r: RowResult): string {
+  const gt = r.ground_truth;
+  const merchant = gt.merchant.padEnd(20).slice(0, 20);
+  const gtTot = fmtDollar(gt.total_minor ?? null).padStart(9);
+
+  if (r.error) {
+    return `✗ ${gt.date} ${merchant} ${gtTot}  →  ERROR: ${r.error}`;
+  }
+
+  const ext = r.extracted!;
+  const dateOk = r.date_match ? "✓" : "✗";
+  const totalOk =
+    r.total_match === undefined ? "-" : r.total_match ? "✓" : "✗";
+  const payeeOk = r.payee_match ? "✓" : "✗";
+
+  let extra = "";
+  if (r.total_match === false) {
+    const diff = (ext.total_minor - (gt.total_minor ?? 0)) / 100;
+    extra += `  [total ${ext.total_minor}¢ vs gt ${gt.total_minor}¢, off $${diff.toFixed(2)}]`;
+  }
+  if (r.date_match === false) {
+    extra += `  [date ${ext.occurred_on} vs gt ${gt.date}]`;
+  }
+  if (!r.payee_match) {
+    extra += `  [payee "${ext.payee}" vs tokens ${JSON.stringify(gt.merchantTokens)}]`;
+  }
+
+  const ok = r.date_match && (r.total_match ?? true) && r.payee_match;
+  const marker = ok ? "✓" : "✗";
+  const reusedTag = (ext as Extracted & { __reused?: boolean }).__reused
+    ? " [reused prior tx]"
+    : "";
+  return (
+    `${marker} ${gt.date} ${merchant} ${gtTot}  →  ` +
+    `tx=${short(r.tx_id!, 8)} docId=${short(r.doc_id!, 8)} ` +
+    `acct=${r.accounts_resolved_to} ` +
+    `(date ${dateOk} total ${totalOk} payee ${payeeOk})${extra}${reusedTag}`
+  );
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv);
+  console.log(`\nReceipt Assistant — /v1 smoke test`);
+  console.log(`  base         = ${args.base}`);
+  console.log(`  concurrency  = ${args.concurrency}`);
+  console.log(`  files        = ${args.files.length}`);
+  for (const f of args.files) console.log(`                 ${path.basename(f)}`);
+  console.log("");
+
+  const missing = args.files.filter((f) => !fs.existsSync(f));
+  if (missing.length) {
+    console.error(`Missing files:\n  ${missing.join("\n  ")}`);
+    process.exit(2);
+  }
+
+  // Fetch accounts once
+  const accounts = await fetchAccountsMap(args.base);
+  console.log(`Account map resolved:`);
+  for (const [k, v] of Object.entries(accounts))
+    console.log(`  ${k.padEnd(12)} = ${v}`);
+  console.log("");
+
+  // Run with bounded concurrency. Claude -p calls dominate latency (~15-30s
+  // each); 3 in parallel keeps the host responsive without starving auth.
+  const results: RowResult[] = new Array(args.files.length);
+  let next = 0;
+  const started = Date.now();
+
+  async function worker(wid: number) {
+    while (true) {
+      const idx = next++;
+      if (idx >= args.files.length) return;
+      const abs = args.files[idx]!;
+      console.log(`[w${wid}] ${idx + 1}/${args.files.length} ${path.basename(abs)}`);
+      const r = await processOne(abs, args.base, accounts);
+      results[idx] = r;
+      console.log(`[w${wid}] ${formatRow(r)}`);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: args.concurrency }, (_, i) => worker(i + 1)),
+  );
+
+  const totalMs = Date.now() - started;
+
+  // Aggregate
+  const processed = results.filter(Boolean);
+  const errored = processed.filter((r) => r.error);
+  const extracted = processed.filter((r) => !r.error);
+  const dateMatches = extracted.filter((r) => r.date_match).length;
+  const totalEligible = extracted.filter((r) => r.total_match !== undefined);
+  const totalMatches = totalEligible.filter((r) => r.total_match).length;
+  const payeeMatches = extracted.filter((r) => r.payee_match).length;
+  const roundTrip = processed.filter((r) => r.tx_id && r.link_status === 204).length;
+
+  console.log("\n" + "═".repeat(78));
+  console.log("Per-receipt results:\n");
+  for (const r of processed) console.log("  " + formatRow(r));
+
+  console.log("\n" + "═".repeat(78));
+  console.log("Aggregate accuracy:\n");
+  const pct = (n: number, d: number) => (d === 0 ? "n/a" : `${Math.round((n / d) * 100)}%`);
+  console.log(`  Receipts processed : ${processed.length} / ${args.files.length}`);
+  console.log(`  Extractions parsed : ${extracted.length} / ${processed.length}`);
+  console.log(`  Errors             : ${errored.length}`);
+  console.log(`  Date matches       : ${dateMatches} / ${extracted.length}  (${pct(dateMatches, extracted.length)})`);
+  console.log(
+    `  Total matches      : ${totalMatches} / ${totalEligible.length}  (${pct(totalMatches, totalEligible.length)})  ` +
+      `[${extracted.length - totalEligible.length} ground-truth totals missing from filename]`,
+  );
+  console.log(`  Payee substring    : ${payeeMatches} / ${extracted.length}  (${pct(payeeMatches, extracted.length)})`);
+  console.log(`  Round-trip success : ${roundTrip} / ${processed.length}  (tx created + document linked)`);
+  console.log(`  Wall clock         : ${(totalMs / 1000).toFixed(1)}s`);
+  console.log(`  Avg per receipt    : ${(totalMs / 1000 / processed.length).toFixed(1)}s`);
+
+  // Failures block
+  const failures = processed.filter(
+    (r) => r.error || !r.date_match || r.total_match === false || !r.payee_match,
+  );
+  if (failures.length) {
+    console.log("\n" + "═".repeat(78));
+    console.log(`Failures (${failures.length}):\n`);
+    for (const r of failures) {
+      console.log(`── ${r.filename}`);
+      if (r.error) {
+        console.log(`    error: ${r.error}`);
+        if (r.raw_claude_tail)
+          console.log(`    raw tail:\n${r.raw_claude_tail.split("\n").map((l) => "      " + l).join("\n")}`);
+      } else {
+        const ext = r.extracted!;
+        console.log(`    ground truth: date=${r.ground_truth.date} total=${fmtDollar(r.ground_truth.total_minor ?? null)} tokens=${JSON.stringify(r.ground_truth.merchantTokens)}`);
+        console.log(`    extracted   : date=${ext.occurred_on} total=${fmtDollar(ext.total_minor)} payee="${ext.payee}" category=${ext.category_hint}`);
+        console.log(`    mismatches  : date=${r.date_match} total=${r.total_match} payee=${r.payee_match}`);
+      }
+      console.log("");
+    }
+  }
+
+  // Persist structured report
+  const report = {
+    base: args.base,
+    started_at: new Date(started).toISOString(),
+    finished_at: new Date().toISOString(),
+    total_wall_ms: totalMs,
+    concurrency: args.concurrency,
+    file_count: args.files.length,
+    accounts,
+    aggregate: {
+      processed: processed.length,
+      extracted: extracted.length,
+      errors: errored.length,
+      date_matches: dateMatches,
+      total_matches: totalMatches,
+      total_eligible: totalEligible.length,
+      payee_matches: payeeMatches,
+      round_trip_success: roundTrip,
+    },
+    rows: processed,
+  };
+  const reportPath = path.resolve(path.dirname(import.meta.url.replace("file://", "")), "smoke-v1-ingest.report.json");
+  fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+  console.log(`\nReport written to ${reportPath}`);
+
+  // Exit non-zero if any round-trip failed (extraction mismatch is
+  // informational — accuracy, not correctness of the API under test).
+  if (errored.length > 0 || roundTrip !== processed.length) {
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error("FATAL:", e);
+  process.exit(2);
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,61 @@
+/**
+ * Express app factory — separated from `server.ts` so integration tests
+ * can `supertest(buildApp())` without opening a listening socket.
+ *
+ * Middleware stack (order matters):
+ *   1. JSON body parsing + trust-proxy (for correct `req.protocol`)
+ *   2. `contextMiddleware` attaches `req.ctx` { workspaceId, userId, traceId }
+ *   3. Routes — feature-scoped routers mounted under `/v1/*`
+ *   4. `problemHandler` — RFC 7807 serialization (ALWAYS last)
+ *
+ * The `/v1/*` routers are added by feature-specific modules and imported
+ * here so the app factory stays a single source of truth for the
+ * middleware order.
+ */
+import express, { type Express, type Request, type Response } from "express";
+import swaggerUi from "swagger-ui-express";
+import { buildOpenApiDocument } from "./openapi.js";
+import { contextMiddleware } from "./http/context.js";
+import { problemHandler } from "./http/problem.js";
+import { accountsRouter } from "./routes/accounts.js";
+import { transactionsRouter } from "./routes/transactions.js";
+import { postingsRouter } from "./routes/postings.js";
+import { documentsRouter } from "./routes/documents.js";
+
+export function buildApp(): Express {
+  const app = express();
+  app.set("trust proxy", true);
+  app.use(express.json({ limit: "25mb" }));
+
+  // ── Meta: spec + docs (registered before context to keep them cheap) ──
+  const openApiDoc = buildOpenApiDocument();
+  app.get("/openapi.json", (_req: Request, res: Response) => {
+    res.json(openApiDoc);
+  });
+  app.use(
+    "/docs",
+    swaggerUi.serve,
+    swaggerUi.setup(openApiDoc, {
+      customSiteTitle: "Receipt Assistant API",
+      swaggerOptions: { persistAuthorization: true },
+    }),
+  );
+
+  app.get("/health", (_req: Request, res: Response) => {
+    res.json({ status: "ok", service: "receipt-assistant", version: "2.0.0-alpha" });
+  });
+
+  // ── Per-request context ─────────────────────────────────────────────
+  app.use(contextMiddleware);
+
+  // ── v1 resource routers ─────────────────────────────────────────────
+  app.use("/v1/accounts", accountsRouter);
+  app.use("/v1/transactions", transactionsRouter);
+  app.use("/v1/postings", postingsRouter);
+  app.use("/v1/documents", documentsRouter);
+
+  // ── Final error handler ─────────────────────────────────────────────
+  app.use(problemHandler);
+
+  return app;
+}

--- a/src/http/context.ts
+++ b/src/http/context.ts
@@ -1,0 +1,44 @@
+/**
+ * Per-request context: workspace_id, user_id, trace_id.
+ *
+ * Until the auth epic lands, every request is pinned to the seeded
+ * workspace + owner user. Once auth ships, this middleware will:
+ *   1. Resolve the bearer token / session cookie to a user.
+ *   2. Resolve the target workspace (header `X-Workspace-Id` or path).
+ *   3. Run `SET LOCAL app.current_workspace = '...'` on the connection
+ *      so the RLS policies in the schema become authoritative.
+ *
+ * For now we only attach `req.ctx` so downstream handlers can pretend
+ * auth already works — the interface is stable.
+ */
+import type { Request, Response, NextFunction } from "express";
+import { randomUUID } from "crypto";
+import { SEED_USER_ID, SEED_WORKSPACE_ID } from "../db/seed.js";
+
+export interface RequestContext {
+  workspaceId: string;
+  userId: string;
+  traceId: string;
+}
+
+declare module "express-serve-static-core" {
+  interface Request {
+    ctx: RequestContext;
+    traceId: string;
+  }
+}
+
+export function contextMiddleware(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const traceId = req.header("x-trace-id") ?? randomUUID();
+  req.traceId = traceId;
+  req.ctx = {
+    workspaceId: SEED_WORKSPACE_ID,
+    userId: SEED_USER_ID,
+    traceId,
+  };
+  next();
+}

--- a/src/http/etag.ts
+++ b/src/http/etag.ts
@@ -1,0 +1,63 @@
+/**
+ * Weak-ETag helpers for optimistic-concurrency-controlled resources.
+ *
+ * Format: `W/"<version>"` where `<version>` is the monotonic `version`
+ * column maintained by the `bump_version` DB trigger.
+ *
+ * Mutations (PATCH/DELETE/void) MUST carry `If-Match`; missing → 428,
+ * mismatch → 412. GET accepts optional `If-None-Match` → 304 on match.
+ */
+import type { Request, Response } from "express";
+import {
+  PreconditionRequiredProblem,
+  VersionMismatchProblem,
+} from "./problem.js";
+
+export function formatEtag(version: number): string {
+  return `W/"${version}"`;
+}
+
+export function parseEtag(header: string | undefined): number | null {
+  if (!header) return null;
+  const m = /^\s*W\/"(\d+)"\s*$/.exec(header);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Emit the ETag header on a resource response. */
+export function setEtag(res: Response, version: number): void {
+  res.setHeader("ETag", formatEtag(version));
+}
+
+/**
+ * Enforce If-Match on a mutation endpoint.
+ * Throws HttpProblem on missing / malformed / mismatched tag.
+ */
+export function requireIfMatch(req: Request, currentVersion: number): void {
+  const header = req.header("If-Match");
+  if (!header) throw new PreconditionRequiredProblem("If-Match");
+  const supplied = parseEtag(header);
+  if (supplied === null || supplied !== currentVersion) {
+    throw new VersionMismatchProblem(currentVersion, supplied ?? undefined);
+  }
+}
+
+/**
+ * Handle If-None-Match on a GET. Returns true if a 304 was sent;
+ * the caller should `return` immediately on true.
+ */
+export function handleIfNoneMatch(
+  req: Request,
+  res: Response,
+  currentVersion: number,
+): boolean {
+  const header = req.header("If-None-Match");
+  if (!header) return false;
+  const supplied = parseEtag(header);
+  if (supplied !== null && supplied === currentVersion) {
+    res.status(304).end();
+    return true;
+  }
+  return false;
+}

--- a/src/http/idempotency.ts
+++ b/src/http/idempotency.ts
@@ -1,0 +1,107 @@
+/**
+ * Stripe-style `Idempotency-Key` middleware.
+ *
+ * Scope: workspace_id + key (keys are unique per workspace).
+ * Body fingerprint: sha256 of the canonicalized request body.
+ *
+ * Behavior:
+ *   - Missing `Idempotency-Key` header → route handler runs unchanged.
+ *     (Enforcement — "POST must carry the header" — is route-specific;
+ *     add `throw new PreconditionRequiredProblem("Idempotency-Key")` to
+ *     handlers that mandate it.)
+ *   - Header present, key+hash match existing row and unexpired → serve
+ *     the cached response verbatim (status + body).
+ *   - Header present, key matches but hash differs → 409
+ *     `errors/idempotency-conflict`.
+ *   - Header present, key new → capture the eventual response and
+ *     persist on successful completion.
+ *
+ * The middleware wraps `res.status().json()` so capture happens
+ * transparently. Only JSON responses are cached; streaming/binary
+ * endpoints (documents/:id/content) should opt out by not mounting
+ * this middleware.
+ */
+import type { Request, Response, NextFunction } from "express";
+import { createHash, randomUUID } from "crypto";
+import { sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { IdempotencyConflictProblem } from "./problem.js";
+
+const TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+function hashBody(body: unknown): string {
+  const canonical = body === undefined ? "" : JSON.stringify(body);
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export function idempotencyMiddleware(): (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<void> {
+  return async (req, res, next) => {
+    const key = req.header("Idempotency-Key");
+    if (!key) return next();
+
+    const workspaceId = req.ctx.workspaceId;
+    const requestHash = hashBody(req.body);
+
+    // Look up prior response
+    const existing = await db.execute(
+      sql`SELECT response_status, response_body, request_hash, expires_at
+          FROM idempotency_keys
+          WHERE workspace_id = ${workspaceId}::uuid AND key = ${key}
+            AND expires_at > NOW()
+          LIMIT 1`,
+    );
+
+    if (existing.rows.length > 0) {
+      const row = existing.rows[0] as {
+        response_status: number;
+        response_body: unknown;
+        request_hash: string;
+      };
+      if (row.request_hash !== requestHash) {
+        return next(new IdempotencyConflictProblem());
+      }
+      res
+        .status(row.response_status)
+        .type("application/json")
+        .json(row.response_body);
+      return;
+    }
+
+    // Capture the eventual response so we can persist it.
+    const originalJson = res.json.bind(res);
+    let captured: { status: number; body: unknown } | null = null;
+    res.json = ((body: unknown) => {
+      captured = { status: res.statusCode, body };
+      return originalJson(body);
+    }) as typeof res.json;
+
+    res.on("finish", () => {
+      if (!captured) return;
+      // Only persist successful responses (2xx); don't memoize errors.
+      if (captured.status < 200 || captured.status >= 300) return;
+      const expiresAt = new Date(Date.now() + TTL_MS).toISOString();
+      db.execute(
+        sql`INSERT INTO idempotency_keys
+            (id, workspace_id, key, request_hash, response_status, response_body, expires_at)
+            VALUES (
+              ${randomUUID()}::uuid,
+              ${workspaceId}::uuid,
+              ${key},
+              ${requestHash},
+              ${captured.status},
+              ${JSON.stringify(captured.body)}::jsonb,
+              ${expiresAt}::timestamptz
+            )
+            ON CONFLICT (workspace_id, key) DO NOTHING`,
+      ).catch((err) => {
+        console.error("[idempotency] persist failed:", err);
+      });
+    });
+
+    next();
+  };
+}

--- a/src/http/pagination.ts
+++ b/src/http/pagination.ts
@@ -1,0 +1,55 @@
+/**
+ * Keyset pagination helpers.
+ *
+ * Cursors are opaque base64url-encoded JSON of the tuple that the
+ * caller's SQL ORDER BY sorts on — typically `(occurred_on, id)` for
+ * transactions, `(created_at, posting_id)` for postings/register, etc.
+ *
+ * Callers never expose the cursor shape in docs; clients only echo the
+ * `next` link from the previous response. This lets us change the
+ * underlying sort tuple without breaking API consumers.
+ */
+import type { Request, Response } from "express";
+
+export const DEFAULT_PAGE_LIMIT = 50;
+export const MAX_PAGE_LIMIT = 500;
+
+export function clampLimit(raw: unknown): number {
+  const n = typeof raw === "string" ? parseInt(raw, 10) : (raw as number);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_PAGE_LIMIT;
+  return Math.min(n, MAX_PAGE_LIMIT);
+}
+
+export function encodeCursor(payload: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+export function decodeCursor<T = Record<string, unknown>>(
+  cursor: string | undefined,
+): T | null {
+  if (!cursor) return null;
+  try {
+    const json = Buffer.from(cursor, "base64url").toString("utf8");
+    return JSON.parse(json) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Emit `Link: <...>; rel="next"` with the cursor baked into the current
+ * request URL's query string.
+ */
+export function emitNextLink(
+  req: Request,
+  res: Response,
+  nextCursor: string | null,
+): void {
+  if (!nextCursor) return;
+  // Build absolute URL from the request
+  const proto = (req.header("x-forwarded-proto") ?? req.protocol) || "http";
+  const host = req.header("host") ?? "localhost";
+  const url = new URL(`${proto}://${host}${req.originalUrl}`);
+  url.searchParams.set("cursor", nextCursor);
+  res.setHeader("Link", `<${url.toString()}>; rel="next"`);
+}

--- a/src/http/problem.ts
+++ b/src/http/problem.ts
@@ -1,0 +1,208 @@
+/**
+ * RFC 7807 Problem Details for HTTP APIs.
+ *
+ * All error responses serialize as `application/problem+json`. Clients
+ * branch on the machine-readable `type` URI, not on the human-readable
+ * `title` / `detail`.
+ *
+ * Usage in handlers — throw:
+ *     throw new NotFoundProblem("Account", id);
+ *     throw new VersionMismatchProblem(currentVersion);
+ *     throw new ValidationProblem(zodIssues);
+ *
+ * The final Express middleware (`problemHandler`) catches all errors
+ * and emits the correct status + headers. Uncaught / non-problem
+ * errors surface as 500 with `type=errors/internal`.
+ */
+import type { Request, Response, NextFunction } from "express";
+import { ZodError } from "zod";
+
+const TYPE_BASE = "https://receipts.dev/errors";
+
+export interface Violation {
+  path: string;
+  code: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export interface ProblemBody {
+  type: string;
+  title: string;
+  status: number;
+  detail?: string;
+  instance?: string;
+  trace_id?: string;
+  violations?: Violation[];
+  [key: string]: unknown;
+}
+
+export class HttpProblem extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly type: string,
+    public readonly title: string,
+    public readonly detail?: string,
+    public readonly extras: Record<string, unknown> = {},
+  ) {
+    super(detail ?? title);
+  }
+
+  toBody(instance?: string, traceId?: string): ProblemBody {
+    return {
+      type: `${TYPE_BASE}/${this.type}`,
+      title: this.title,
+      status: this.status,
+      ...(this.detail ? { detail: this.detail } : {}),
+      ...(instance ? { instance } : {}),
+      ...(traceId ? { trace_id: traceId } : {}),
+      ...this.extras,
+    };
+  }
+}
+
+export class ValidationProblem extends HttpProblem {
+  constructor(violations: Violation[], detail = "Request failed validation") {
+    super(422, "validation", "Validation failed", detail, { violations });
+  }
+
+  static fromZod(err: ZodError): ValidationProblem {
+    const violations: Violation[] = err.issues.map((i) => ({
+      path: i.path.join("."),
+      code: i.code,
+      message: i.message,
+    }));
+    return new ValidationProblem(violations);
+  }
+}
+
+export class NotFoundProblem extends HttpProblem {
+  constructor(resource: string, id?: string) {
+    super(
+      404,
+      "not-found",
+      `${resource} not found`,
+      id ? `No ${resource} with id=${id}` : undefined,
+    );
+  }
+}
+
+export class VersionMismatchProblem extends HttpProblem {
+  constructor(current: number, supplied?: number) {
+    super(
+      412,
+      "version-mismatch",
+      "Resource version mismatch",
+      `If-Match supplied version=${supplied ?? "?"}, current=${current}. Re-fetch and retry.`,
+      { current_version: current, supplied_version: supplied ?? null },
+    );
+  }
+}
+
+export class PreconditionRequiredProblem extends HttpProblem {
+  constructor(header: string) {
+    super(
+      428,
+      "precondition-required",
+      `${header} header required`,
+      `This endpoint requires ${header} for safe concurrent modification`,
+    );
+  }
+}
+
+export class IdempotencyConflictProblem extends HttpProblem {
+  constructor() {
+    super(
+      409,
+      "idempotency-conflict",
+      "Idempotency-Key replayed with different body",
+      "This Idempotency-Key was previously used for a different request payload",
+    );
+  }
+}
+
+export class AccountInUseProblem extends HttpProblem {
+  constructor(accountId: string, postingCount: number) {
+    super(
+      409,
+      "account-in-use",
+      "Account has postings",
+      `Account ${accountId} cannot be deleted — ${postingCount} posting(s) reference it. Close the account via PATCH { closed_at } instead.`,
+      { account_id: accountId, posting_count: postingCount },
+    );
+  }
+}
+
+export class MustVoidInsteadProblem extends HttpProblem {
+  constructor(txId: string, status: string) {
+    super(
+      409,
+      "must-void-instead",
+      "Use POST /void instead of DELETE",
+      `Transaction ${txId} is in status=${status}. Only draft/error transactions can be hard-deleted; posted/reconciled transactions must be voided.`,
+      { transaction_id: txId, status },
+    );
+  }
+}
+
+export class PostingsImbalanceProblem extends HttpProblem {
+  constructor(detail: string, violations: Violation[]) {
+    super(422, "postings-imbalance", "Postings do not balance", detail, {
+      violations,
+    });
+  }
+}
+
+export class DocumentHasLinksProblem extends HttpProblem {
+  constructor(documentId: string, linkCount: number) {
+    super(
+      409,
+      "document-has-links",
+      "Document is linked to transactions",
+      `Document ${documentId} is linked to ${linkCount} transaction(s). Unlink first, then DELETE.`,
+      { document_id: documentId, link_count: linkCount },
+    );
+  }
+}
+
+/**
+ * Final Express error handler — must be registered AFTER all routes.
+ */
+export function problemHandler(
+  err: unknown,
+  req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  const traceId = (req as any).traceId as string | undefined;
+  const instance = req.originalUrl;
+
+  if (err instanceof HttpProblem) {
+    res
+      .status(err.status)
+      .type("application/problem+json")
+      .json(err.toBody(instance, traceId));
+    return;
+  }
+
+  if (err instanceof ZodError) {
+    const p = ValidationProblem.fromZod(err);
+    res
+      .status(p.status)
+      .type("application/problem+json")
+      .json(p.toBody(instance, traceId));
+    return;
+  }
+
+  // Unknown error — log and return generic 500. Never leak internals.
+  console.error("[problemHandler] unhandled:", err);
+  const message = err instanceof Error ? err.message : String(err);
+  res.status(500).type("application/problem+json").json({
+    type: `${TYPE_BASE}/internal`,
+    title: "Internal Server Error",
+    status: 500,
+    detail: message,
+    ...(instance ? { instance } : {}),
+    ...(traceId ? { trace_id: traceId } : {}),
+  });
+}

--- a/src/http/uuid.ts
+++ b/src/http/uuid.ts
@@ -1,0 +1,12 @@
+/**
+ * Thin wrapper around the `uuid` package — centralizes our dependency
+ * on UUIDv7 so we can swap to PostgreSQL-native `uuidv7()` once PG 18
+ * is baseline.
+ *
+ * Never use v4 for app-generated IDs: v7 is time-ordered, which is a
+ * 10x B-tree index locality improvement for our keyset-paginated
+ * tables.
+ */
+import { v7 } from "uuid";
+
+export const newId = (): string => v7();

--- a/src/http/validate.ts
+++ b/src/http/validate.ts
@@ -1,0 +1,20 @@
+/**
+ * Zod → `ValidationProblem` bridge used by route handlers.
+ *
+ * Replaces the old `parseOr400` helper which returned `null` and wrote
+ * a 400 directly. The new contract throws so the central
+ * `problemHandler` serializes uniformly.
+ */
+import type { ZodTypeAny, infer as zInfer } from "zod";
+import { ValidationProblem } from "./problem.js";
+
+export function parseOrThrow<S extends ZodTypeAny>(
+  schema: S,
+  data: unknown,
+): zInfer<S> {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    throw ValidationProblem.fromZod(result.error);
+  }
+  return result.data;
+}

--- a/src/mcp/accounts.ts
+++ b/src/mcp/accounts.ts
@@ -1,0 +1,176 @@
+/**
+ * FastMCP tools for the `/v1/accounts` surface.
+ *
+ * Thin adapters: each tool calls the service function exported from
+ * `src/routes/accounts.ts` directly (no HTTP self-call). The workspace
+ * and user IDs are pinned to the seeded defaults until the auth epic
+ * lands and an auth-resolving context becomes available to MCP tools.
+ */
+import { z } from "zod";
+import type { FastMCP } from "fastmcp";
+import { parseEtag } from "../http/etag.js";
+import { PreconditionRequiredProblem } from "../http/problem.js";
+import { SEED_WORKSPACE_ID } from "../db/seed.js";
+import {
+  listAccountsService,
+  createAccountService,
+  updateAccountService,
+  getBalanceService,
+  getRegisterService,
+  getAccountService,
+} from "../routes/accounts.js";
+import {
+  CreateAccountRequest,
+  UpdateAccountRequest,
+} from "../schemas/v1/account.js";
+
+function toJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+export function registerAccountsMcpTools(mcp: FastMCP): void {
+  mcp.addTool({
+    name: "list_accounts",
+    description:
+      "List chart-of-accounts. Default returns a nested tree (root accounts with children[]). " +
+      "Pass flat=true for a flat list. Pass include_closed=true to include soft-closed accounts.",
+    parameters: z.object({
+      flat: z.boolean().optional(),
+      include_closed: z.boolean().optional(),
+    }),
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await listAccountsService({
+        workspaceId: SEED_WORKSPACE_ID,
+        flat: args.flat,
+        includeClosed: args.include_closed,
+      });
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "get_account",
+    description: "Fetch a single account by id.",
+    parameters: z.object({ id: z.string().uuid() }),
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await getAccountService(SEED_WORKSPACE_ID, args.id);
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "create_account",
+    description:
+      "Create a new account. If parent_id is supplied the parent's type must match; " +
+      "currency is inherited from parent when omitted.",
+    parameters: CreateAccountRequest,
+    execute: async (args) => {
+      const out = await createAccountService({
+        workspaceId: SEED_WORKSPACE_ID,
+        body: args,
+      });
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "update_account",
+    description:
+      "Apply a merge-patch to an account. Requires if_match (weak ETag, e.g. 'W/\"3\"').",
+    parameters: z.object({
+      id: z.string().uuid(),
+      patch: UpdateAccountRequest,
+      if_match: z.string(),
+    }),
+    execute: async (args) => {
+      const v = parseEtag(args.if_match);
+      if (v === null) {
+        throw new PreconditionRequiredProblem("If-Match");
+      }
+      const out = await updateAccountService({
+        workspaceId: SEED_WORKSPACE_ID,
+        id: args.id,
+        patch: args.patch,
+        ifMatchVersion: v,
+      });
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "close_account",
+    description:
+      "Soft-close an account by setting closed_at=NOW(). Convenience wrapper over update_account. " +
+      "Requires if_match.",
+    parameters: z.object({
+      id: z.string().uuid(),
+      if_match: z.string(),
+    }),
+    execute: async (args) => {
+      const v = parseEtag(args.if_match);
+      if (v === null) {
+        throw new PreconditionRequiredProblem("If-Match");
+      }
+      const out = await updateAccountService({
+        workspaceId: SEED_WORKSPACE_ID,
+        id: args.id,
+        patch: { closed_at: new Date().toISOString() },
+        ifMatchVersion: v,
+      });
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "get_account_balance",
+    description:
+      "Point-in-time balance. Defaults: as_of=today, currency=workspace base, include_children=false.",
+    parameters: z.object({
+      id: z.string().uuid(),
+      as_of: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+      currency: z.string().regex(/^[A-Z]{3}$/).optional(),
+      include_children: z.boolean().optional(),
+    }),
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await getBalanceService({
+        workspaceId: SEED_WORKSPACE_ID,
+        accountId: args.id,
+        asOf: args.as_of,
+        currency: args.currency,
+        includeChildren: args.include_children,
+      });
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "get_account_register",
+    description:
+      "Checkbook-style register with running balance, counter-postings, and linked documents. " +
+      "Keyset-paginated via an opaque cursor.",
+    parameters: z.object({
+      id: z.string().uuid(),
+      from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+      to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+      include_voided: z.boolean().optional(),
+      cursor: z.string().optional(),
+      limit: z.number().int().min(1).max(500).optional(),
+    }),
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await getRegisterService({
+        workspaceId: SEED_WORKSPACE_ID,
+        accountId: args.id,
+        from: args.from,
+        to: args.to,
+        includeVoided: args.include_voided,
+        cursor: args.cursor,
+        limit: args.limit,
+      });
+      return toJson(out);
+    },
+  });
+}

--- a/src/mcp/documents.ts
+++ b/src/mcp/documents.ts
@@ -1,0 +1,93 @@
+/**
+ * MCP tools for documents. Thin wrappers around the service layer in
+ * `src/routes/documents.service.ts` so that the HTTP and MCP surfaces
+ * stay provably equivalent (same dedup rules, same DB writes).
+ */
+import type { FastMCP } from "fastmcp";
+import { readFile } from "fs/promises";
+import * as path from "path";
+import { z } from "zod";
+import { SEED_WORKSPACE_ID } from "../db/seed.js";
+import {
+  uploadDocumentBytes,
+  linkDocumentToTransaction,
+  type DocumentKindValue,
+} from "../routes/documents.service.js";
+
+const KindSchema = z
+  .enum([
+    "receipt_image",
+    "receipt_email",
+    "receipt_pdf",
+    "statement_pdf",
+    "other",
+  ])
+  .optional();
+
+/**
+ * Detect MIME from the file extension. A full `file-type`
+ * magic-bytes probe would be nicer, but for the MCP call path we trust
+ * the operator-supplied path and only care about mapping .jpg→image/jpeg
+ * for the on-disk filename.
+ */
+const EXT_MIME: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".heic": "image/heic",
+  ".heif": "image/heif",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+  ".pdf": "application/pdf",
+  ".eml": "message/rfc822",
+  ".txt": "text/plain",
+  ".html": "text/html",
+};
+
+function mimeFromPath(p: string): string | null {
+  return EXT_MIME[path.extname(p).toLowerCase()] ?? null;
+}
+
+export function registerDocumentsMcpTools(mcp: FastMCP): void {
+  mcp.addTool({
+    name: "upload_document",
+    description:
+      "Upload a local file as a Document. sha256 de-duplicates: a second call " +
+      "on the same bytes returns the existing row.",
+    parameters: z.object({
+      file_path: z.string().describe("Absolute path to the file on disk"),
+      kind: KindSchema.describe(
+        "Document kind; defaults to `other` when omitted.",
+      ),
+    }),
+    async execute(args) {
+      const bytes = await readFile(args.file_path);
+      const mime = mimeFromPath(args.file_path);
+      const { doc } = await uploadDocumentBytes({
+        workspaceId: SEED_WORKSPACE_ID,
+        bytes,
+        mimeType: mime,
+        kind: (args.kind ?? "other") as DocumentKindValue,
+      });
+      return JSON.stringify(doc);
+    },
+  });
+
+  mcp.addTool({
+    name: "link_document",
+    description:
+      "Link a document to a transaction. Idempotent: re-linking is a no-op.",
+    parameters: z.object({
+      transaction_id: z.string().uuid(),
+      document_id: z.string().uuid(),
+    }),
+    async execute(args) {
+      await linkDocumentToTransaction({
+        workspaceId: SEED_WORKSPACE_ID,
+        documentId: args.document_id,
+        transactionId: args.transaction_id,
+      });
+      return JSON.stringify({ success: true });
+    },
+  });
+}

--- a/src/mcp/transactions.ts
+++ b/src/mcp/transactions.ts
@@ -1,0 +1,129 @@
+/**
+ * FastMCP tools for the `/v1/transactions` surface.
+ *
+ * Thin adapters that call the service functions in
+ * `src/routes/transactions.service.ts` directly — no HTTP self-call,
+ * no Express round-trip.
+ *
+ * Workspace + user IDs are pinned to the seeded defaults until auth
+ * lands. `if_match` parameters accept either a raw integer version or a
+ * standard weak-ETag string `W/"<n>"`.
+ */
+import { z } from "zod";
+import type { FastMCP } from "fastmcp";
+import { parseEtag } from "../http/etag.js";
+import { PreconditionRequiredProblem } from "../http/problem.js";
+import { SEED_USER_ID, SEED_WORKSPACE_ID } from "../db/seed.js";
+import {
+  createTransaction,
+  getTransaction,
+  listTransactions,
+  updateTransaction,
+  voidTransaction,
+} from "../routes/transactions.service.js";
+import {
+  CreateTransactionRequest,
+  UpdateTransactionRequest,
+  ListTransactionsQuery,
+} from "../schemas/v1/transaction.js";
+
+function toJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/** Accept either a numeric version or a weak-ETag string. */
+function resolveIfMatch(raw: string | number): number {
+  if (typeof raw === "number") return raw;
+  const n = parseEtag(raw);
+  if (n === null) {
+    // Allow a bare integer-as-string (e.g. "3").
+    const asNum = Number(raw);
+    if (Number.isInteger(asNum) && asNum >= 0) return asNum;
+    throw new PreconditionRequiredProblem("If-Match");
+  }
+  return n;
+}
+
+export function registerTransactionsMcpTools(mcp: FastMCP): void {
+  mcp.addTool({
+    name: "create_transaction",
+    description:
+      "Create a balanced double-entry transaction. Postings must sum to zero in base-currency minor units. " +
+      "Optional document_ids[] link receipts/statements. Optional idempotency_key for safe retries.",
+    parameters: CreateTransactionRequest,
+    execute: async (args) => {
+      const out = await createTransaction(SEED_WORKSPACE_ID, SEED_USER_ID, args);
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "list_transactions",
+    description:
+      "List transactions with filters: occurred_from/to, amount range, payee/narration search (q), " +
+      "account_id, status, has_document, trip_id. Keyset-paginated via opaque cursor.",
+    parameters: ListTransactionsQuery,
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await listTransactions(SEED_WORKSPACE_ID, args);
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "get_transaction",
+    description: "Fetch a single transaction with its postings and linked documents.",
+    parameters: z.object({ id: z.string().uuid() }),
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await getTransaction(SEED_WORKSPACE_ID, args.id);
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "update_transaction",
+    description:
+      "Apply a merge-patch to a transaction's head fields (payee, narration, occurred_on, occurred_at, " +
+      "trip_id, metadata). Requires if_match (weak ETag 'W/\"3\"' or bare integer).",
+    parameters: z.object({
+      id: z.string().uuid(),
+      patch: UpdateTransactionRequest,
+      if_match: z.string(),
+    }),
+    execute: async (args) => {
+      const version = resolveIfMatch(args.if_match);
+      const out = await updateTransaction(
+        SEED_WORKSPACE_ID,
+        SEED_USER_ID,
+        args.id,
+        version,
+        args.patch,
+      );
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "void_transaction",
+    description:
+      "Void a posted transaction by inserting a mirror with negated postings. The original flips to " +
+      "status='voided' and voided_by_id points to the mirror. Requires if_match.",
+    parameters: z.object({
+      id: z.string().uuid(),
+      reason: z.string().optional(),
+      if_match: z.string(),
+    }),
+    execute: async (args) => {
+      const version = resolveIfMatch(args.if_match);
+      const out = await voidTransaction(
+        SEED_WORKSPACE_ID,
+        SEED_USER_ID,
+        args.id,
+        version,
+        args.reason,
+      );
+      return toJson(out);
+    },
+  });
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -19,6 +19,11 @@ import {
   ValidationErrorResponse,
 } from "./schemas/common.js";
 import { HealthResponse } from "./schemas/health.js";
+import { ProblemDetails } from "./schemas/v1/common.js";
+import { registerAccountsOpenApi } from "./routes/accounts.js";
+import { registerTransactionsOpenApi } from "./routes/transactions.js";
+import { registerPostingsOpenApi } from "./routes/postings.js";
+import { registerDocumentsOpenApi } from "./routes/documents.js";
 
 export function buildRegistry(): OpenAPIRegistry {
   const registry = new OpenAPIRegistry();
@@ -26,6 +31,7 @@ export function buildRegistry(): OpenAPIRegistry {
   registry.register("ErrorResponse", ErrorResponse);
   registry.register("ValidationErrorResponse", ValidationErrorResponse);
   registry.register("HealthResponse", HealthResponse);
+  registry.register("ProblemDetails", ProblemDetails);
 
   // Bearer-token scheme reserved for the upcoming /v1 auth epic.
   registry.registerComponent("securitySchemes", "bearerAuth", {
@@ -45,6 +51,12 @@ export function buildRegistry(): OpenAPIRegistry {
       },
     },
   });
+
+  // v1 resource routers register their own paths + response schemas.
+  registerAccountsOpenApi(registry);
+  registerTransactionsOpenApi(registry);
+  registerPostingsOpenApi(registry);
+  registerDocumentsOpenApi(registry);
 
   return registry;
 }

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -1,0 +1,943 @@
+/**
+ * `/v1/accounts` — chart-of-accounts CRUD + derived views.
+ *
+ * Implements issue #36. See epic #28 for the endpoint surface + header
+ * contract. All mutations use ETag / If-Match for OCC; all errors
+ * serialize as `application/problem+json` via the central
+ * `problemHandler`.
+ *
+ * The service functions (`listAccountsService`, `createAccountService`,
+ * etc.) are exported so the MCP tool layer in `src/mcp/accounts.ts` can
+ * invoke them directly without doing HTTP self-calls.
+ */
+import { Router, type Request, type Response, type NextFunction } from "express";
+import { z } from "zod";
+import { sql, and, eq, isNull, asc } from "drizzle-orm";
+import {
+  OpenAPIRegistry,
+} from "@asteasolutions/zod-to-openapi";
+
+import { db } from "../db/client.js";
+import { accounts, postings, workspaces } from "../schema/index.js";
+import { newId } from "../http/uuid.js";
+import { parseOrThrow } from "../http/validate.js";
+import {
+  formatEtag,
+  setEtag,
+  requireIfMatch,
+  handleIfNoneMatch,
+} from "../http/etag.js";
+import {
+  clampLimit,
+  encodeCursor,
+  decodeCursor,
+  emitNextLink,
+} from "../http/pagination.js";
+import {
+  AccountInUseProblem,
+  HttpProblem,
+  NotFoundProblem,
+  ValidationProblem,
+} from "../http/problem.js";
+
+import {
+  Account,
+  AccountBalance,
+  AccountRegister,
+  CreateAccountRequest,
+  UpdateAccountRequest,
+  ListAccountsQuery,
+  BalanceQuery,
+  RegisterQuery,
+} from "../schemas/v1/account.js";
+import { IdParam, ProblemDetails } from "../schemas/v1/common.js";
+
+// ── Shared types ────────────────────────────────────────────────────────
+
+type AccountRow = typeof accounts.$inferSelect;
+
+export interface AccountDto {
+  id: string;
+  workspace_id: string;
+  parent_id: string | null;
+  code: string | null;
+  name: string;
+  type: "asset" | "liability" | "equity" | "income" | "expense";
+  subtype: string | null;
+  currency: string;
+  institution: string | null;
+  last4: string | null;
+  opening_balance_minor: number;
+  closed_at: string | null;
+  metadata: Record<string, unknown>;
+  version: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AccountTreeDto extends AccountDto {
+  children: AccountTreeDto[];
+}
+
+function toIso(d: Date | string | null): string | null {
+  if (d === null || d === undefined) return null;
+  if (d instanceof Date) return d.toISOString();
+  // Postgres may already have returned a string (timestamptz text form)
+  return new Date(d as string).toISOString();
+}
+
+function rowToDto(r: AccountRow): AccountDto {
+  return {
+    id: r.id,
+    workspace_id: r.workspaceId,
+    parent_id: r.parentId,
+    code: r.code,
+    name: r.name,
+    type: r.type,
+    subtype: r.subtype,
+    currency: r.currency,
+    institution: r.institution,
+    last4: r.last4,
+    opening_balance_minor: Number(r.openingBalanceMinor),
+    closed_at: r.closedAt ? toIso(r.closedAt) : null,
+    metadata: (r.metadata ?? {}) as Record<string, unknown>,
+    version: Number(r.version),
+    created_at: toIso(r.createdAt)!,
+    updated_at: toIso(r.updatedAt)!,
+  };
+}
+
+// Promise-aware route wrapper: forwards rejections to Express error
+// middleware. Express 5 forwards rejections too, but wrapping gives us
+// a crisp stack trace and protects against older middleware quirks.
+type AsyncHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<unknown>;
+
+function ah(fn: AsyncHandler) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    fn(req, res, next).catch(next);
+  };
+}
+
+// ── Service: common helpers ─────────────────────────────────────────────
+
+async function fetchAccount(
+  workspaceId: string,
+  id: string,
+): Promise<AccountRow | null> {
+  const rows = await db
+    .select()
+    .from(accounts)
+    .where(and(eq(accounts.workspaceId, workspaceId), eq(accounts.id, id)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+async function fetchWorkspaceBaseCurrency(workspaceId: string): Promise<string> {
+  const rows = await db
+    .select({ baseCurrency: workspaces.baseCurrency })
+    .from(workspaces)
+    .where(eq(workspaces.id, workspaceId))
+    .limit(1);
+  if (rows.length === 0) {
+    throw new NotFoundProblem("Workspace", workspaceId);
+  }
+  return rows[0]!.baseCurrency;
+}
+
+// ── Service: list ───────────────────────────────────────────────────────
+
+export interface ListAccountsArgs {
+  workspaceId: string;
+  flat?: boolean;
+  includeClosed?: boolean;
+}
+
+export async function listAccountsService(
+  args: ListAccountsArgs,
+): Promise<AccountDto[] | AccountTreeDto[]> {
+  const whereClause = args.includeClosed
+    ? eq(accounts.workspaceId, args.workspaceId)
+    : and(
+        eq(accounts.workspaceId, args.workspaceId),
+        isNull(accounts.closedAt),
+      );
+
+  const rows = await db
+    .select()
+    .from(accounts)
+    .where(whereClause)
+    .orderBy(asc(accounts.name));
+
+  const dtos = rows.map(rowToDto);
+
+  if (args.flat) return dtos;
+
+  // Build tree: group by parent_id, attach children[]; return roots.
+  const byId = new Map<string, AccountTreeDto>();
+  for (const d of dtos) byId.set(d.id, { ...d, children: [] });
+  const roots: AccountTreeDto[] = [];
+  for (const node of byId.values()) {
+    if (node.parent_id && byId.has(node.parent_id)) {
+      byId.get(node.parent_id)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  // Stable sort: by name within each level
+  const sortTree = (ns: AccountTreeDto[]): void => {
+    ns.sort((a, b) => a.name.localeCompare(b.name));
+    for (const n of ns) sortTree(n.children);
+  };
+  sortTree(roots);
+  return roots;
+}
+
+// ── Service: create ─────────────────────────────────────────────────────
+
+export interface CreateAccountArgs {
+  workspaceId: string;
+  body: z.infer<typeof CreateAccountRequest>;
+}
+
+export async function createAccountService(
+  args: CreateAccountArgs,
+): Promise<AccountDto> {
+  const { workspaceId, body } = args;
+
+  // Resolve currency: inherit from parent if omitted.
+  let currency = body.currency;
+  let parent: AccountRow | null = null;
+  if (body.parent_id) {
+    parent = await fetchAccount(workspaceId, body.parent_id);
+    if (!parent) {
+      throw new NotFoundProblem("Account", body.parent_id);
+    }
+    if (parent.type !== body.type) {
+      throw new ValidationProblem(
+        [
+          {
+            path: "type",
+            code: "parent_type_mismatch",
+            message: `Child type '${body.type}' does not match parent type '${parent.type}'`,
+          },
+        ],
+        "Parent account type must match child type",
+      );
+    }
+    if (!currency) currency = parent.currency;
+  }
+  if (!currency) {
+    // Fall back to workspace base currency if no parent and no override.
+    currency = await fetchWorkspaceBaseCurrency(workspaceId);
+  }
+
+  const id = newId();
+  const insertVals = {
+    id,
+    workspaceId,
+    parentId: body.parent_id ?? null,
+    code: body.code ?? null,
+    name: body.name,
+    type: body.type,
+    subtype: body.subtype ?? null,
+    currency,
+    institution: body.institution ?? null,
+    last4: body.last4 ?? null,
+    openingBalanceMinor:
+      body.opening_balance_minor !== undefined
+        ? BigInt(body.opening_balance_minor)
+        : 0n,
+    metadata: body.metadata ?? {},
+  };
+
+  await db.insert(accounts).values(insertVals);
+
+  const created = await fetchAccount(workspaceId, id);
+  if (!created) throw new NotFoundProblem("Account", id);
+  return rowToDto(created);
+}
+
+// ── Service: get ────────────────────────────────────────────────────────
+
+export async function getAccountService(
+  workspaceId: string,
+  id: string,
+): Promise<AccountDto> {
+  const row = await fetchAccount(workspaceId, id);
+  if (!row) throw new NotFoundProblem("Account", id);
+  return rowToDto(row);
+}
+
+// ── Service: update ─────────────────────────────────────────────────────
+
+export interface UpdateAccountArgs {
+  workspaceId: string;
+  id: string;
+  patch: z.infer<typeof UpdateAccountRequest>;
+  ifMatchVersion: number; // already parsed
+}
+
+export async function updateAccountService(
+  args: UpdateAccountArgs,
+): Promise<AccountDto> {
+  const { workspaceId, id, patch } = args;
+  const current = await fetchAccount(workspaceId, id);
+  if (!current) throw new NotFoundProblem("Account", id);
+
+  // Verify optimistic-concurrency version (caller already checked the
+  // header, but re-check with fresh row in case of race).
+  if (current.version !== args.ifMatchVersion) {
+    const { VersionMismatchProblem } = await import("../http/problem.js");
+    throw new VersionMismatchProblem(current.version, args.ifMatchVersion);
+  }
+
+  // Re-parent: validate type consistency.
+  if (patch.parent_id !== undefined && patch.parent_id !== null) {
+    const newParent = await fetchAccount(workspaceId, patch.parent_id);
+    if (!newParent) throw new NotFoundProblem("Account", patch.parent_id);
+    if (newParent.type !== current.type) {
+      throw new ValidationProblem(
+        [
+          {
+            path: "parent_id",
+            code: "parent_type_mismatch",
+            message: `New parent type '${newParent.type}' does not match child type '${current.type}'`,
+          },
+        ],
+        "Parent account type must match child type",
+      );
+    }
+    // Cycle check: can't re-parent under a descendant.
+    if (patch.parent_id === id) {
+      throw new ValidationProblem(
+        [{ path: "parent_id", code: "self_parent", message: "Cannot parent under self" }],
+      );
+    }
+  }
+
+  const updateVals: Partial<typeof accounts.$inferInsert> = {};
+  if (patch.code !== undefined) updateVals.code = patch.code;
+  if (patch.name !== undefined) updateVals.name = patch.name;
+  if (patch.subtype !== undefined) updateVals.subtype = patch.subtype;
+  if (patch.institution !== undefined) updateVals.institution = patch.institution;
+  if (patch.last4 !== undefined) updateVals.last4 = patch.last4;
+  if (patch.parent_id !== undefined) updateVals.parentId = patch.parent_id;
+  if (patch.closed_at !== undefined) {
+    updateVals.closedAt = patch.closed_at ? new Date(patch.closed_at) : null;
+  }
+  if (patch.metadata !== undefined) updateVals.metadata = patch.metadata;
+
+  if (Object.keys(updateVals).length === 0) {
+    // No-op patch: return current.
+    return rowToDto(current);
+  }
+
+  await db
+    .update(accounts)
+    .set(updateVals)
+    .where(and(eq(accounts.workspaceId, workspaceId), eq(accounts.id, id)));
+
+  const updated = await fetchAccount(workspaceId, id);
+  if (!updated) throw new NotFoundProblem("Account", id);
+  return rowToDto(updated);
+}
+
+// ── Service: delete ─────────────────────────────────────────────────────
+
+export async function deleteAccountService(
+  workspaceId: string,
+  id: string,
+  ifMatchVersion: number,
+): Promise<void> {
+  const current = await fetchAccount(workspaceId, id);
+  if (!current) throw new NotFoundProblem("Account", id);
+  if (current.version !== ifMatchVersion) {
+    const { VersionMismatchProblem } = await import("../http/problem.js");
+    throw new VersionMismatchProblem(current.version, ifMatchVersion);
+  }
+
+  // Postings referencing this account?
+  const cntRes = await db.execute(
+    sql`SELECT COUNT(*)::int AS n FROM postings
+        WHERE workspace_id = ${workspaceId}::uuid AND account_id = ${id}::uuid`,
+  );
+  const n = Number((cntRes.rows[0] as { n: number })?.n ?? 0);
+  if (n > 0) throw new AccountInUseProblem(id, n);
+
+  await db
+    .delete(accounts)
+    .where(and(eq(accounts.workspaceId, workspaceId), eq(accounts.id, id)));
+}
+
+// ── Service: balance ────────────────────────────────────────────────────
+
+export interface BalanceArgs {
+  workspaceId: string;
+  accountId: string;
+  asOf?: string; // YYYY-MM-DD
+  currency?: string;
+  includeChildren?: boolean;
+}
+
+export async function getBalanceService(
+  args: BalanceArgs,
+): Promise<z.infer<typeof AccountBalance>> {
+  const account = await fetchAccount(args.workspaceId, args.accountId);
+  if (!account) throw new NotFoundProblem("Account", args.accountId);
+
+  const asOf =
+    args.asOf ?? new Date().toISOString().slice(0, 10); // today in UTC
+  const currency =
+    args.currency ?? (await fetchWorkspaceBaseCurrency(args.workspaceId));
+
+  // Gather relevant account IDs: either just this one, or the subtree.
+  const result = await db.execute(
+    args.includeChildren
+      ? sql`
+          WITH RECURSIVE subtree(id) AS (
+            SELECT id FROM accounts
+              WHERE workspace_id = ${args.workspaceId}::uuid AND id = ${args.accountId}::uuid
+            UNION ALL
+            SELECT a.id FROM accounts a
+              JOIN subtree s ON a.parent_id = s.id
+              WHERE a.workspace_id = ${args.workspaceId}::uuid
+          )
+          SELECT COALESCE(SUM(p.amount_base_minor), 0)::bigint AS balance,
+                 COUNT(*)::int AS posting_count
+            FROM postings p
+            JOIN transactions t ON t.id = p.transaction_id
+           WHERE p.workspace_id = ${args.workspaceId}::uuid
+             AND p.account_id IN (SELECT id FROM subtree)
+             AND t.occurred_on <= ${asOf}::date
+             AND t.status = 'posted'
+        `
+      : sql`
+          SELECT COALESCE(SUM(p.amount_base_minor), 0)::bigint AS balance,
+                 COUNT(*)::int AS posting_count
+            FROM postings p
+            JOIN transactions t ON t.id = p.transaction_id
+           WHERE p.workspace_id = ${args.workspaceId}::uuid
+             AND p.account_id = ${args.accountId}::uuid
+             AND t.occurred_on <= ${asOf}::date
+             AND t.status = 'posted'
+        `,
+  );
+  const row = result.rows[0] as {
+    balance: string | number | bigint;
+    posting_count: number;
+  };
+  // node-postgres returns bigint-like values as strings by default.
+  const balanceMinor = Number(row?.balance ?? 0);
+  const postingCount = Number(row?.posting_count ?? 0);
+
+  return {
+    account_id: args.accountId,
+    as_of: asOf,
+    balance_minor: balanceMinor,
+    currency,
+    posting_count: postingCount,
+    includes_children: Boolean(args.includeChildren),
+  };
+}
+
+// ── Service: register ───────────────────────────────────────────────────
+
+export interface RegisterArgs {
+  workspaceId: string;
+  accountId: string;
+  from?: string;
+  to?: string;
+  includeVoided?: boolean;
+  cursor?: string;
+  limit?: number;
+}
+
+interface RegisterCursor {
+  occurred_on: string;
+  posting_id: string;
+}
+
+export async function getRegisterService(
+  args: RegisterArgs,
+): Promise<z.infer<typeof AccountRegister>> {
+  const account = await fetchAccount(args.workspaceId, args.accountId);
+  if (!account) throw new NotFoundProblem("Account", args.accountId);
+
+  const limit = clampLimit(args.limit);
+  const cursor = decodeCursor<RegisterCursor>(args.cursor);
+
+  // Step 1: fetch candidate postings window via keyset pagination. We
+  // query ONE extra row to know if there's a "next" page. The window
+  // function for running_balance_after_minor must be computed over the
+  // FULL filtered set, not the paginated slice — so we compute it in
+  // the CTE over all rows then filter + limit in the outer query.
+  //
+  // Running balance is SUM(amount_base_minor) ordered by
+  // (occurred_on ASC, posting_id ASC) — so older rows accumulate first.
+  // We *display* rows in descending order (most recent first) but the
+  // cumulative sum is still evaluated in chronological order.
+  const statusFilter = args.includeVoided
+    ? sql``
+    : sql`AND t.status = 'posted'`;
+  const fromFilter = args.from
+    ? sql`AND t.occurred_on >= ${args.from}::date`
+    : sql``;
+  const toFilter = args.to
+    ? sql`AND t.occurred_on <= ${args.to}::date`
+    : sql``;
+
+  // Keyset predicate: rows strictly "after" the cursor in descending
+  // (occurred_on DESC, posting_id DESC) ordering. That means:
+  //   (occurred_on < cursor.occurred_on)
+  //   OR (occurred_on = cursor.occurred_on AND posting_id < cursor.posting_id)
+  // Evaluated against the CTE's exposed columns, not the base tables.
+  const cursorFilter = cursor
+    ? sql`AND (occurred_on < ${cursor.occurred_on}::date
+             OR (occurred_on = ${cursor.occurred_on}::date AND posting_id < ${cursor.posting_id}::uuid))`
+    : sql``;
+
+  const rowsRes = await db.execute(sql`
+    WITH all_rows AS (
+      SELECT
+        p.id            AS posting_id,
+        p.transaction_id,
+        t.version       AS transaction_version,
+        t.occurred_on,
+        t.payee,
+        t.narration,
+        t.status,
+        p.amount_minor,
+        p.amount_base_minor,
+        p.currency,
+        SUM(p.amount_base_minor) OVER (
+          ORDER BY t.occurred_on ASC, p.id ASC
+          ROWS UNBOUNDED PRECEDING
+        ) AS running_balance_after_minor
+      FROM postings p
+      JOIN transactions t ON t.id = p.transaction_id
+      WHERE p.workspace_id = ${args.workspaceId}::uuid
+        AND p.account_id = ${args.accountId}::uuid
+        ${statusFilter}
+        ${fromFilter}
+        ${toFilter}
+    )
+    SELECT *
+      FROM all_rows
+     WHERE 1 = 1
+       ${cursorFilter}
+     ORDER BY occurred_on DESC, posting_id DESC
+     LIMIT ${limit + 1}
+  `);
+
+  const pageRows = rowsRes.rows as Array<{
+    posting_id: string;
+    transaction_id: string;
+    transaction_version: string | number;
+    occurred_on: Date | string;
+    payee: string | null;
+    narration: string | null;
+    status: string;
+    amount_minor: string | number | bigint;
+    amount_base_minor: string | number | bigint;
+    currency: string;
+    running_balance_after_minor: string | number | bigint;
+  }>;
+
+  const hasMore = pageRows.length > limit;
+  const pageSlice = hasMore ? pageRows.slice(0, limit) : pageRows;
+
+  // Collect transaction ids to look up counter_postings + documents in bulk.
+  const txIds = Array.from(new Set(pageSlice.map((r) => r.transaction_id)));
+  const postingIds = pageSlice.map((r) => r.posting_id);
+
+  type CounterRow = {
+    transaction_id: string;
+    posting_id: string;
+    account_id: string;
+    name: string;
+    amount_minor: string | number | bigint;
+  };
+  type DocRow = {
+    transaction_id: string;
+    id: string;
+    kind: string;
+  };
+
+  let counterRows: CounterRow[] = [];
+  let docRows: DocRow[] = [];
+  if (txIds.length > 0) {
+    const cRes = await db.execute(sql`
+      SELECT p.transaction_id,
+             p.id AS posting_id,
+             p.account_id,
+             a.name,
+             p.amount_minor
+        FROM postings p
+        JOIN accounts a ON a.id = p.account_id
+       WHERE p.workspace_id = ${args.workspaceId}::uuid
+         AND p.transaction_id IN (${sql.join(
+           txIds.map((id) => sql`${id}::uuid`),
+           sql`, `,
+         )})
+         AND p.id NOT IN (${sql.join(
+           postingIds.map((id) => sql`${id}::uuid`),
+           sql`, `,
+         )})
+    `);
+    counterRows = cRes.rows as CounterRow[];
+
+    const dRes = await db.execute(sql`
+      SELECT dl.transaction_id, d.id, d.kind
+        FROM document_links dl
+        JOIN documents d ON d.id = dl.document_id
+       WHERE d.workspace_id = ${args.workspaceId}::uuid
+         AND dl.transaction_id IN (${sql.join(
+           txIds.map((id) => sql`${id}::uuid`),
+           sql`, `,
+         )})
+       ORDER BY
+         CASE d.kind
+           WHEN 'receipt_image' THEN 1
+           WHEN 'receipt_pdf'   THEN 2
+           WHEN 'statement_pdf' THEN 3
+           WHEN 'receipt_email' THEN 4
+           ELSE 5
+         END
+    `);
+    docRows = dRes.rows as DocRow[];
+  }
+
+  const counterByTx = new Map<string, CounterRow[]>();
+  for (const c of counterRows) {
+    const arr = counterByTx.get(c.transaction_id) ?? [];
+    arr.push(c);
+    counterByTx.set(c.transaction_id, arr);
+  }
+  const docsByTx = new Map<string, DocRow[]>();
+  for (const d of docRows) {
+    const arr = docsByTx.get(d.transaction_id) ?? [];
+    arr.push(d);
+    docsByTx.set(d.transaction_id, arr);
+  }
+
+  const items = pageSlice.map((r) => {
+    const occurredOn =
+      r.occurred_on instanceof Date
+        ? r.occurred_on.toISOString().slice(0, 10)
+        : typeof r.occurred_on === "string"
+          ? r.occurred_on.slice(0, 10)
+          : String(r.occurred_on);
+    const cp = counterByTx.get(r.transaction_id) ?? [];
+    const docs = docsByTx.get(r.transaction_id) ?? [];
+    return {
+      posting_id: r.posting_id,
+      transaction_id: r.transaction_id,
+      transaction_version: Number(r.transaction_version),
+      occurred_on: occurredOn,
+      payee: r.payee,
+      narration: r.narration,
+      amount_minor: Number(r.amount_minor),
+      currency: r.currency,
+      running_balance_after_minor: Number(r.running_balance_after_minor),
+      counter_postings: cp.map((c) => ({
+        account_id: c.account_id,
+        name: c.name,
+        amount_minor: Number(c.amount_minor),
+      })),
+      documents: docs.map((d) => ({ id: d.id, kind: d.kind })),
+    };
+  });
+
+  let next_cursor: string | null = null;
+  if (hasMore && pageSlice.length > 0) {
+    const last = pageSlice[pageSlice.length - 1]!;
+    const lastDate =
+      last.occurred_on instanceof Date
+        ? last.occurred_on.toISOString().slice(0, 10)
+        : typeof last.occurred_on === "string"
+          ? last.occurred_on.slice(0, 10)
+          : String(last.occurred_on);
+    next_cursor = encodeCursor({
+      occurred_on: lastDate,
+      posting_id: last.posting_id,
+    });
+  }
+
+  return {
+    account_id: args.accountId,
+    items,
+    next_cursor,
+  };
+}
+
+// ── Router ──────────────────────────────────────────────────────────────
+
+export const accountsRouter: Router = Router();
+
+accountsRouter.get(
+  "/",
+  ah(async (req, res) => {
+    const q = parseOrThrow(ListAccountsQuery, req.query);
+    const out = await listAccountsService({
+      workspaceId: req.ctx.workspaceId,
+      flat: q.flat,
+      includeClosed: q.include_closed,
+    });
+    res.json(out);
+  }),
+);
+
+accountsRouter.post(
+  "/",
+  ah(async (req, res) => {
+    const body = parseOrThrow(CreateAccountRequest, req.body);
+    const account = await createAccountService({
+      workspaceId: req.ctx.workspaceId,
+      body,
+    });
+    setEtag(res, account.version);
+    res.setHeader("Location", `/v1/accounts/${account.id}`);
+    res.status(201).json(account);
+  }),
+);
+
+accountsRouter.get(
+  "/:id",
+  ah(async (req, res) => {
+    const { id } = parseOrThrow(IdParam, req.params);
+    const account = await getAccountService(req.ctx.workspaceId, id);
+    if (handleIfNoneMatch(req, res, account.version)) return;
+    setEtag(res, account.version);
+    res.json(account);
+  }),
+);
+
+accountsRouter.patch(
+  "/:id",
+  ah(async (req, res) => {
+    const { id } = parseOrThrow(IdParam, req.params);
+    // Validate body first so shape errors are 422 not 428.
+    const patch = parseOrThrow(UpdateAccountRequest, req.body ?? {});
+    // Peek at the header-checked version explicitly so the service can
+    // pass it through (avoids a second DB read in the helper).
+    const current = await fetchAccount(req.ctx.workspaceId, id);
+    if (!current) throw new NotFoundProblem("Account", id);
+    requireIfMatch(req, current.version);
+    const out = await updateAccountService({
+      workspaceId: req.ctx.workspaceId,
+      id,
+      patch,
+      ifMatchVersion: current.version,
+    });
+    setEtag(res, out.version);
+    res.json(out);
+  }),
+);
+
+accountsRouter.delete(
+  "/:id",
+  ah(async (req, res) => {
+    const { id } = parseOrThrow(IdParam, req.params);
+    const current = await fetchAccount(req.ctx.workspaceId, id);
+    if (!current) throw new NotFoundProblem("Account", id);
+    requireIfMatch(req, current.version);
+    await deleteAccountService(req.ctx.workspaceId, id, current.version);
+    res.status(204).end();
+  }),
+);
+
+accountsRouter.get(
+  "/:id/balance",
+  ah(async (req, res) => {
+    const { id } = parseOrThrow(IdParam, req.params);
+    const q = parseOrThrow(BalanceQuery, req.query);
+    const out = await getBalanceService({
+      workspaceId: req.ctx.workspaceId,
+      accountId: id,
+      asOf: q.as_of,
+      currency: q.currency,
+      includeChildren: q.include_children,
+    });
+    res.json(out);
+  }),
+);
+
+accountsRouter.get(
+  "/:id/register",
+  ah(async (req, res) => {
+    const { id } = parseOrThrow(IdParam, req.params);
+    const q = parseOrThrow(RegisterQuery, req.query);
+    const out = await getRegisterService({
+      workspaceId: req.ctx.workspaceId,
+      accountId: id,
+      from: q.from,
+      to: q.to,
+      includeVoided: q.include_voided,
+      cursor: q.cursor,
+      limit: q.limit,
+    });
+    emitNextLink(req, res, out.next_cursor);
+    res.json(out);
+  }),
+);
+
+// ── OpenAPI registration ────────────────────────────────────────────────
+
+const problemResponse = {
+  content: { "application/problem+json": { schema: ProblemDetails } },
+};
+
+export function registerAccountsOpenApi(registry: OpenAPIRegistry): void {
+  registry.register("Account", Account);
+  // AccountTreeNode contains z.lazy(...) which the OpenAPI generator
+  // cannot introspect. Document the tree shape in the list endpoint's
+  // description; clients build it by walking `parent_id`.
+  registry.register("CreateAccountRequest", CreateAccountRequest);
+  registry.register("UpdateAccountRequest", UpdateAccountRequest);
+  registry.register("AccountBalance", AccountBalance);
+  registry.register("AccountRegister", AccountRegister);
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/accounts",
+    summary: "List accounts (tree by default, flat with ?flat=true)",
+    tags: ["accounts"],
+    request: { query: ListAccountsQuery },
+    responses: {
+      200: {
+        description:
+          "Account list (flat: array of Account; default: array of AccountTreeNode roots)",
+        content: { "application/json": { schema: z.array(Account) } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/accounts",
+    summary: "Create a new account",
+    tags: ["accounts"],
+    request: {
+      body: {
+        content: { "application/json": { schema: CreateAccountRequest } },
+      },
+    },
+    responses: {
+      201: {
+        description: "Account created",
+        content: { "application/json": { schema: Account } },
+        headers: {
+          Location: { schema: { type: "string" } },
+          ETag: { schema: { type: "string" } },
+        },
+      },
+      404: { description: "Parent account not found", ...problemResponse },
+      422: { description: "Validation failed", ...problemResponse },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/accounts/{id}",
+    summary: "Get one account",
+    tags: ["accounts"],
+    request: { params: IdParam },
+    responses: {
+      200: {
+        description: "Account",
+        content: { "application/json": { schema: Account } },
+        headers: { ETag: { schema: { type: "string" } } },
+      },
+      304: { description: "Not Modified (If-None-Match matched)" },
+      404: { description: "Account not found", ...problemResponse },
+    },
+  });
+
+  registry.registerPath({
+    method: "patch",
+    path: "/v1/accounts/{id}",
+    summary: "Patch account (rename / re-parent / close)",
+    tags: ["accounts"],
+    request: {
+      params: IdParam,
+      body: {
+        content: {
+          "application/merge-patch+json": { schema: UpdateAccountRequest },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Account updated",
+        content: { "application/json": { schema: Account } },
+        headers: { ETag: { schema: { type: "string" } } },
+      },
+      404: { description: "Account not found", ...problemResponse },
+      412: { description: "Version mismatch (If-Match)", ...problemResponse },
+      422: { description: "Validation failed", ...problemResponse },
+      428: {
+        description: "Precondition required (If-Match missing)",
+        ...problemResponse,
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/accounts/{id}",
+    summary: "Hard-delete an unused account",
+    tags: ["accounts"],
+    request: { params: IdParam },
+    responses: {
+      204: { description: "Deleted" },
+      404: { description: "Account not found", ...problemResponse },
+      409: {
+        description: "Account has postings; soft-close instead",
+        ...problemResponse,
+      },
+      412: { description: "Version mismatch", ...problemResponse },
+      428: {
+        description: "Precondition required (If-Match missing)",
+        ...problemResponse,
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/accounts/{id}/balance",
+    summary: "Account balance as of a date",
+    tags: ["accounts"],
+    request: { params: IdParam, query: BalanceQuery },
+    responses: {
+      200: {
+        description: "Balance summary",
+        content: { "application/json": { schema: AccountBalance } },
+      },
+      404: { description: "Account not found", ...problemResponse },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/accounts/{id}/register",
+    summary: "Register (checkbook view) with running balance",
+    tags: ["accounts"],
+    request: { params: IdParam, query: RegisterQuery },
+    responses: {
+      200: {
+        description: "Paginated register",
+        content: { "application/json": { schema: AccountRegister } },
+        headers: { Link: { schema: { type: "string" } } },
+      },
+      404: { description: "Account not found", ...problemResponse },
+    },
+  });
+}
+
+// Silence unused-import warnings in declaration-only places.
+void HttpProblem;

--- a/src/routes/documents.service.ts
+++ b/src/routes/documents.service.ts
@@ -1,0 +1,263 @@
+/**
+ * Document service — internal helpers shared by the HTTP handlers and
+ * the FastMCP tools.
+ *
+ * The two clients (Express + MCP) speak different I/O idioms but share
+ * the same business rules: sha256-based content dedup per workspace,
+ * disk write under `UPLOAD_DIR`, insert into `documents`, etc.
+ *
+ * Keeping this logic in one module makes the MCP `upload_document` tool
+ * and the HTTP `POST /v1/documents` provably equivalent.
+ */
+import { createHash } from "crypto";
+import { mkdir, writeFile } from "fs/promises";
+import * as path from "path";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { documents, documentLinks } from "../schema/documents.js";
+import { transactions } from "../schema/transactions.js";
+import { newId } from "../http/uuid.js";
+import {
+  DocumentHasLinksProblem,
+  NotFoundProblem,
+} from "../http/problem.js";
+
+export type DocumentKindValue =
+  | "receipt_image"
+  | "receipt_email"
+  | "receipt_pdf"
+  | "statement_pdf"
+  | "other";
+
+export interface DocumentRow {
+  id: string;
+  workspace_id: string;
+  kind: DocumentKindValue;
+  file_path: string | null;
+  mime_type: string | null;
+  sha256: string;
+  ocr_text: string | null;
+  extraction_meta: Record<string, unknown> | null;
+  source_ingest_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UploadResult {
+  doc: DocumentRow;
+  created: boolean;
+}
+
+export function getUploadDir(): string {
+  return process.env.UPLOAD_DIR ?? "/data/uploads";
+}
+
+/**
+ * Minimal mime → extension map. A dependency on the whole `mime-types`
+ * package would be overkill for the ~6 content types we actually
+ * ingest; the fallback just leaves the on-disk file extension-less,
+ * which is fine since the authoritative type lives in the DB column.
+ */
+const MIME_EXT: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/png": "png",
+  "image/heic": "heic",
+  "image/heif": "heif",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "application/pdf": "pdf",
+  "message/rfc822": "eml",
+  "text/plain": "txt",
+  "text/html": "html",
+};
+
+export function extForMime(mime: string | null | undefined): string | null {
+  if (!mime) return null;
+  const k = mime.toLowerCase().split(";")[0]!.trim();
+  return MIME_EXT[k] ?? null;
+}
+
+export function sha256Hex(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+/** DB row → API shape (snake_case + ISO timestamps). */
+function rowToApi(r: {
+  id: string;
+  workspaceId: string;
+  kind: string;
+  filePath: string | null;
+  mimeType: string | null;
+  sha256: string;
+  ocrText: string | null;
+  extractionMeta: unknown;
+  sourceIngestId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): DocumentRow {
+  return {
+    id: r.id,
+    workspace_id: r.workspaceId,
+    kind: r.kind as DocumentKindValue,
+    file_path: r.filePath,
+    mime_type: r.mimeType,
+    sha256: r.sha256,
+    ocr_text: r.ocrText,
+    extraction_meta:
+      r.extractionMeta == null
+        ? null
+        : (r.extractionMeta as Record<string, unknown>),
+    source_ingest_id: r.sourceIngestId,
+    created_at: r.createdAt.toISOString(),
+    updated_at: r.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Idempotent upload: if a document with the same sha256 already exists
+ * in the workspace, return it verbatim — no new disk write, no new DB
+ * row. This is the documented contract (sha256 is the dedup key per
+ * issue #28 header table).
+ */
+export async function uploadDocumentBytes(params: {
+  workspaceId: string;
+  bytes: Buffer;
+  mimeType: string | null;
+  kind: DocumentKindValue;
+}): Promise<UploadResult> {
+  const { workspaceId, bytes, mimeType, kind } = params;
+  const sha = sha256Hex(bytes);
+
+  // Dedup-lookup first. Unique index is (workspace_id, sha256).
+  const existing = await db
+    .select()
+    .from(documents)
+    .where(and(eq(documents.workspaceId, workspaceId), eq(documents.sha256, sha)));
+  if (existing.length > 0) {
+    return { doc: rowToApi(existing[0]!), created: false };
+  }
+
+  // Persist bytes under UPLOAD_DIR/<sha>.<ext>.
+  const dir = getUploadDir();
+  await mkdir(dir, { recursive: true });
+  const ext = extForMime(mimeType);
+  const filename = ext ? `${sha}.${ext}` : sha;
+  const fullPath = path.join(dir, filename);
+  await writeFile(fullPath, bytes);
+
+  const id = newId();
+  const inserted = await db
+    .insert(documents)
+    .values({
+      id,
+      workspaceId,
+      kind,
+      filePath: fullPath,
+      mimeType: mimeType ?? null,
+      sha256: sha,
+      ocrText: null,
+      extractionMeta: null,
+      sourceIngestId: null,
+    })
+    .returning();
+
+  return { doc: rowToApi(inserted[0]!), created: true };
+}
+
+export async function getDocumentById(
+  workspaceId: string,
+  id: string,
+): Promise<DocumentRow | null> {
+  const rows = await db
+    .select()
+    .from(documents)
+    .where(and(eq(documents.id, id), eq(documents.workspaceId, workspaceId)));
+  return rows.length > 0 ? rowToApi(rows[0]!) : null;
+}
+
+export async function linkDocumentToTransaction(params: {
+  workspaceId: string;
+  documentId: string;
+  transactionId: string;
+}): Promise<void> {
+  const { workspaceId, documentId, transactionId } = params;
+
+  // Both must belong to the caller's workspace. Validate explicitly
+  // rather than rely on FK violations — clearer error payload.
+  const doc = await db
+    .select({ id: documents.id })
+    .from(documents)
+    .where(and(eq(documents.id, documentId), eq(documents.workspaceId, workspaceId)));
+  if (doc.length === 0) throw new NotFoundProblem("Document", documentId);
+
+  const tx = await db
+    .select({ id: transactions.id })
+    .from(transactions)
+    .where(and(eq(transactions.id, transactionId), eq(transactions.workspaceId, workspaceId)));
+  if (tx.length === 0) throw new NotFoundProblem("Transaction", transactionId);
+
+  // Composite PK is (document_id, transaction_id) — re-link is a no-op.
+  await db
+    .insert(documentLinks)
+    .values({ documentId, transactionId })
+    .onConflictDoNothing();
+}
+
+export async function unlinkDocumentFromTransaction(params: {
+  workspaceId: string;
+  documentId: string;
+  transactionId: string;
+}): Promise<boolean> {
+  const { workspaceId, documentId, transactionId } = params;
+
+  // Scope via a join to documents to enforce workspace.
+  const existing = await db
+    .select({ d: documentLinks.documentId })
+    .from(documentLinks)
+    .innerJoin(documents, eq(documents.id, documentLinks.documentId))
+    .where(
+      and(
+        eq(documentLinks.documentId, documentId),
+        eq(documentLinks.transactionId, transactionId),
+        eq(documents.workspaceId, workspaceId),
+      ),
+    );
+  if (existing.length === 0) return false;
+
+  await db
+    .delete(documentLinks)
+    .where(
+      and(
+        eq(documentLinks.documentId, documentId),
+        eq(documentLinks.transactionId, transactionId),
+      ),
+    );
+  return true;
+}
+
+export async function deleteDocument(params: {
+  workspaceId: string;
+  documentId: string;
+}): Promise<boolean> {
+  const { workspaceId, documentId } = params;
+
+  const doc = await db
+    .select({ id: documents.id })
+    .from(documents)
+    .where(and(eq(documents.id, documentId), eq(documents.workspaceId, workspaceId)));
+  if (doc.length === 0) return false;
+
+  // Refuse to delete while links exist — caller must unlink first.
+  const linkCountRes = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(documentLinks)
+    .where(eq(documentLinks.documentId, documentId));
+  const linkCount = linkCountRes[0]?.n ?? 0;
+  if (linkCount > 0) {
+    throw new DocumentHasLinksProblem(documentId, linkCount);
+  }
+
+  await db.delete(documents).where(eq(documents.id, documentId));
+  return true;
+}

--- a/src/routes/documents.ts
+++ b/src/routes/documents.ts
@@ -1,0 +1,339 @@
+/**
+ * `/v1/documents` — multipart upload + content serve + link management.
+ *
+ * Endpoints:
+ *   POST   /v1/documents                 — multipart upload (sha256 dedup)
+ *   GET    /v1/documents/:id             — metadata + ETag/If-None-Match
+ *   GET    /v1/documents/:id/content     — binary stream
+ *   POST   /v1/documents/:id/links       — link to a transaction
+ *   DELETE /v1/documents/:id/links/:txn  — unlink
+ *   DELETE /v1/documents/:id             — hard delete (409 if linked)
+ *
+ * Idempotency here is intentionally *not* driven by the
+ * `Idempotency-Key` header — sha256 of the file bytes is the natural
+ * idempotency token. Re-uploading identical bytes returns the existing
+ * row with 200 OK, not 201.
+ */
+import { Router, type Request, type Response, type NextFunction } from "express";
+import multer from "multer";
+import * as path from "path";
+import { createReadStream } from "fs";
+import { stat } from "fs/promises";
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import {
+  Document,
+  DocumentKind,
+  CreateDocumentLinkRequest,
+  UploadDocumentForm,
+} from "../schemas/v1/document.js";
+import { ProblemDetails, Uuid } from "../schemas/v1/common.js";
+import { NotFoundProblem } from "../http/problem.js";
+import { setEtag, handleIfNoneMatch } from "../http/etag.js";
+import { parseOrThrow } from "../http/validate.js";
+import {
+  getDocumentById,
+  uploadDocumentBytes,
+  linkDocumentToTransaction,
+  unlinkDocumentFromTransaction,
+  deleteDocument,
+  extForMime,
+  type DocumentKindValue,
+} from "./documents.service.js";
+
+export const documentsRouter: Router = Router();
+
+// Multer with memory storage so we can sha256 the bytes *before*
+// committing them to disk — critical for the dedup contract.
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB
+});
+
+/**
+ * Documents don't carry a `version` column in the schema, so ETag is
+ * derived from a synthetic value: `1` for "freshly-materialized
+ * immutable metadata". This matches the pattern in issue #28 — the
+ * caller just wants a stable token for If-None-Match caching.
+ */
+const DOC_VERSION = 1;
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function asyncHandler<T>(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<T>,
+) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    fn(req, res, next).catch(next);
+  };
+}
+
+const IdOnlyParams = z.object({ id: Uuid });
+const LinkParams = z.object({ id: Uuid, txn_id: Uuid });
+
+// ── POST /v1/documents ─────────────────────────────────────────────────
+
+documentsRouter.post(
+  "/",
+  upload.single("file"),
+  asyncHandler(async (req, res) => {
+    const file = req.file;
+    if (!file) {
+      // Explicit 422 to match the rest of the surface — missing field
+      // is a validation issue, not a generic 400.
+      throw new (await import("../http/problem.js")).ValidationProblem([
+        { path: "file", code: "required", message: "multipart field `file` is required" },
+      ]);
+    }
+
+    const rawKind = (req.body?.kind as string | undefined) ?? "other";
+    const kind = parseOrThrow(DocumentKind, rawKind) as DocumentKindValue;
+
+    const { doc, created } = await uploadDocumentBytes({
+      workspaceId: req.ctx.workspaceId,
+      bytes: file.buffer,
+      mimeType: file.mimetype ?? null,
+      kind,
+    });
+
+    setEtag(res, DOC_VERSION);
+    if (created) {
+      res.setHeader("Location", `/v1/documents/${doc.id}`);
+      res.status(201).json(doc);
+    } else {
+      // Dedup hit — same bytes, same row, 200 OK.
+      res.status(200).json(doc);
+    }
+  }),
+);
+
+// ── GET /v1/documents/:id ──────────────────────────────────────────────
+
+documentsRouter.get(
+  "/:id",
+  asyncHandler(async (req, res) => {
+    const { id } = parseOrThrow(IdOnlyParams, req.params);
+    const doc = await getDocumentById(req.ctx.workspaceId, id);
+    if (!doc) throw new NotFoundProblem("Document", id);
+
+    if (handleIfNoneMatch(req, res, DOC_VERSION)) return;
+    setEtag(res, DOC_VERSION);
+    res.json(doc);
+  }),
+);
+
+// ── GET /v1/documents/:id/content ──────────────────────────────────────
+
+documentsRouter.get(
+  "/:id/content",
+  asyncHandler(async (req, res) => {
+    const { id } = parseOrThrow(IdOnlyParams, req.params);
+    const doc = await getDocumentById(req.ctx.workspaceId, id);
+    if (!doc) throw new NotFoundProblem("Document", id);
+    if (!doc.file_path) throw new NotFoundProblem("Document content", id);
+
+    try {
+      await stat(doc.file_path);
+    } catch {
+      throw new NotFoundProblem("Document content", id);
+    }
+
+    const ext = extForMime(doc.mime_type) ?? path.extname(doc.file_path).replace(/^\./, "");
+    const filename = ext ? `${doc.id}.${ext}` : doc.id;
+    res.setHeader(
+      "Content-Type",
+      doc.mime_type ?? "application/octet-stream",
+    );
+    res.setHeader(
+      "Content-Disposition",
+      `inline; filename="${filename}"`,
+    );
+    setEtag(res, DOC_VERSION);
+    createReadStream(doc.file_path).pipe(res);
+  }),
+);
+
+// ── POST /v1/documents/:id/links ───────────────────────────────────────
+
+documentsRouter.post(
+  "/:id/links",
+  asyncHandler(async (req, res) => {
+    const { id } = parseOrThrow(IdOnlyParams, req.params);
+    const body = parseOrThrow(CreateDocumentLinkRequest, req.body ?? {});
+
+    await linkDocumentToTransaction({
+      workspaceId: req.ctx.workspaceId,
+      documentId: id,
+      transactionId: body.transaction_id,
+    });
+
+    res.status(204).end();
+  }),
+);
+
+// ── DELETE /v1/documents/:id/links/:txn_id ─────────────────────────────
+
+documentsRouter.delete(
+  "/:id/links/:txn_id",
+  asyncHandler(async (req, res) => {
+    const { id, txn_id } = parseOrThrow(LinkParams, req.params);
+    const removed = await unlinkDocumentFromTransaction({
+      workspaceId: req.ctx.workspaceId,
+      documentId: id,
+      transactionId: txn_id,
+    });
+    if (!removed) {
+      throw new NotFoundProblem("DocumentLink", `${id}→${txn_id}`);
+    }
+    res.status(204).end();
+  }),
+);
+
+// ── DELETE /v1/documents/:id ───────────────────────────────────────────
+
+documentsRouter.delete(
+  "/:id",
+  asyncHandler(async (req, res) => {
+    const { id } = parseOrThrow(IdOnlyParams, req.params);
+    const removed = await deleteDocument({
+      workspaceId: req.ctx.workspaceId,
+      documentId: id,
+    });
+    if (!removed) throw new NotFoundProblem("Document", id);
+    res.status(204).end();
+  }),
+);
+
+// ── OpenAPI registration ───────────────────────────────────────────────
+
+export function registerDocumentsOpenApi(registry: OpenAPIRegistry): void {
+  // Ensure component schemas are registered (idempotent — registry
+  // deduplicates by z.ZodType identity, which is stable across calls).
+  registry.register("Document", Document);
+  registry.register("DocumentKind", DocumentKind);
+  registry.register("UploadDocumentForm", UploadDocumentForm);
+  registry.register("CreateDocumentLinkRequest", CreateDocumentLinkRequest);
+
+  const problemContent = {
+    "application/problem+json": { schema: ProblemDetails },
+  };
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/documents",
+    summary: "Upload a document (multipart, sha256 content-dedup)",
+    tags: ["documents"],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "multipart/form-data": { schema: UploadDocumentForm },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description:
+          "Duplicate upload detected — returns the existing document row",
+        content: { "application/json": { schema: Document } },
+      },
+      201: {
+        description: "Document created",
+        headers: {
+          Location: { schema: { type: "string" } },
+          ETag: { schema: { type: "string" } },
+        },
+        content: { "application/json": { schema: Document } },
+      },
+      422: { description: "Validation failed", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/documents/{id}",
+    summary: "Get document metadata",
+    tags: ["documents"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: {
+        description: "Document",
+        headers: { ETag: { schema: { type: "string" } } },
+        content: { "application/json": { schema: Document } },
+      },
+      304: { description: "Not modified (If-None-Match matched)" },
+      404: { description: "Not found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/documents/{id}/content",
+    summary: "Stream document binary content",
+    tags: ["documents"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: {
+        description: "Raw file bytes",
+        content: {
+          "application/octet-stream": {
+            schema: { type: "string", format: "binary" },
+          },
+        },
+      },
+      404: { description: "Not found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/documents/{id}/links",
+    summary: "Link a document to a transaction (idempotent)",
+    tags: ["documents"],
+    request: {
+      params: z.object({ id: Uuid }),
+      body: {
+        required: true,
+        content: { "application/json": { schema: CreateDocumentLinkRequest } },
+      },
+    },
+    responses: {
+      204: { description: "Linked (or already linked — idempotent)" },
+      404: {
+        description: "Document or transaction not found",
+        content: problemContent,
+      },
+      422: { description: "Validation failed", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/documents/{id}/links/{txn_id}",
+    summary: "Unlink a document from a transaction",
+    tags: ["documents"],
+    request: {
+      params: z.object({ id: Uuid, txn_id: Uuid }),
+    },
+    responses: {
+      204: { description: "Unlinked" },
+      404: { description: "Link not found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/documents/{id}",
+    summary: "Hard-delete a document (only if it has no links)",
+    tags: ["documents"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      204: { description: "Deleted" },
+      404: { description: "Not found", content: problemContent },
+      409: {
+        description: "Document has links — unlink first",
+        content: problemContent,
+      },
+    },
+  });
+}

--- a/src/routes/postings.ts
+++ b/src/routes/postings.ts
@@ -1,0 +1,83 @@
+/**
+ * Read-only `/v1/postings` endpoints.
+ *
+ * Postings are created/mutated through the nested routes on
+ * `/v1/transactions/:id/postings*`; this router exists so clients can
+ * query postings flat (by account, date range, or transaction id)
+ * without round-tripping through their parent transactions.
+ */
+import { Router, type Request, type Response, type NextFunction } from "express";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+import { parseOrThrow } from "../http/validate.js";
+import { emitNextLink } from "../http/pagination.js";
+import {
+  ListPostingsQuery,
+  Posting as PostingSchema,
+} from "../schemas/v1/transaction.js";
+import { listPostings, getPosting } from "./transactions.service.js";
+import { ProblemDetails, paginated, Uuid } from "../schemas/v1/common.js";
+
+export const postingsRouter: Router = Router();
+
+postingsRouter.get(
+  "/",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const query = parseOrThrow(ListPostingsQuery, req.query);
+      const result = await listPostings(req.ctx.workspaceId, query);
+      emitNextLink(req, res, result.next_cursor);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+postingsRouter.get(
+  "/:id",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const params = parseOrThrow(z.object({ id: Uuid }), req.params);
+      const result = await getPosting(req.ctx.workspaceId, params.id);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export function registerPostingsOpenApi(registry: OpenAPIRegistry): void {
+  const problemContent = {
+    "application/problem+json": { schema: ProblemDetails },
+  };
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/postings",
+    summary: "List postings",
+    tags: ["postings"],
+    request: { query: ListPostingsQuery },
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: paginated(PostingSchema) } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/postings/{id}",
+    summary: "Get a posting",
+    tags: ["postings"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: PostingSchema } },
+      },
+      404: { description: "Not Found", content: problemContent },
+    },
+  });
+}

--- a/src/routes/transactions.service.ts
+++ b/src/routes/transactions.service.ts
@@ -1,0 +1,1067 @@
+/**
+ * Transactions service — the business logic shared between the HTTP
+ * router (`/v1/transactions*`) and the FastMCP tools.
+ *
+ * Everything that mutates the ledger runs inside a single
+ * `db.transaction(...)` block so that the deferred `postings_balance_ck`
+ * constraint trigger fires at commit on exactly the set of rows written
+ * together (parent transaction + postings + document_links).
+ *
+ * PG `check_violation` (ERRCODE 23514) raised by those triggers is
+ * translated to `PostingsImbalanceProblem` (422) so clients see a
+ * structured 7807 error rather than an opaque 500.
+ */
+import { sql, eq, and, inArray } from "drizzle-orm";
+import { db } from "../db/client.js";
+import {
+  transactions,
+  postings,
+  accounts,
+  documents,
+  documentLinks,
+  transactionEvents,
+  workspaces,
+} from "../schema/index.js";
+import { newId } from "../http/uuid.js";
+import {
+  HttpProblem,
+  NotFoundProblem,
+  PostingsImbalanceProblem,
+  ValidationProblem,
+  MustVoidInsteadProblem,
+} from "../http/problem.js";
+import type {
+  CreateTransactionRequest,
+  UpdateTransactionRequest,
+  NewPosting,
+  UpdatePostingRequest,
+  ListTransactionsQuery,
+  ListPostingsQuery,
+} from "../schemas/v1/transaction.js";
+import type { z } from "zod";
+import {
+  clampLimit,
+  encodeCursor,
+  decodeCursor,
+  DEFAULT_PAGE_LIMIT,
+} from "../http/pagination.js";
+
+type CreateReq = z.infer<typeof CreateTransactionRequest>;
+type UpdateReq = z.infer<typeof UpdateTransactionRequest>;
+type NewPostingT = z.infer<typeof NewPosting>;
+type UpdatePostingReq = z.infer<typeof UpdatePostingRequest>;
+type ListTxQuery = z.infer<typeof ListTransactionsQuery>;
+type ListPostingQuery = z.infer<typeof ListPostingsQuery>;
+
+// ── Shared output shapes ───────────────────────────────────────────────
+
+export interface PostingRow {
+  id: string;
+  transaction_id: string;
+  account_id: string;
+  amount_minor: number;
+  currency: string;
+  fx_rate: string | null;
+  amount_base_minor: number | null;
+  memo: string | null;
+  created_at: string;
+}
+
+export interface TransactionRow {
+  id: string;
+  workspace_id: string;
+  occurred_on: string;
+  occurred_at: string | null;
+  payee: string | null;
+  narration: string | null;
+  status: "draft" | "posted" | "voided" | "reconciled" | "error";
+  voided_by_id: string | null;
+  source_ingest_id: string | null;
+  trip_id: string | null;
+  metadata: Record<string, unknown>;
+  version: number;
+  created_at: string;
+  updated_at: string;
+  postings: PostingRow[];
+  documents: Array<{ id: string; kind: string }>;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function pgCode(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  // Drizzle wraps driver errors; check err + err.cause chain.
+  const root = err as { code?: string; cause?: unknown };
+  if (typeof root.code === "string") return root.code;
+  let cur: any = root.cause;
+  while (cur) {
+    if (typeof cur.code === "string") return cur.code;
+    cur = cur.cause;
+  }
+  return undefined;
+}
+
+function pgMessage(err: unknown): string {
+  const parts: string[] = [];
+  let cur: any = err;
+  while (cur) {
+    if (typeof cur.message === "string") parts.push(cur.message);
+    cur = cur.cause;
+  }
+  return parts.join(" | ");
+}
+
+/**
+ * Wrap a mutation so PG `check_violation` → PostingsImbalanceProblem.
+ * Other errors bubble untouched.
+ */
+export async function mapBalanceErrors<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof HttpProblem) throw err;
+    if (pgCode(err) === "23514") {
+      const detail = pgMessage(err);
+      throw new PostingsImbalanceProblem(detail, [
+        { path: "postings", code: "imbalance", message: detail },
+      ]);
+    }
+    throw err;
+  }
+}
+
+function toIsoString(v: unknown): string {
+  if (v instanceof Date) return v.toISOString();
+  if (typeof v === "string") {
+    // node-postgres may return 'YYYY-MM-DD' for date columns.
+    return v;
+  }
+  return String(v);
+}
+
+function toIsoDate(v: unknown): string {
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  if (typeof v === "string") return v.length >= 10 ? v.slice(0, 10) : v;
+  return String(v);
+}
+
+function bigintToNumber(v: unknown): number {
+  if (typeof v === "bigint") return Number(v);
+  if (typeof v === "number") return v;
+  if (typeof v === "string") return Number(v);
+  return 0;
+}
+
+function bigintToNumberNullable(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  return bigintToNumber(v);
+}
+
+function mapPostingRow(row: any): PostingRow {
+  return {
+    id: row.id,
+    transaction_id: row.transactionId ?? row.transaction_id,
+    account_id: row.accountId ?? row.account_id,
+    amount_minor: bigintToNumber(row.amountMinor ?? row.amount_minor),
+    currency: row.currency,
+    fx_rate: row.fxRate ?? row.fx_rate ?? null,
+    amount_base_minor: bigintToNumberNullable(
+      row.amountBaseMinor ?? row.amount_base_minor,
+    ),
+    memo: row.memo ?? null,
+    created_at: toIsoString(row.createdAt ?? row.created_at),
+  };
+}
+
+function mapTransactionRow(
+  row: any,
+  posts: any[],
+  docs: Array<{ id: string; kind: string }>,
+): TransactionRow {
+  return {
+    id: row.id,
+    workspace_id: row.workspaceId ?? row.workspace_id,
+    occurred_on: toIsoDate(row.occurredOn ?? row.occurred_on),
+    occurred_at: row.occurredAt ?? row.occurred_at
+      ? toIsoString(row.occurredAt ?? row.occurred_at)
+      : null,
+    payee: row.payee ?? null,
+    narration: row.narration ?? null,
+    status: row.status,
+    voided_by_id: row.voidedById ?? row.voided_by_id ?? null,
+    source_ingest_id: row.sourceIngestId ?? row.source_ingest_id ?? null,
+    trip_id: row.tripId ?? row.trip_id ?? null,
+    metadata: row.metadata ?? {},
+    version: Number(row.version),
+    created_at: toIsoString(row.createdAt ?? row.created_at),
+    updated_at: toIsoString(row.updatedAt ?? row.updated_at),
+    postings: posts.map(mapPostingRow),
+    documents: docs,
+  };
+}
+
+// ── Load utilities ─────────────────────────────────────────────────────
+
+async function loadTransactionFull(
+  runner: typeof db,
+  workspaceId: string,
+  id: string,
+): Promise<TransactionRow | null> {
+  const rows = await runner
+    .select()
+    .from(transactions)
+    .where(
+      and(eq(transactions.id, id), eq(transactions.workspaceId, workspaceId)),
+    );
+  if (rows.length === 0) return null;
+  const t = rows[0]!;
+  const posts = await runner
+    .select()
+    .from(postings)
+    .where(eq(postings.transactionId, id))
+    .orderBy(postings.createdAt);
+  const docLinks = await runner
+    .select({ id: documents.id, kind: documents.kind })
+    .from(documentLinks)
+    .innerJoin(documents, eq(documents.id, documentLinks.documentId))
+    .where(eq(documentLinks.transactionId, id));
+  return mapTransactionRow(t, posts, docLinks);
+}
+
+async function loadWorkspaceBaseCurrency(
+  runner: typeof db,
+  workspaceId: string,
+): Promise<string> {
+  const rows = await runner
+    .select({ baseCurrency: workspaces.baseCurrency })
+    .from(workspaces)
+    .where(eq(workspaces.id, workspaceId));
+  if (rows.length === 0) throw new NotFoundProblem("Workspace", workspaceId);
+  return rows[0]!.baseCurrency;
+}
+
+// ── Create ─────────────────────────────────────────────────────────────
+
+export async function createTransaction(
+  workspaceId: string,
+  userId: string,
+  body: CreateReq,
+): Promise<TransactionRow> {
+  const status = body.status ?? "posted";
+  const baseCurrency = await loadWorkspaceBaseCurrency(db, workspaceId);
+
+  // Pre-load all referenced accounts so we can validate currency and
+  // workspace ownership in one round trip.
+  const acctIds = Array.from(new Set(body.postings.map((p) => p.account_id)));
+  const acctRows = await db
+    .select({ id: accounts.id, currency: accounts.currency, workspaceId: accounts.workspaceId })
+    .from(accounts)
+    .where(inArray(accounts.id, acctIds));
+  const acctMap = new Map(acctRows.map((r) => [r.id, r]));
+  for (const aid of acctIds) {
+    const a = acctMap.get(aid);
+    if (!a || a.workspaceId !== workspaceId) {
+      throw new ValidationProblem(
+        [{ path: "postings.account_id", code: "not_found", message: `Account ${aid} not found in workspace` }],
+        "One or more postings reference unknown accounts",
+      );
+    }
+  }
+
+  // Validate documents up-front if provided.
+  if (body.document_ids && body.document_ids.length > 0) {
+    const docRows = await db
+      .select({ id: documents.id })
+      .from(documents)
+      .where(
+        and(
+          inArray(documents.id, body.document_ids),
+          eq(documents.workspaceId, workspaceId),
+        ),
+      );
+    if (docRows.length !== body.document_ids.length) {
+      const found = new Set(docRows.map((d) => d.id));
+      const missing = body.document_ids.filter((d) => !found.has(d));
+      throw new ValidationProblem(
+        missing.map((m) => ({ path: "document_ids", code: "not_found", message: `Document ${m} not in workspace` })),
+        "One or more documents not found",
+      );
+    }
+  }
+
+  // Build posting inserts with computed currency/fx fields.
+  type PostingInsert = {
+    id: string;
+    workspaceId: string;
+    transactionId: string;
+    accountId: string;
+    amountMinor: bigint;
+    currency: string;
+    fxRate: string | null;
+    amountBaseMinor: bigint | null;
+    memo: string | null;
+  };
+
+  const txId = newId();
+  const postingInserts: PostingInsert[] = body.postings.map((p, idx) => {
+    const acct = acctMap.get(p.account_id)!;
+    const currency = p.currency ?? acct.currency;
+    let fxRate: string | null = null;
+    let amountBaseMinor: bigint;
+    if (currency === baseCurrency) {
+      if (p.fx_rate !== undefined && p.fx_rate !== "1" && p.fx_rate !== "1.0") {
+        // Allow redundant "1" but otherwise reject.
+        const n = Number(p.fx_rate);
+        if (!Number.isFinite(n) || n !== 1) {
+          throw new ValidationProblem(
+            [{ path: `postings.${idx}.fx_rate`, code: "unexpected", message: "fx_rate must be null when currency equals workspace base currency" }],
+          );
+        }
+      }
+      amountBaseMinor = BigInt(p.amount_base_minor ?? p.amount_minor);
+    } else {
+      if (p.fx_rate === undefined || p.amount_base_minor === undefined) {
+        throw new ValidationProblem(
+          [
+            { path: `postings.${idx}.fx_rate`, code: "required", message: "fx_rate + amount_base_minor required for non-base currency postings" },
+          ],
+          "Non-base-currency postings must supply fx_rate and amount_base_minor",
+        );
+      }
+      fxRate = p.fx_rate;
+      amountBaseMinor = BigInt(p.amount_base_minor);
+    }
+    return {
+      id: newId(),
+      workspaceId,
+      transactionId: txId,
+      accountId: p.account_id,
+      amountMinor: BigInt(p.amount_minor),
+      currency,
+      fxRate,
+      amountBaseMinor,
+      memo: p.memo ?? null,
+    };
+  });
+
+  return await mapBalanceErrors(async () => {
+    return await db.transaction(async (tx) => {
+      await tx.insert(transactions).values({
+        id: txId,
+        workspaceId,
+        occurredOn: body.occurred_on,
+        occurredAt: body.occurred_at ? new Date(body.occurred_at) : null,
+        payee: body.payee ?? null,
+        narration: body.narration ?? null,
+        status,
+        tripId: body.trip_id ?? null,
+        metadata: body.metadata ?? {},
+        createdBy: userId,
+      });
+
+      await tx.insert(postings).values(postingInserts);
+
+      if (body.document_ids && body.document_ids.length > 0) {
+        await tx.insert(documentLinks).values(
+          body.document_ids.map((docId) => ({
+            documentId: docId,
+            transactionId: txId,
+          })),
+        );
+      }
+
+      await tx.insert(transactionEvents).values({
+        id: newId(),
+        workspaceId,
+        transactionId: txId,
+        eventType: "created",
+        actorId: userId,
+        payload: {
+          occurred_on: body.occurred_on,
+          payee: body.payee ?? null,
+          narration: body.narration ?? null,
+          status,
+          posting_count: postingInserts.length,
+          document_ids: body.document_ids ?? [],
+        },
+      });
+
+      const full = await loadTransactionFull(
+        tx as unknown as typeof db,
+        workspaceId,
+        txId,
+      );
+      if (!full) throw new Error("Failed to read back newly-created transaction");
+      return full;
+    });
+  });
+}
+
+// ── Get ────────────────────────────────────────────────────────────────
+
+export async function getTransaction(
+  workspaceId: string,
+  id: string,
+): Promise<TransactionRow> {
+  const row = await loadTransactionFull(db, workspaceId, id);
+  if (!row) throw new NotFoundProblem("Transaction", id);
+  return row;
+}
+
+// ── List ───────────────────────────────────────────────────────────────
+
+interface ListCursor {
+  occurred_on: string;
+  id: string;
+}
+
+export interface ListTransactionsResult {
+  items: TransactionRow[];
+  next_cursor: string | null;
+}
+
+export async function listTransactions(
+  workspaceId: string,
+  query: ListTxQuery,
+): Promise<ListTransactionsResult> {
+  const limit = clampLimit(query.limit ?? DEFAULT_PAGE_LIMIT);
+  const order = query.order ?? "desc";
+  const wantDesc = order === "desc";
+
+  const conditions: ReturnType<typeof sql>[] = [];
+  conditions.push(sql`t.workspace_id = ${workspaceId}::uuid`);
+  if (query.occurred_from) conditions.push(sql`t.occurred_on >= ${query.occurred_from}::date`);
+  if (query.occurred_to) conditions.push(sql`t.occurred_on <= ${query.occurred_to}::date`);
+  if (query.status) conditions.push(sql`t.status = ${query.status}`);
+  if (query.trip_id) conditions.push(sql`t.trip_id = ${query.trip_id}::uuid`);
+  if (query.source_ingest_id) conditions.push(sql`t.source_ingest_id = ${query.source_ingest_id}::uuid`);
+  if (query.payee_contains) conditions.push(sql`t.payee ILIKE ${"%" + query.payee_contains + "%"}`);
+  if (query.q) conditions.push(sql`(COALESCE(t.payee, '') || ' ' || COALESCE(t.narration, '')) ILIKE ${"%" + query.q + "%"}`);
+  if (query.account_id) {
+    conditions.push(sql`EXISTS (SELECT 1 FROM postings p WHERE p.transaction_id = t.id AND p.account_id = ${query.account_id}::uuid)`);
+  }
+  if (query.amount_min_minor !== undefined) {
+    conditions.push(sql`EXISTS (SELECT 1 FROM postings p WHERE p.transaction_id = t.id AND ABS(p.amount_base_minor) >= ${query.amount_min_minor})`);
+  }
+  if (query.amount_max_minor !== undefined) {
+    conditions.push(sql`EXISTS (SELECT 1 FROM postings p WHERE p.transaction_id = t.id AND ABS(p.amount_base_minor) <= ${query.amount_max_minor})`);
+  }
+  if (query.has_document === true) {
+    conditions.push(sql`EXISTS (SELECT 1 FROM document_links dl WHERE dl.transaction_id = t.id)`);
+  } else if (query.has_document === false) {
+    conditions.push(sql`NOT EXISTS (SELECT 1 FROM document_links dl WHERE dl.transaction_id = t.id)`);
+  }
+
+  // Keyset cursor on (occurred_on, id)
+  const cursor = decodeCursor<ListCursor>(query.cursor ?? undefined);
+  if (cursor) {
+    if (wantDesc) {
+      conditions.push(sql`(t.occurred_on, t.id) < (${cursor.occurred_on}::date, ${cursor.id}::uuid)`);
+    } else {
+      conditions.push(sql`(t.occurred_on, t.id) > (${cursor.occurred_on}::date, ${cursor.id}::uuid)`);
+    }
+  }
+
+  const where = sql.join(conditions, sql` AND `);
+  const orderSql = wantDesc
+    ? sql`t.occurred_on DESC, t.id DESC`
+    : sql`t.occurred_on ASC, t.id ASC`;
+
+  const rowsRes = await db.execute(
+    sql`SELECT t.* FROM transactions t WHERE ${where} ORDER BY ${orderSql} LIMIT ${limit + 1}`,
+  );
+  const rows = rowsRes.rows as any[];
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+
+  if (page.length === 0) {
+    return { items: [], next_cursor: null };
+  }
+
+  const ids = page.map((r) => r.id);
+  const postRes = await db.execute(
+    sql`SELECT * FROM postings WHERE transaction_id = ANY(${sql.raw(`ARRAY[${ids.map((i) => `'${i}'`).join(",")}]::uuid[]`)}) ORDER BY created_at ASC`,
+  );
+  const postByTx = new Map<string, any[]>();
+  for (const p of postRes.rows as any[]) {
+    const arr = postByTx.get(p.transaction_id) ?? [];
+    arr.push(p);
+    postByTx.set(p.transaction_id, arr);
+  }
+
+  const docRes = await db.execute(
+    sql`SELECT dl.transaction_id, d.id, d.kind
+        FROM document_links dl JOIN documents d ON d.id = dl.document_id
+        WHERE dl.transaction_id = ANY(${sql.raw(`ARRAY[${ids.map((i) => `'${i}'`).join(",")}]::uuid[]`)})`,
+  );
+  const docByTx = new Map<string, Array<{ id: string; kind: string }>>();
+  for (const d of docRes.rows as any[]) {
+    const arr = docByTx.get(d.transaction_id) ?? [];
+    arr.push({ id: d.id, kind: d.kind });
+    docByTx.set(d.transaction_id, arr);
+  }
+
+  const items = page.map((r) =>
+    mapTransactionRow(r, postByTx.get(r.id) ?? [], docByTx.get(r.id) ?? []),
+  );
+
+  const last = page[page.length - 1]!;
+  const nextCursor = hasMore
+    ? encodeCursor({ occurred_on: toIsoDate(last.occurred_on), id: last.id })
+    : null;
+
+  return { items, next_cursor: nextCursor };
+}
+
+// ── Update (head fields) ───────────────────────────────────────────────
+
+export async function updateTransaction(
+  workspaceId: string,
+  userId: string,
+  id: string,
+  expectedVersion: number,
+  patch: UpdateReq,
+): Promise<TransactionRow> {
+  return await db.transaction(async (tx) => {
+    const rows = await tx
+      .select()
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.id, id),
+          eq(transactions.workspaceId, workspaceId),
+        ),
+      );
+    if (rows.length === 0) throw new NotFoundProblem("Transaction", id);
+    const current = rows[0]!;
+    if (Number(current.version) !== expectedVersion) {
+      // Caller is expected to have pre-checked with requireIfMatch, but
+      // defence-in-depth: race between fetch and update.
+      const { VersionMismatchProblem } = await import("../http/problem.js");
+      throw new VersionMismatchProblem(Number(current.version), expectedVersion);
+    }
+
+    const updates: Record<string, unknown> = {};
+    const oldSnap: Record<string, unknown> = {};
+    if (patch.occurred_on !== undefined) {
+      updates.occurredOn = patch.occurred_on;
+      oldSnap.occurred_on = current.occurredOn;
+    }
+    if (patch.occurred_at !== undefined) {
+      updates.occurredAt = patch.occurred_at === null ? null : new Date(patch.occurred_at);
+      oldSnap.occurred_at = current.occurredAt;
+    }
+    if (patch.payee !== undefined) {
+      updates.payee = patch.payee;
+      oldSnap.payee = current.payee;
+    }
+    if (patch.narration !== undefined) {
+      updates.narration = patch.narration;
+      oldSnap.narration = current.narration;
+    }
+    if (patch.trip_id !== undefined) {
+      updates.tripId = patch.trip_id;
+      oldSnap.trip_id = current.tripId;
+    }
+    if (patch.metadata !== undefined) {
+      updates.metadata = patch.metadata;
+      oldSnap.metadata = current.metadata;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      // No-op patch: still bump the audit trail? No — idempotent no-op.
+      const full = await loadTransactionFull(tx as unknown as typeof db, workspaceId, id);
+      return full!;
+    }
+
+    await tx
+      .update(transactions)
+      .set(updates)
+      .where(eq(transactions.id, id));
+
+    await tx.insert(transactionEvents).values({
+      id: newId(),
+      workspaceId,
+      transactionId: id,
+      eventType: "updated",
+      actorId: userId,
+      payload: { old: oldSnap, new: patch },
+    });
+
+    const full = await loadTransactionFull(tx as unknown as typeof db, workspaceId, id);
+    return full!;
+  });
+}
+
+// ── Delete ─────────────────────────────────────────────────────────────
+
+export async function deleteTransaction(
+  workspaceId: string,
+  id: string,
+  expectedVersion: number,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    const rows = await tx
+      .select()
+      .from(transactions)
+      .where(
+        and(eq(transactions.id, id), eq(transactions.workspaceId, workspaceId)),
+      );
+    if (rows.length === 0) throw new NotFoundProblem("Transaction", id);
+    const current = rows[0]!;
+    if (Number(current.version) !== expectedVersion) {
+      const { VersionMismatchProblem } = await import("../http/problem.js");
+      throw new VersionMismatchProblem(Number(current.version), expectedVersion);
+    }
+    if (current.status !== "draft" && current.status !== "error") {
+      throw new MustVoidInsteadProblem(id, current.status);
+    }
+    // Hard-delete: postings + document_links cascade via FK.
+    await tx.delete(transactions).where(eq(transactions.id, id));
+  });
+}
+
+// ── Void ───────────────────────────────────────────────────────────────
+
+export async function voidTransaction(
+  workspaceId: string,
+  userId: string,
+  id: string,
+  expectedVersion: number,
+  reason?: string,
+): Promise<TransactionRow> {
+  return await mapBalanceErrors(async () => {
+    return await db.transaction(async (tx) => {
+      const rows = await tx
+        .select()
+        .from(transactions)
+        .where(
+          and(eq(transactions.id, id), eq(transactions.workspaceId, workspaceId)),
+        );
+      if (rows.length === 0) throw new NotFoundProblem("Transaction", id);
+      const current = rows[0]!;
+      if (Number(current.version) !== expectedVersion) {
+        const { VersionMismatchProblem } = await import("../http/problem.js");
+        throw new VersionMismatchProblem(Number(current.version), expectedVersion);
+      }
+      if (current.status === "voided" || current.status === "draft" || current.status === "error") {
+        throw new HttpProblem(
+          409,
+          "invalid-state",
+          "Cannot void transaction",
+          `Transaction ${id} is in status=${current.status}; only posted/reconciled may be voided.`,
+          { transaction_id: id, status: current.status },
+        );
+      }
+
+      const originalPostings = await tx
+        .select()
+        .from(postings)
+        .where(eq(postings.transactionId, id));
+
+      const mirrorId = newId();
+      const existingMeta = (current.metadata ?? {}) as Record<string, unknown>;
+      const mirrorMeta: Record<string, unknown> = {
+        ...existingMeta,
+        voided: id,
+        ...(reason ? { void_reason: reason } : {}),
+      };
+
+      await tx.insert(transactions).values({
+        id: mirrorId,
+        workspaceId,
+        occurredOn: toIsoDate(current.occurredOn),
+        occurredAt: current.occurredAt,
+        payee: `VOID: ${current.payee ?? ""}`.trim(),
+        narration: current.narration,
+        status: "posted",
+        tripId: current.tripId,
+        metadata: mirrorMeta,
+        createdBy: userId,
+      });
+
+      await tx.insert(postings).values(
+        originalPostings.map((p) => ({
+          id: newId(),
+          workspaceId,
+          transactionId: mirrorId,
+          accountId: p.accountId,
+          amountMinor: -BigInt(p.amountMinor),
+          currency: p.currency,
+          fxRate: p.fxRate,
+          amountBaseMinor:
+            p.amountBaseMinor === null ? null : -BigInt(p.amountBaseMinor),
+          memo: p.memo,
+        })),
+      );
+
+      await tx
+        .update(transactions)
+        .set({ status: "voided", voidedById: mirrorId })
+        .where(eq(transactions.id, id));
+
+      await tx.insert(transactionEvents).values([
+        {
+          id: newId(),
+          workspaceId,
+          transactionId: id,
+          eventType: "voided",
+          actorId: userId,
+          payload: { voided_by: mirrorId, reason: reason ?? null },
+        },
+        {
+          id: newId(),
+          workspaceId,
+          transactionId: mirrorId,
+          eventType: "created",
+          actorId: userId,
+          payload: { voids: id, reason: reason ?? null },
+        },
+      ]);
+
+      const full = await loadTransactionFull(
+        tx as unknown as typeof db,
+        workspaceId,
+        mirrorId,
+      );
+      return full!;
+    });
+  });
+}
+
+// ── Reconcile ──────────────────────────────────────────────────────────
+
+export async function reconcileTransaction(
+  workspaceId: string,
+  userId: string,
+  id: string,
+  expectedVersion: number,
+): Promise<TransactionRow> {
+  return await mapBalanceErrors(async () => {
+    return await db.transaction(async (tx) => {
+      const rows = await tx
+        .select()
+        .from(transactions)
+        .where(
+          and(eq(transactions.id, id), eq(transactions.workspaceId, workspaceId)),
+        );
+      if (rows.length === 0) throw new NotFoundProblem("Transaction", id);
+      const current = rows[0]!;
+      if (Number(current.version) !== expectedVersion) {
+        const { VersionMismatchProblem } = await import("../http/problem.js");
+        throw new VersionMismatchProblem(Number(current.version), expectedVersion);
+      }
+      if (current.status !== "posted") {
+        throw new HttpProblem(
+          409,
+          "invalid-state",
+          "Cannot reconcile",
+          `Transaction ${id} is in status=${current.status}; only 'posted' may be reconciled.`,
+          { transaction_id: id, status: current.status },
+        );
+      }
+
+      await tx
+        .update(transactions)
+        .set({ status: "reconciled" })
+        .where(eq(transactions.id, id));
+
+      await tx.insert(transactionEvents).values({
+        id: newId(),
+        workspaceId,
+        transactionId: id,
+        eventType: "reconciled",
+        actorId: userId,
+        payload: {},
+      });
+
+      const full = await loadTransactionFull(
+        tx as unknown as typeof db,
+        workspaceId,
+        id,
+      );
+      return full!;
+    });
+  });
+}
+
+// ── Posting-level mutations ────────────────────────────────────────────
+
+export async function addPosting(
+  workspaceId: string,
+  userId: string,
+  txId: string,
+  expectedVersion: number,
+  body: NewPostingT,
+): Promise<PostingRow> {
+  const baseCurrency = await loadWorkspaceBaseCurrency(db, workspaceId);
+
+  const acctRows = await db
+    .select({ id: accounts.id, currency: accounts.currency, workspaceId: accounts.workspaceId })
+    .from(accounts)
+    .where(eq(accounts.id, body.account_id));
+  const acct = acctRows[0];
+  if (!acct || acct.workspaceId !== workspaceId) {
+    throw new ValidationProblem(
+      [{ path: "account_id", code: "not_found", message: `Account ${body.account_id} not found in workspace` }],
+    );
+  }
+
+  const currency = body.currency ?? acct.currency;
+  let fxRate: string | null = null;
+  let amountBaseMinor: bigint;
+  if (currency === baseCurrency) {
+    amountBaseMinor = BigInt(body.amount_base_minor ?? body.amount_minor);
+  } else {
+    if (body.fx_rate === undefined || body.amount_base_minor === undefined) {
+      throw new ValidationProblem([
+        { path: "fx_rate", code: "required", message: "fx_rate + amount_base_minor required for non-base currency postings" },
+      ]);
+    }
+    fxRate = body.fx_rate;
+    amountBaseMinor = BigInt(body.amount_base_minor);
+  }
+
+  return await mapBalanceErrors(async () => {
+    return await db.transaction(async (tx) => {
+      const rows = await tx
+        .select()
+        .from(transactions)
+        .where(
+          and(eq(transactions.id, txId), eq(transactions.workspaceId, workspaceId)),
+        );
+      if (rows.length === 0) throw new NotFoundProblem("Transaction", txId);
+      const current = rows[0]!;
+      if (Number(current.version) !== expectedVersion) {
+        const { VersionMismatchProblem } = await import("../http/problem.js");
+        throw new VersionMismatchProblem(Number(current.version), expectedVersion);
+      }
+
+      const newPostingId = newId();
+      await tx.insert(postings).values({
+        id: newPostingId,
+        workspaceId,
+        transactionId: txId,
+        accountId: body.account_id,
+        amountMinor: BigInt(body.amount_minor),
+        currency,
+        fxRate,
+        amountBaseMinor,
+        memo: body.memo ?? null,
+      });
+
+      // Bump parent version via a dummy UPDATE to fire the version trigger.
+      await tx
+        .update(transactions)
+        .set({ updatedAt: new Date() })
+        .where(eq(transactions.id, txId));
+
+      await tx.insert(transactionEvents).values({
+        id: newId(),
+        workspaceId,
+        transactionId: txId,
+        eventType: "posting_added",
+        actorId: userId,
+        payload: { posting_id: newPostingId, account_id: body.account_id, amount_minor: body.amount_minor },
+      });
+
+      const postRows = await tx
+        .select()
+        .from(postings)
+        .where(eq(postings.id, newPostingId));
+      return mapPostingRow(postRows[0]!);
+    });
+  });
+}
+
+export async function updatePosting(
+  workspaceId: string,
+  userId: string,
+  txId: string,
+  postingId: string,
+  expectedVersion: number,
+  patch: UpdatePostingReq,
+): Promise<PostingRow> {
+  return await mapBalanceErrors(async () => {
+    return await db.transaction(async (tx) => {
+      const rows = await tx
+        .select()
+        .from(transactions)
+        .where(
+          and(eq(transactions.id, txId), eq(transactions.workspaceId, workspaceId)),
+        );
+      if (rows.length === 0) throw new NotFoundProblem("Transaction", txId);
+      const current = rows[0]!;
+      if (Number(current.version) !== expectedVersion) {
+        const { VersionMismatchProblem } = await import("../http/problem.js");
+        throw new VersionMismatchProblem(Number(current.version), expectedVersion);
+      }
+
+      const existingRows = await tx
+        .select()
+        .from(postings)
+        .where(eq(postings.id, postingId));
+      if (existingRows.length === 0 || existingRows[0]!.transactionId !== txId) {
+        throw new NotFoundProblem("Posting", postingId);
+      }
+
+      const updates: Record<string, unknown> = {};
+      if (patch.account_id !== undefined) updates.accountId = patch.account_id;
+      if (patch.amount_minor !== undefined) updates.amountMinor = BigInt(patch.amount_minor);
+      if (patch.currency !== undefined) updates.currency = patch.currency;
+      if (patch.fx_rate !== undefined) updates.fxRate = patch.fx_rate;
+      if (patch.amount_base_minor !== undefined) updates.amountBaseMinor = BigInt(patch.amount_base_minor);
+      if (patch.memo !== undefined) updates.memo = patch.memo;
+
+      if (Object.keys(updates).length > 0) {
+        await tx.update(postings).set(updates).where(eq(postings.id, postingId));
+      }
+
+      // Bump parent version.
+      await tx
+        .update(transactions)
+        .set({ updatedAt: new Date() })
+        .where(eq(transactions.id, txId));
+
+      await tx.insert(transactionEvents).values({
+        id: newId(),
+        workspaceId,
+        transactionId: txId,
+        eventType: "posting_updated",
+        actorId: userId,
+        payload: { posting_id: postingId, patch },
+      });
+
+      const postRows = await tx
+        .select()
+        .from(postings)
+        .where(eq(postings.id, postingId));
+      return mapPostingRow(postRows[0]!);
+    });
+  });
+}
+
+export async function deletePosting(
+  workspaceId: string,
+  userId: string,
+  txId: string,
+  postingId: string,
+  expectedVersion: number,
+): Promise<void> {
+  await mapBalanceErrors(async () => {
+    await db.transaction(async (tx) => {
+      const rows = await tx
+        .select()
+        .from(transactions)
+        .where(
+          and(eq(transactions.id, txId), eq(transactions.workspaceId, workspaceId)),
+        );
+      if (rows.length === 0) throw new NotFoundProblem("Transaction", txId);
+      const current = rows[0]!;
+      if (Number(current.version) !== expectedVersion) {
+        const { VersionMismatchProblem } = await import("../http/problem.js");
+        throw new VersionMismatchProblem(Number(current.version), expectedVersion);
+      }
+
+      const allPostings = await tx
+        .select()
+        .from(postings)
+        .where(eq(postings.transactionId, txId));
+      const target = allPostings.find((p) => p.id === postingId);
+      if (!target) throw new NotFoundProblem("Posting", postingId);
+
+      // Check resulting count upfront to produce a clear 422.
+      if (current.status !== "draft" && current.status !== "error" && allPostings.length - 1 < 2) {
+        throw new ValidationProblem(
+          [{ path: "postings", code: "min_items", message: "A posted transaction must retain at least 2 postings" }],
+          "Deleting this posting would leave the transaction with fewer than 2 postings",
+        );
+      }
+
+      await tx.delete(postings).where(eq(postings.id, postingId));
+
+      await tx
+        .update(transactions)
+        .set({ updatedAt: new Date() })
+        .where(eq(transactions.id, txId));
+
+      await tx.insert(transactionEvents).values({
+        id: newId(),
+        workspaceId,
+        transactionId: txId,
+        eventType: "posting_removed",
+        actorId: userId,
+        payload: { posting_id: postingId },
+      });
+    });
+  });
+}
+
+// ── Posting queries (for /v1/postings) ─────────────────────────────────
+
+export interface ListPostingsResult {
+  items: PostingRow[];
+  next_cursor: string | null;
+}
+
+interface PostingCursor {
+  created_at: string;
+  id: string;
+}
+
+export async function listPostings(
+  workspaceId: string,
+  query: ListPostingQuery,
+): Promise<ListPostingsResult> {
+  const limit = clampLimit(query.limit ?? DEFAULT_PAGE_LIMIT);
+
+  const conditions: ReturnType<typeof sql>[] = [];
+  conditions.push(sql`p.workspace_id = ${workspaceId}::uuid`);
+  if (query.transaction_id) conditions.push(sql`p.transaction_id = ${query.transaction_id}::uuid`);
+  if (query.account_id) conditions.push(sql`p.account_id = ${query.account_id}::uuid`);
+  if (query.from || query.to) {
+    // Join via EXISTS to transactions.occurred_on
+    if (query.from) conditions.push(sql`EXISTS (SELECT 1 FROM transactions t WHERE t.id = p.transaction_id AND t.occurred_on >= ${query.from}::date)`);
+    if (query.to) conditions.push(sql`EXISTS (SELECT 1 FROM transactions t WHERE t.id = p.transaction_id AND t.occurred_on <= ${query.to}::date)`);
+  }
+
+  const cursor = decodeCursor<PostingCursor>(query.cursor ?? undefined);
+  if (cursor) {
+    conditions.push(
+      sql`(p.created_at, p.id) < (${cursor.created_at}::timestamptz, ${cursor.id}::uuid)`,
+    );
+  }
+
+  const where = sql.join(conditions, sql` AND `);
+  const res = await db.execute(
+    sql`SELECT * FROM postings p WHERE ${where} ORDER BY p.created_at DESC, p.id DESC LIMIT ${limit + 1}`,
+  );
+  const rows = res.rows as any[];
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+
+  const items = page.map(mapPostingRow);
+  const last = page[page.length - 1];
+  const nextCursor = hasMore && last
+    ? encodeCursor({
+        created_at: toIsoString(last.created_at),
+        id: last.id,
+      })
+    : null;
+
+  return { items, next_cursor: nextCursor };
+}
+
+export async function getPosting(
+  workspaceId: string,
+  id: string,
+): Promise<PostingRow> {
+  const rows = await db
+    .select()
+    .from(postings)
+    .where(
+      and(eq(postings.id, id), eq(postings.workspaceId, workspaceId)),
+    );
+  if (rows.length === 0) throw new NotFoundProblem("Posting", id);
+  return mapPostingRow(rows[0]!);
+}

--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -1,0 +1,625 @@
+/**
+ * HTTP routes for `/v1/transactions` (CRUD + void + reconcile + bulk +
+ * nested postings).
+ *
+ * The heavy lifting — DB transaction wrapping, balance-trigger error
+ * translation, audit-log writes — lives in `transactions.service.ts`
+ * so the MCP tools can reuse the same code path without spinning a
+ * fake HTTP request.
+ *
+ * Error handling: every handler is an `async (req, res, next)` that
+ * forwards thrown `HttpProblem`s to `next(err)` — the final
+ * `problemHandler` in `app.ts` serializes them as 7807.
+ */
+import express, { Router, type Request, type Response, type NextFunction } from "express";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+import { db } from "../db/client.js";
+import { transactions } from "../schema/index.js";
+import { eq, and } from "drizzle-orm";
+import {
+  CreateTransactionRequest,
+  UpdateTransactionRequest,
+  VoidTransactionRequest,
+  UpdatePostingRequest,
+  NewPosting,
+  ListTransactionsQuery,
+  BulkRequest,
+  Transaction as TransactionSchema,
+  Posting as PostingSchema,
+  BulkResponse,
+} from "../schemas/v1/transaction.js";
+import { parseOrThrow } from "../http/validate.js";
+import {
+  setEtag,
+  requireIfMatch,
+  handleIfNoneMatch,
+  parseEtag,
+} from "../http/etag.js";
+import {
+  PreconditionRequiredProblem,
+  NotFoundProblem,
+  HttpProblem,
+  VersionMismatchProblem,
+} from "../http/problem.js";
+import { idempotencyMiddleware } from "../http/idempotency.js";
+import { emitNextLink } from "../http/pagination.js";
+import {
+  createTransaction,
+  getTransaction,
+  listTransactions,
+  updateTransaction,
+  deleteTransaction,
+  voidTransaction,
+  reconcileTransaction,
+  addPosting,
+  updatePosting,
+  deletePosting,
+} from "./transactions.service.js";
+import { ProblemDetails, paginated, IdParam, Uuid } from "../schemas/v1/common.js";
+
+export const transactionsRouter: Router = Router();
+
+// Parse `application/merge-patch+json` bodies on PATCH routes. The app-
+// level `express.json()` only covers `application/json`; patch requests
+// using the RFC 7396 content type would otherwise arrive with an empty
+// body. Harmless on non-PATCH methods — only fires when the header is
+// present.
+transactionsRouter.use(
+  express.json({ type: "application/merge-patch+json", limit: "25mb" }),
+);
+
+// Helper: load current version (for If-Match check) before mutation.
+async function loadVersion(
+  workspaceId: string,
+  id: string,
+): Promise<number> {
+  const rows = await db
+    .select({ version: transactions.version })
+    .from(transactions)
+    .where(
+      and(eq(transactions.id, id), eq(transactions.workspaceId, workspaceId)),
+    );
+  if (rows.length === 0) throw new NotFoundProblem("Transaction", id);
+  return Number(rows[0]!.version);
+}
+
+// ── POST /v1/transactions ──────────────────────────────────────────────
+
+transactionsRouter.post(
+  "/",
+  idempotencyMiddleware(),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (!req.header("Idempotency-Key")) {
+        throw new PreconditionRequiredProblem("Idempotency-Key");
+      }
+      const body = parseOrThrow(CreateTransactionRequest, req.body);
+      const result = await createTransaction(
+        req.ctx.workspaceId,
+        req.ctx.userId,
+        body,
+      );
+      res.setHeader("Location", `/v1/transactions/${result.id}`);
+      setEtag(res, result.version);
+      res.status(201).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── GET /v1/transactions ───────────────────────────────────────────────
+
+transactionsRouter.get(
+  "/",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Zod's z.coerce.boolean() treats any non-empty string as `true`,
+      // including the literal "false". Normalize the raw query string
+      // BEFORE parsing so `has_document=false` → boolean false.
+      const raw = { ...(req.query as Record<string, unknown>) };
+      if (typeof raw.has_document === "string") {
+        const lower = (raw.has_document as string).toLowerCase();
+        if (lower === "false" || lower === "0") raw.has_document = false;
+        else if (lower === "true" || lower === "1") raw.has_document = true;
+      }
+      const query = parseOrThrow(ListTransactionsQuery, raw);
+      const result = await listTransactions(req.ctx.workspaceId, query);
+      emitNextLink(req, res, result.next_cursor);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── POST /v1/transactions:bulk (aliased /v1/transactions/bulk) ─────────
+//
+// Epic #28 specifies the Google AEIP-style colon-verb form
+// `/v1/transactions:bulk`. Express 5 mounts at a segment boundary, so
+// `/v1/transactions:bulk` is not reachable via `app.use("/v1/transactions", router)`.
+// We expose the feature at the equivalent `/v1/transactions/bulk` path
+// (also documented in OpenAPI) so existing clients can use it today;
+// once the mount is consolidated the colon form can be added as a 308
+// redirect alias.
+
+transactionsRouter.post(
+  "/bulk",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const body = parseOrThrow(BulkRequest, req.body);
+      const results: Array<{ index: number; status: number; body: unknown }> = [];
+
+      for (let i = 0; i < body.operations.length; i++) {
+        const op = body.operations[i]!;
+        try {
+          const expected = parseEtag(op.if_match);
+          if (expected === null) {
+            throw new VersionMismatchProblem(await loadVersion(req.ctx.workspaceId, op.id), undefined);
+          }
+          if (op.op === "update") {
+            const out = await updateTransaction(
+              req.ctx.workspaceId,
+              req.ctx.userId,
+              op.id,
+              expected,
+              op.patch,
+            );
+            results.push({ index: i, status: 200, body: out });
+          } else if (op.op === "void") {
+            const out = await voidTransaction(
+              req.ctx.workspaceId,
+              req.ctx.userId,
+              op.id,
+              expected,
+              op.reason,
+            );
+            results.push({ index: i, status: 201, body: out });
+          } else if (op.op === "reconcile") {
+            const out = await reconcileTransaction(
+              req.ctx.workspaceId,
+              req.ctx.userId,
+              op.id,
+              expected,
+            );
+            results.push({ index: i, status: 200, body: out });
+          }
+        } catch (err) {
+          if (err instanceof HttpProblem) {
+            results.push({
+              index: i,
+              status: err.status,
+              body: err.toBody(),
+            });
+          } else {
+            results.push({
+              index: i,
+              status: 500,
+              body: {
+                type: "https://receipts.dev/errors/internal",
+                title: "Internal Server Error",
+                status: 500,
+                detail: err instanceof Error ? err.message : String(err),
+              },
+            });
+          }
+        }
+      }
+
+      res.status(200).json({ results });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── GET /v1/transactions/:id ───────────────────────────────────────────
+
+transactionsRouter.get(
+  "/:id",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = parseOrThrow(IdParam, req.params);
+      const result = await getTransaction(req.ctx.workspaceId, id);
+      if (handleIfNoneMatch(req, res, result.version)) return;
+      setEtag(res, result.version);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── PATCH /v1/transactions/:id ─────────────────────────────────────────
+
+transactionsRouter.patch(
+  "/:id",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = parseOrThrow(IdParam, req.params);
+      const ct = req.header("Content-Type") ?? "";
+      const ctBase = ct.split(";")[0]!.trim().toLowerCase();
+      if (ctBase && ctBase !== "application/merge-patch+json" && ctBase !== "application/json") {
+        throw new HttpProblem(
+          415,
+          "unsupported-media-type",
+          "Unsupported Media Type",
+          `Content-Type must be application/merge-patch+json or application/json; got ${ctBase}`,
+        );
+      }
+
+      const currentVersion = await loadVersion(req.ctx.workspaceId, id);
+      requireIfMatch(req, currentVersion);
+
+      const patch = parseOrThrow(UpdateTransactionRequest, req.body);
+      const result = await updateTransaction(
+        req.ctx.workspaceId,
+        req.ctx.userId,
+        id,
+        currentVersion,
+        patch,
+      );
+      setEtag(res, result.version);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── DELETE /v1/transactions/:id ────────────────────────────────────────
+
+transactionsRouter.delete(
+  "/:id",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = parseOrThrow(IdParam, req.params);
+      const currentVersion = await loadVersion(req.ctx.workspaceId, id);
+      requireIfMatch(req, currentVersion);
+      await deleteTransaction(req.ctx.workspaceId, id, currentVersion);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── POST /v1/transactions/:id/void ─────────────────────────────────────
+
+transactionsRouter.post(
+  "/:id/void",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = parseOrThrow(IdParam, req.params);
+      const body = parseOrThrow(VoidTransactionRequest, req.body ?? {});
+      const currentVersion = await loadVersion(req.ctx.workspaceId, id);
+      requireIfMatch(req, currentVersion);
+      const result = await voidTransaction(
+        req.ctx.workspaceId,
+        req.ctx.userId,
+        id,
+        currentVersion,
+        body.reason,
+      );
+      res.setHeader("Location", `/v1/transactions/${result.id}`);
+      setEtag(res, result.version);
+      res.status(201).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── POST /v1/transactions/:id/reconcile ────────────────────────────────
+
+transactionsRouter.post(
+  "/:id/reconcile",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = parseOrThrow(IdParam, req.params);
+      const currentVersion = await loadVersion(req.ctx.workspaceId, id);
+      requireIfMatch(req, currentVersion);
+      const result = await reconcileTransaction(
+        req.ctx.workspaceId,
+        req.ctx.userId,
+        id,
+        currentVersion,
+      );
+      setEtag(res, result.version);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── POST /v1/transactions/:id/postings ─────────────────────────────────
+
+transactionsRouter.post(
+  "/:id/postings",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = parseOrThrow(IdParam, req.params);
+      const body = parseOrThrow(NewPosting, req.body);
+      const currentVersion = await loadVersion(req.ctx.workspaceId, id);
+      requireIfMatch(req, currentVersion);
+      const result = await addPosting(
+        req.ctx.workspaceId,
+        req.ctx.userId,
+        id,
+        currentVersion,
+        body,
+      );
+      res.status(201).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── PATCH /v1/transactions/:tid/postings/:pid ──────────────────────────
+
+transactionsRouter.patch(
+  "/:tid/postings/:pid",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const params = parseOrThrow(
+        z.object({ tid: Uuid, pid: Uuid }),
+        req.params,
+      );
+      const patch = parseOrThrow(UpdatePostingRequest, req.body);
+      const currentVersion = await loadVersion(req.ctx.workspaceId, params.tid);
+      requireIfMatch(req, currentVersion);
+      const result = await updatePosting(
+        req.ctx.workspaceId,
+        req.ctx.userId,
+        params.tid,
+        params.pid,
+        currentVersion,
+        patch,
+      );
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── DELETE /v1/transactions/:tid/postings/:pid ─────────────────────────
+
+transactionsRouter.delete(
+  "/:tid/postings/:pid",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const params = parseOrThrow(
+        z.object({ tid: Uuid, pid: Uuid }),
+        req.params,
+      );
+      const currentVersion = await loadVersion(req.ctx.workspaceId, params.tid);
+      requireIfMatch(req, currentVersion);
+      await deletePosting(
+        req.ctx.workspaceId,
+        req.ctx.userId,
+        params.tid,
+        params.pid,
+        currentVersion,
+      );
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── OpenAPI registration ───────────────────────────────────────────────
+
+export function registerTransactionsOpenApi(registry: OpenAPIRegistry): void {
+  registry.register("Transaction", TransactionSchema);
+  registry.register("Posting", PostingSchema);
+  registry.register("BulkResponse", BulkResponse);
+
+  const problemContent = {
+    "application/problem+json": { schema: ProblemDetails },
+  };
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/transactions",
+    summary: "Create a transaction",
+    tags: ["transactions"],
+    request: {
+      headers: z.object({ "Idempotency-Key": z.string() }),
+      body: {
+        content: { "application/json": { schema: CreateTransactionRequest } },
+      },
+    },
+    responses: {
+      201: {
+        description: "Created",
+        content: { "application/json": { schema: TransactionSchema } },
+      },
+      409: { description: "Idempotency conflict", content: problemContent },
+      422: { description: "Validation failed", content: problemContent },
+      428: { description: "Idempotency-Key required", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/transactions",
+    summary: "List transactions",
+    tags: ["transactions"],
+    request: { query: ListTransactionsQuery },
+    responses: {
+      200: {
+        description: "OK",
+        content: {
+          "application/json": { schema: paginated(TransactionSchema) },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/transactions/{id}",
+    summary: "Get a transaction",
+    tags: ["transactions"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: TransactionSchema } },
+      },
+      304: { description: "Not Modified" },
+      404: { description: "Not Found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "patch",
+    path: "/v1/transactions/{id}",
+    summary: "Patch transaction head fields",
+    tags: ["transactions"],
+    request: {
+      params: z.object({ id: Uuid }),
+      headers: z.object({ "If-Match": z.string() }),
+      body: {
+        content: {
+          "application/merge-patch+json": { schema: UpdateTransactionRequest },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: TransactionSchema } },
+      },
+      412: { description: "Version mismatch", content: problemContent },
+      428: { description: "If-Match required", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/transactions/{id}",
+    summary: "Delete draft/error transaction",
+    tags: ["transactions"],
+    request: {
+      params: z.object({ id: Uuid }),
+      headers: z.object({ "If-Match": z.string() }),
+    },
+    responses: {
+      204: { description: "Deleted" },
+      409: { description: "Must void instead", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/transactions/{id}/void",
+    summary: "Void a posted transaction",
+    tags: ["transactions"],
+    request: {
+      params: z.object({ id: Uuid }),
+      headers: z.object({ "If-Match": z.string() }),
+      body: {
+        content: { "application/json": { schema: VoidTransactionRequest } },
+      },
+    },
+    responses: {
+      201: {
+        description: "Mirror transaction created",
+        content: { "application/json": { schema: TransactionSchema } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/transactions/{id}/reconcile",
+    summary: "Reconcile a posted transaction",
+    tags: ["transactions"],
+    request: {
+      params: z.object({ id: Uuid }),
+      headers: z.object({ "If-Match": z.string() }),
+    },
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: TransactionSchema } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/transactions/bulk",
+    summary: "Bulk update/void/reconcile",
+    tags: ["transactions"],
+    request: {
+      body: { content: { "application/json": { schema: BulkRequest } } },
+    },
+    responses: {
+      200: {
+        description: "Per-op results",
+        content: { "application/json": { schema: BulkResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/transactions/{id}/postings",
+    summary: "Add a posting to a transaction",
+    tags: ["transactions"],
+    request: {
+      params: z.object({ id: Uuid }),
+      headers: z.object({ "If-Match": z.string() }),
+      body: { content: { "application/json": { schema: NewPosting } } },
+    },
+    responses: {
+      201: {
+        description: "Posting added",
+        content: { "application/json": { schema: PostingSchema } },
+      },
+      422: { description: "Imbalance", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "patch",
+    path: "/v1/transactions/{tid}/postings/{pid}",
+    summary: "Update a posting",
+    tags: ["transactions"],
+    request: {
+      params: z.object({ tid: Uuid, pid: Uuid }),
+      headers: z.object({ "If-Match": z.string() }),
+      body: {
+        content: { "application/json": { schema: UpdatePostingRequest } },
+      },
+    },
+    responses: {
+      200: {
+        description: "Updated",
+        content: { "application/json": { schema: PostingSchema } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/transactions/{tid}/postings/{pid}",
+    summary: "Delete a posting",
+    tags: ["transactions"],
+    request: {
+      params: z.object({ tid: Uuid, pid: Uuid }),
+      headers: z.object({ "If-Match": z.string() }),
+    },
+    responses: {
+      204: { description: "Deleted" },
+      422: { description: "Would leave <2 postings", content: problemContent },
+    },
+  });
+}

--- a/src/schemas/v1/account.ts
+++ b/src/schemas/v1/account.ts
@@ -1,0 +1,145 @@
+/**
+ * Zod schemas for `/v1/accounts` and its derived views.
+ */
+import { z } from "zod";
+import {
+  AmountMinor,
+  CurrencyCode,
+  IsoDate,
+  IsoDateTime,
+  Metadata,
+  Uuid,
+} from "./common.js";
+
+export const AccountType = z.enum([
+  "asset",
+  "liability",
+  "equity",
+  "income",
+  "expense",
+]);
+
+const baseAccountFields = {
+  id: Uuid,
+  workspace_id: Uuid,
+  parent_id: Uuid.nullable(),
+  code: z.string().nullable(),
+  name: z.string().min(1),
+  type: AccountType,
+  subtype: z.string().nullable(),
+  currency: CurrencyCode,
+  institution: z.string().nullable(),
+  last4: z.string().nullable(),
+  opening_balance_minor: AmountMinor,
+  closed_at: IsoDateTime.nullable(),
+  metadata: Metadata,
+  version: z.number().int(),
+  created_at: IsoDateTime,
+  updated_at: IsoDateTime,
+};
+
+export const Account = z.object(baseAccountFields).openapi("Account");
+
+export const AccountTreeNode: z.ZodType<any> = z
+  .object({
+    ...baseAccountFields,
+    children: z.lazy(() => z.array(AccountTreeNode)).default([]),
+  })
+  .openapi("AccountTreeNode");
+
+export const CreateAccountRequest = z
+  .object({
+    parent_id: Uuid.optional(),
+    code: z.string().optional(),
+    name: z.string().min(1),
+    type: AccountType,
+    subtype: z.string().optional(),
+    currency: CurrencyCode.optional(), // inherit from parent if omitted
+    institution: z.string().optional(),
+    last4: z.string().optional(),
+    opening_balance_minor: AmountMinor.optional(),
+    metadata: Metadata.optional(),
+  })
+  .openapi("CreateAccountRequest");
+
+export const UpdateAccountRequest = z
+  .object({
+    code: z.string().nullable().optional(),
+    name: z.string().min(1).optional(),
+    subtype: z.string().nullable().optional(),
+    institution: z.string().nullable().optional(),
+    last4: z.string().nullable().optional(),
+    parent_id: Uuid.nullable().optional(),
+    closed_at: IsoDateTime.nullable().optional(),
+    metadata: Metadata.optional(),
+  })
+  .openapi("UpdateAccountRequest");
+
+export const AccountBalance = z
+  .object({
+    account_id: Uuid,
+    as_of: IsoDate,
+    balance_minor: AmountMinor,
+    currency: CurrencyCode,
+    posting_count: z.number().int(),
+    includes_children: z.boolean(),
+  })
+  .openapi("AccountBalance");
+
+export const RegisterCounterPosting = z
+  .object({
+    account_id: Uuid,
+    name: z.string(),
+    amount_minor: AmountMinor,
+  })
+  .openapi("RegisterCounterPosting");
+
+export const RegisterDocumentRef = z
+  .object({
+    id: Uuid,
+    kind: z.string(),
+  })
+  .openapi("RegisterDocumentRef");
+
+export const RegisterItem = z
+  .object({
+    posting_id: Uuid,
+    transaction_id: Uuid,
+    transaction_version: z.number().int(),
+    occurred_on: IsoDate,
+    payee: z.string().nullable(),
+    narration: z.string().nullable(),
+    amount_minor: AmountMinor,
+    currency: CurrencyCode,
+    running_balance_after_minor: AmountMinor,
+    counter_postings: z.array(RegisterCounterPosting),
+    documents: z.array(RegisterDocumentRef),
+  })
+  .openapi("RegisterItem");
+
+export const AccountRegister = z
+  .object({
+    account_id: Uuid,
+    items: z.array(RegisterItem),
+    next_cursor: z.string().nullable(),
+  })
+  .openapi("AccountRegister");
+
+export const ListAccountsQuery = z.object({
+  flat: z.coerce.boolean().optional(),
+  include_closed: z.coerce.boolean().optional(),
+});
+
+export const BalanceQuery = z.object({
+  as_of: IsoDate.optional(),
+  currency: CurrencyCode.optional(),
+  include_children: z.coerce.boolean().optional(),
+});
+
+export const RegisterQuery = z.object({
+  from: IsoDate.optional(),
+  to: IsoDate.optional(),
+  include_voided: z.coerce.boolean().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+});

--- a/src/schemas/v1/common.ts
+++ b/src/schemas/v1/common.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared v1 Zod schemas: primitives, error envelope, pagination.
+ *
+ * All schemas call `.openapi(...)` so `@asteasolutions/zod-to-openapi`
+ * registers them under `components/schemas`.
+ */
+import { z } from "zod";
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+
+extendZodWithOpenApi(z);
+
+// ── Primitives ─────────────────────────────────────────────────────────
+
+export const Uuid = z.string().uuid().openapi({ format: "uuid", example: "01HXY9F0ABCDEFGHJKMNPQRSTV" });
+
+export const CurrencyCode = z
+  .string()
+  .regex(/^[A-Z]{3}$/, "ISO 4217 3-letter code, uppercase")
+  .openapi({ example: "USD" });
+
+export const AmountMinor = z
+  .number()
+  .int()
+  .openapi({
+    description:
+      "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). " +
+      "Never store money as float.",
+    example: 14723,
+  });
+
+export const IsoDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .openapi({ format: "date", example: "2026-04-19" });
+
+export const IsoDateTime = z.string().datetime().openapi({ format: "date-time" });
+
+export const Metadata = z
+  .record(z.string(), z.unknown())
+  .default({})
+  .openapi({ description: "User-defined JSON object; not schema-validated." });
+
+// ── Path + query primitives ────────────────────────────────────────────
+
+export const IdParam = z.object({ id: Uuid }).openapi({ title: "IdParam" });
+
+export const CursorQuery = z.object({
+  cursor: z.string().optional().openapi({ description: "Opaque pagination cursor from a previous Link header" }),
+  limit: z.coerce.number().int().min(1).max(500).default(50).optional(),
+});
+
+// ── Error envelope (RFC 7807) ──────────────────────────────────────────
+
+export const Violation = z
+  .object({
+    path: z.string(),
+    code: z.string(),
+    message: z.string().optional(),
+  })
+  .passthrough()
+  .openapi("Violation");
+
+export const ProblemDetails = z
+  .object({
+    type: z.string().url(),
+    title: z.string(),
+    status: z.number().int(),
+    detail: z.string().optional(),
+    instance: z.string().optional(),
+    trace_id: z.string().optional(),
+    violations: z.array(Violation).optional(),
+  })
+  .passthrough()
+  .openapi("ProblemDetails");
+
+// ── List envelope ──────────────────────────────────────────────────────
+
+/**
+ * Wrap a list of items with `next_cursor` (mirror of the Link header,
+ * for clients that can't read response headers — looking at you, some
+ * fetch polyfills).
+ */
+export function paginated<T extends z.ZodTypeAny>(item: T) {
+  return z.object({
+    items: z.array(item),
+    next_cursor: z.string().nullable(),
+  });
+}

--- a/src/schemas/v1/document.ts
+++ b/src/schemas/v1/document.ts
@@ -1,0 +1,43 @@
+/**
+ * Zod schemas for `/v1/documents` and its `links` sub-resource.
+ */
+import { z } from "zod";
+import { IsoDateTime, Uuid } from "./common.js";
+
+export const DocumentKind = z.enum([
+  "receipt_image",
+  "receipt_email",
+  "receipt_pdf",
+  "statement_pdf",
+  "other",
+]);
+
+export const Document = z
+  .object({
+    id: Uuid,
+    workspace_id: Uuid,
+    kind: DocumentKind,
+    file_path: z.string().nullable(),
+    mime_type: z.string().nullable(),
+    sha256: z.string(),
+    ocr_text: z.string().nullable(),
+    extraction_meta: z.record(z.string(), z.unknown()).nullable(),
+    source_ingest_id: Uuid.nullable(),
+    created_at: IsoDateTime,
+    updated_at: IsoDateTime,
+  })
+  .openapi("Document");
+
+export const CreateDocumentLinkRequest = z
+  .object({ transaction_id: Uuid })
+  .openapi("CreateDocumentLinkRequest");
+
+// Multipart form is described inline in the route registration;
+// Zod can't fully model multipart, but we register the field shape
+// so the OpenAPI docs reflect the expected client contract.
+export const UploadDocumentForm = z
+  .object({
+    file: z.any().openapi({ type: "string", format: "binary" }),
+    kind: DocumentKind.optional(),
+  })
+  .openapi("UploadDocumentForm");

--- a/src/schemas/v1/index.ts
+++ b/src/schemas/v1/index.ts
@@ -1,0 +1,4 @@
+export * from "./common.js";
+export * from "./account.js";
+export * from "./transaction.js";
+export * from "./document.js";

--- a/src/schemas/v1/transaction.ts
+++ b/src/schemas/v1/transaction.ts
@@ -1,0 +1,166 @@
+/**
+ * Zod schemas for `/v1/transactions` and its nested `postings`.
+ */
+import { z } from "zod";
+import {
+  AmountMinor,
+  CurrencyCode,
+  IsoDate,
+  IsoDateTime,
+  Metadata,
+  Uuid,
+} from "./common.js";
+
+export const TxnStatus = z.enum([
+  "draft",
+  "posted",
+  "voided",
+  "reconciled",
+  "error",
+]);
+
+export const Posting = z
+  .object({
+    id: Uuid,
+    transaction_id: Uuid,
+    account_id: Uuid,
+    amount_minor: AmountMinor,
+    currency: CurrencyCode,
+    fx_rate: z.string().nullable(), // numeric returned as string from pg
+    amount_base_minor: AmountMinor.nullable(),
+    memo: z.string().nullable(),
+    created_at: IsoDateTime,
+  })
+  .openapi("Posting");
+
+export const NewPosting = z
+  .object({
+    account_id: Uuid,
+    amount_minor: AmountMinor,
+    currency: CurrencyCode.optional(),
+    fx_rate: z.string().optional(),
+    amount_base_minor: AmountMinor.optional(),
+    memo: z.string().optional(),
+  })
+  .openapi("NewPosting");
+
+export const TransactionDocumentRef = z
+  .object({
+    id: Uuid,
+    kind: z.string(),
+  })
+  .openapi("TransactionDocumentRef");
+
+export const Transaction = z
+  .object({
+    id: Uuid,
+    workspace_id: Uuid,
+    occurred_on: IsoDate,
+    occurred_at: IsoDateTime.nullable(),
+    payee: z.string().nullable(),
+    narration: z.string().nullable(),
+    status: TxnStatus,
+    voided_by_id: Uuid.nullable(),
+    source_ingest_id: Uuid.nullable(),
+    trip_id: Uuid.nullable(),
+    metadata: Metadata,
+    version: z.number().int(),
+    created_at: IsoDateTime,
+    updated_at: IsoDateTime,
+    postings: z.array(Posting),
+    documents: z.array(TransactionDocumentRef),
+  })
+  .openapi("Transaction");
+
+export const CreateTransactionRequest = z
+  .object({
+    occurred_on: IsoDate,
+    occurred_at: IsoDateTime.optional(),
+    payee: z.string().optional(),
+    narration: z.string().optional(),
+    status: TxnStatus.optional(), // defaults to 'posted'
+    postings: z.array(NewPosting).min(2),
+    document_ids: z.array(Uuid).optional(),
+    trip_id: Uuid.optional(),
+    metadata: Metadata.optional(),
+  })
+  .openapi("CreateTransactionRequest");
+
+export const UpdateTransactionRequest = z
+  .object({
+    occurred_on: IsoDate.optional(),
+    occurred_at: IsoDateTime.nullable().optional(),
+    payee: z.string().nullable().optional(),
+    narration: z.string().nullable().optional(),
+    trip_id: Uuid.nullable().optional(),
+    metadata: Metadata.optional(),
+  })
+  .openapi("UpdateTransactionRequest");
+
+export const VoidTransactionRequest = z
+  .object({
+    reason: z.string().optional(),
+  })
+  .openapi("VoidTransactionRequest");
+
+export const UpdatePostingRequest = z
+  .object({
+    account_id: Uuid.optional(),
+    amount_minor: AmountMinor.optional(),
+    currency: CurrencyCode.optional(),
+    fx_rate: z.string().optional(),
+    amount_base_minor: AmountMinor.optional(),
+    memo: z.string().nullable().optional(),
+  })
+  .openapi("UpdatePostingRequest");
+
+// Filter surface for GET /v1/transactions
+export const ListTransactionsQuery = z.object({
+  occurred_from: IsoDate.optional(),
+  occurred_to: IsoDate.optional(),
+  amount_min_minor: z.coerce.number().int().optional(),
+  amount_max_minor: z.coerce.number().int().optional(),
+  account_id: Uuid.optional(),
+  payee_contains: z.string().optional(),
+  q: z.string().optional(),
+  status: TxnStatus.optional(),
+  trip_id: Uuid.optional(),
+  has_document: z.coerce.boolean().optional(),
+  source_ingest_id: Uuid.optional(),
+  sort: z.enum(["occurred_on", "amount", "created_at"]).optional(),
+  order: z.enum(["asc", "desc"]).optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+});
+
+export const ListPostingsQuery = z.object({
+  transaction_id: Uuid.optional(),
+  account_id: Uuid.optional(),
+  from: IsoDate.optional(),
+  to: IsoDate.optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+});
+
+// Bulk operations (RPC-style)
+export const BulkOperation = z.discriminatedUnion("op", [
+  z.object({ op: z.literal("update"), id: Uuid, if_match: z.string(), patch: UpdateTransactionRequest }),
+  z.object({ op: z.literal("void"),   id: Uuid, if_match: z.string(), reason: z.string().optional() }),
+  z.object({ op: z.literal("reconcile"), id: Uuid, if_match: z.string() }),
+]);
+
+export const BulkRequest = z
+  .object({ operations: z.array(BulkOperation).min(1).max(100) })
+  .openapi("BulkRequest");
+
+export const BulkResultItem = z
+  .object({
+    index: z.number().int(),
+    status: z.number().int(),
+    body: z.unknown(),
+  })
+  .openapi("BulkResultItem");
+
+export const BulkResponse = z
+  .object({ results: z.array(BulkResultItem) })
+  .openapi("BulkResponse");

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,89 +1,38 @@
 /**
  * HTTP + MCP entrypoint.
  *
- * Post-refactor state (epic #28 in progress):
- *   - Old `/receipt*`, `/jobs/*`, `/summary`, `/ask` endpoints removed.
- *   - New `/v1/*` surface (transactions, accounts, documents) is being
- *     built out under #35 and #36 and will land here in follow-up PRs.
- *
- * This file currently exposes only:
- *   - `GET  /health`
- *   - `GET  /openapi.json`
- *   - `GET  /docs`
- *
  * Boot sequence:
- *   1. Run pending Drizzle migrations (from the committed `drizzle/`
- *      folder). Fail fast on any migration error.
- *   2. Start the MCP server (currently with no tools registered).
- *   3. Start the Express HTTP server.
+ *   1. Run pending Drizzle migrations. Fail fast on any migration error.
+ *   2. Idempotent seed (default workspace + chart of accounts).
+ *   3. Start MCP server with registered v1 tools.
+ *   4. Start Express HTTP server built from `buildApp()`.
  */
 import "dotenv/config";
 import { FastMCP } from "fastmcp";
-import express, {
-  type Request,
-  type Response,
-  type NextFunction,
-} from "express";
-import swaggerUi from "swagger-ui-express";
-import { buildOpenApiDocument } from "./openapi.js";
+import { buildApp } from "./app.js";
 import { runMigrations } from "./db/migrate.js";
 import { seed } from "./db/seed.js";
+import { registerAccountsMcpTools } from "./mcp/accounts.js";
+import { registerTransactionsMcpTools } from "./mcp/transactions.js";
+import { registerDocumentsMcpTools } from "./mcp/documents.js";
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
 const MCP_PORT = parseInt(process.env.MCP_PORT ?? "3001", 10);
-
-// ── MCP server (empty scaffold; tools ship with v1 resource PRs) ────────
 
 const mcp = new FastMCP({
   name: "receipt-assistant",
   version: "2.0.0",
 });
 
-// ── HTTP server ─────────────────────────────────────────────────────────
-
-const app = express();
-app.use(express.json());
-
-const openApiDoc = buildOpenApiDocument();
-app.get("/openapi.json", (_req: Request, res: Response) => {
-  res.json(openApiDoc);
-});
-app.use(
-  "/docs",
-  swaggerUi.serve,
-  swaggerUi.setup(openApiDoc, {
-    customSiteTitle: "Receipt Assistant API",
-    swaggerOptions: { persistAuthorization: true },
-  }),
-);
-
-// Optional bearer-token gate (no-op when AUTH_TOKEN is unset).
-const AUTH_TOKEN = process.env.AUTH_TOKEN;
-function authMiddleware(req: Request, res: Response, next: NextFunction) {
-  if (!AUTH_TOKEN) return next();
-  const token = req.headers.authorization?.replace("Bearer ", "");
-  if (token !== AUTH_TOKEN) {
-    res.status(401).json({ error: "Unauthorized" });
-    return;
-  }
-  next();
-}
-app.use(authMiddleware);
-
-app.get("/health", (_req: Request, res: Response) => {
-  res.json({ status: "ok", service: "receipt-assistant", version: "2.0.0-alpha" });
-});
-
-// ── Startup ─────────────────────────────────────────────────────────────
+registerAccountsMcpTools(mcp);
+registerTransactionsMcpTools(mcp);
+registerDocumentsMcpTools(mcp);
 
 async function main(): Promise<void> {
   console.log("🗄️  Running Drizzle migrations…");
   await runMigrations();
   console.log("✅ Migrations complete");
 
-  // Idempotent seed — no-op if the default workspace already exists.
-  // Opt out with SEED_ON_BOOT=false for production workspaces that
-  // own their own chart-of-accounts bootstrap.
   if (process.env.SEED_ON_BOOT !== "false") {
     const r = await seed();
     console.log(
@@ -99,15 +48,16 @@ async function main(): Promise<void> {
   });
   console.log(`🔌 MCP server listening on http://0.0.0.0:${MCP_PORT}/mcp`);
 
+  const app = buildApp();
   app.listen(PORT, "0.0.0.0", () => {
     console.log(`🌐 HTTP API listening on http://0.0.0.0:${PORT}`);
     console.log(`
-📋 Active endpoints:
-   GET  /health          — health check
-   GET  /openapi.json    — OpenAPI 3.1 spec (v2.0.0-alpha)
-   GET  /docs            — interactive Swagger UI
-
-🚧 v1 resources (transactions / accounts / documents) land under #35 and #36.
+📋 Endpoints:
+   GET  /health · /openapi.json · /docs
+   /v1/accounts        — chart of accounts + balance + register
+   /v1/transactions    — double-entry ledger CRUD + postings + void
+   /v1/postings        — read-only posting search
+   /v1/documents       — multipart upload + link to transactions
     `);
   });
 }

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Integration tests for /v1/accounts — CRUD + balance + register.
+ *
+ * Exercises the full Express app via supertest against the per-suite
+ * testcontainers Postgres. The ledger invariants (balance trigger,
+ * version/updated_at bump) are covered in schema.test.ts; this file
+ * focuses on the HTTP contract: headers, status codes, problem+json,
+ * tree/flat list, keyset pagination, register reconciliation.
+ */
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import { Router } from "express";
+import { sql } from "drizzle-orm";
+import { v7 as uuidv7 } from "uuid";
+
+// ── Concurrent-agent insulation ─────────────────────────────────────────
+// The `transactions` and `documents` routers are being written by
+// other agents under sister sub-issues. At the time this file runs,
+// those modules may contain Express-4 path-to-regexp syntax that
+// crashes Express 5 at route-registration time, which would prevent
+// `buildApp()` (invoked by withTestDb) from ever returning. We stub
+// them out at the module-resolution layer so our test suite can start.
+vi.mock("../../src/routes/transactions.js", () => ({
+  transactionsRouter: Router(),
+  registerTransactionsOpenApi: () => {},
+}));
+vi.mock("../../src/routes/documents.js", () => ({
+  documentsRouter: Router(),
+  registerDocumentsOpenApi: () => {},
+}));
+vi.mock("../../src/routes/postings.js", () => ({
+  postingsRouter: Router(),
+  registerPostingsOpenApi: () => {},
+}));
+
+import { withTestDb } from "../setup/db.js";
+import {
+  accounts,
+  transactions,
+  postings,
+} from "../../src/schema/index.js";
+
+const ctx = withTestDb();
+
+async function accountIdByName(name: string): Promise<string> {
+  const rows = await ctx.db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(sql`${accounts.workspaceId} = ${ctx.workspaceId} AND ${accounts.name} = ${name}`);
+  if (rows.length === 0) throw new Error(`Account not found: ${name}`);
+  return rows[0]!.id;
+}
+
+async function insertBalancedTxn(opts: {
+  occurredOn: string;
+  debitAccountId: string;
+  creditAccountId: string;
+  amountMinor: bigint;
+  payee?: string;
+}): Promise<string> {
+  const txId = uuidv7();
+  await ctx.db.transaction(async (tx) => {
+    await tx.insert(transactions).values({
+      id: txId,
+      workspaceId: ctx.workspaceId,
+      occurredOn: opts.occurredOn,
+      payee: opts.payee ?? "Test Payee",
+      status: "posted",
+    });
+    await tx.insert(postings).values([
+      {
+        id: uuidv7(),
+        workspaceId: ctx.workspaceId,
+        transactionId: txId,
+        accountId: opts.debitAccountId,
+        amountMinor: opts.amountMinor,
+        currency: "USD",
+        amountBaseMinor: opts.amountMinor,
+      },
+      {
+        id: uuidv7(),
+        workspaceId: ctx.workspaceId,
+        transactionId: txId,
+        accountId: opts.creditAccountId,
+        amountMinor: -opts.amountMinor,
+        currency: "USD",
+        amountBaseMinor: -opts.amountMinor,
+      },
+    ]);
+  });
+  return txId;
+}
+
+describe("GET /v1/accounts (list)", () => {
+  it("returns the 5-branch tree by default", async () => {
+    const res = await request(ctx.app).get("/v1/accounts");
+    expect(res.status).toBe(200);
+    const roots = res.body as Array<{ name: string; children: unknown[] }>;
+    expect(Array.isArray(roots)).toBe(true);
+    expect(roots).toHaveLength(5);
+    const rootNames = roots.map((r) => r.name).sort();
+    expect(rootNames).toEqual([
+      "Assets",
+      "Equity",
+      "Expenses",
+      "Income",
+      "Liabilities",
+    ]);
+    // Total-across-tree count should equal 18 (seed).
+    const countAll = (nodes: any[]): number =>
+      nodes.reduce((acc, n) => acc + 1 + countAll(n.children ?? []), 0);
+    expect(countAll(roots)).toBe(18);
+  });
+
+  it("returns a flat list when ?flat=true", async () => {
+    const res = await request(ctx.app).get("/v1/accounts?flat=true");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(18);
+    for (const a of res.body as any[]) {
+      expect(typeof a.id).toBe("string");
+      expect(typeof a.name).toBe("string");
+      expect(a.children).toBeUndefined();
+    }
+  });
+});
+
+describe("POST /v1/accounts (create)", () => {
+  it("creates a new expense sub-account under Expenses", async () => {
+    const expensesRoot = await accountIdByName("Expenses");
+    const res = await request(ctx.app)
+      .post("/v1/accounts")
+      .send({
+        parent_id: expensesRoot,
+        name: "Coffee",
+        type: "expense",
+      });
+    expect(res.status).toBe(201);
+    expect(res.headers.location).toMatch(/^\/v1\/accounts\/[0-9a-f-]{36}$/);
+    expect(res.headers.etag).toBe('W/"1"');
+    const body = res.body;
+    expect(body).toMatchObject({
+      parent_id: expensesRoot,
+      name: "Coffee",
+      type: "expense",
+      currency: "USD", // inherited from parent
+      version: 1,
+    });
+    expect(typeof body.id).toBe("string");
+    expect(typeof body.created_at).toBe("string");
+  });
+
+  it("rejects a child whose type does not match its parent (422)", async () => {
+    const assets = await accountIdByName("Assets");
+    const res = await request(ctx.app)
+      .post("/v1/accounts")
+      .send({
+        parent_id: assets,
+        name: "Misplaced",
+        type: "expense", // parent is asset
+      });
+    expect(res.status).toBe(422);
+    expect(res.headers["content-type"]).toMatch(/application\/problem\+json/);
+    expect(res.body.type).toMatch(/\/errors\/validation$/);
+    const paths = (res.body.violations ?? []).map((v: any) => v.path);
+    expect(paths).toContain("type");
+  });
+
+  it("inherits currency from workspace base when no parent given", async () => {
+    const res = await request(ctx.app)
+      .post("/v1/accounts")
+      .send({ name: "Floating Root", type: "asset" });
+    expect(res.status).toBe(201);
+    expect(res.body.currency).toBe("USD");
+    expect(res.body.parent_id).toBeNull();
+  });
+});
+
+describe("GET /v1/accounts/:id + If-None-Match", () => {
+  it("returns a single account with ETag", async () => {
+    const id = await accountIdByName("Dining");
+    const res = await request(ctx.app).get(`/v1/accounts/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.etag).toBeDefined();
+    expect(res.body.id).toBe(id);
+  });
+
+  it("returns 304 when If-None-Match matches", async () => {
+    const id = await accountIdByName("Dining");
+    const r1 = await request(ctx.app).get(`/v1/accounts/${id}`);
+    const etag = r1.headers.etag as string;
+    const r2 = await request(ctx.app)
+      .get(`/v1/accounts/${id}`)
+      .set("If-None-Match", etag);
+    expect(r2.status).toBe(304);
+  });
+});
+
+describe("PATCH /v1/accounts/:id (If-Match semantics)", () => {
+  it("updates when If-Match is correct, bumps version", async () => {
+    const id = await accountIdByName("Transport");
+    const r1 = await request(ctx.app).get(`/v1/accounts/${id}`);
+    const etag = r1.headers.etag as string;
+    const beforeVersion = r1.body.version as number;
+
+    const r2 = await request(ctx.app)
+      .patch(`/v1/accounts/${id}`)
+      .set("If-Match", etag)
+      .send({ name: "Transportation" });
+    expect(r2.status).toBe(200);
+    expect(r2.body.name).toBe("Transportation");
+    expect(r2.body.version).toBe(beforeVersion + 1);
+    expect(r2.headers.etag).toBe(`W/"${beforeVersion + 1}"`);
+  });
+
+  it("rejects missing If-Match with 428", async () => {
+    const id = await accountIdByName("Utilities");
+    const res = await request(ctx.app)
+      .patch(`/v1/accounts/${id}`)
+      .send({ name: "Utilities & Bills" });
+    expect(res.status).toBe(428);
+    expect(res.headers["content-type"]).toMatch(/application\/problem\+json/);
+    expect(res.body.type).toMatch(/\/errors\/precondition-required$/);
+  });
+
+  it("rejects wrong If-Match with 412 + current_version", async () => {
+    const id = await accountIdByName("Entertainment");
+    const res = await request(ctx.app)
+      .patch(`/v1/accounts/${id}`)
+      .set("If-Match", 'W/"999"')
+      .send({ name: "Fun" });
+    expect(res.status).toBe(412);
+    expect(res.body.type).toMatch(/\/errors\/version-mismatch$/);
+    expect(res.body.current_version).toBeGreaterThanOrEqual(1);
+    expect(res.body.supplied_version).toBe(999);
+  });
+});
+
+describe("DELETE /v1/accounts/:id", () => {
+  it("hard-deletes an unused account; then returns 404", async () => {
+    // Create a disposable leaf.
+    const expenses = await accountIdByName("Expenses");
+    const r1 = await request(ctx.app)
+      .post("/v1/accounts")
+      .send({ parent_id: expenses, name: "Disposable", type: "expense" });
+    expect(r1.status).toBe(201);
+    const id = r1.body.id;
+    const etag = r1.headers.etag as string;
+
+    const r2 = await request(ctx.app)
+      .delete(`/v1/accounts/${id}`)
+      .set("If-Match", etag);
+    expect(r2.status).toBe(204);
+
+    const r3 = await request(ctx.app).get(`/v1/accounts/${id}`);
+    expect(r3.status).toBe(404);
+    expect(r3.body.type).toMatch(/\/errors\/not-found$/);
+
+    const r4 = await request(ctx.app)
+      .delete(`/v1/accounts/${id}`)
+      .set("If-Match", etag);
+    expect(r4.status).toBe(404);
+  });
+
+  it("refuses to delete an account with postings (409 account-in-use)", async () => {
+    const groceries = await accountIdByName("Groceries");
+    const visa = await accountIdByName("Credit Card");
+
+    await insertBalancedTxn({
+      occurredOn: "2026-02-10",
+      debitAccountId: groceries,
+      creditAccountId: visa,
+      amountMinor: 500n,
+      payee: "Bodega",
+    });
+
+    const r1 = await request(ctx.app).get(`/v1/accounts/${groceries}`);
+    const etag = r1.headers.etag as string;
+    const r2 = await request(ctx.app)
+      .delete(`/v1/accounts/${groceries}`)
+      .set("If-Match", etag);
+    expect(r2.status).toBe(409);
+    expect(r2.body.type).toMatch(/\/errors\/account-in-use$/);
+    expect(r2.body.account_id).toBe(groceries);
+    expect(r2.body.posting_count).toBeGreaterThan(0);
+  });
+});
+
+describe("GET /v1/accounts/:id/balance", () => {
+  it("returns 0 for a fresh leaf with no postings", async () => {
+    // Use a fresh child we create here; Transport/Dining may have been
+    // touched by earlier suites via PATCH but should still have zero
+    // postings unless another suite wrote.
+    const expenses = await accountIdByName("Expenses");
+    const r = await request(ctx.app)
+      .post("/v1/accounts")
+      .send({ parent_id: expenses, name: "BalanceTestLeaf", type: "expense" });
+    expect(r.status).toBe(201);
+    const id = r.body.id as string;
+
+    const res = await request(ctx.app).get(
+      `/v1/accounts/${id}/balance?as_of=2026-12-31`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      account_id: id,
+      as_of: "2026-12-31",
+      balance_minor: 0,
+      currency: "USD",
+      posting_count: 0,
+      includes_children: false,
+    });
+  });
+
+  it("sums postings up to as_of", async () => {
+    const dining = await accountIdByName("Dining");
+    const cash = await accountIdByName("Cash");
+
+    await insertBalancedTxn({
+      occurredOn: "2026-02-14",
+      debitAccountId: dining,
+      creditAccountId: cash,
+      amountMinor: 2500n,
+      payee: "Valentine",
+    });
+    await insertBalancedTxn({
+      occurredOn: "2026-03-01",
+      debitAccountId: dining,
+      creditAccountId: cash,
+      amountMinor: 1200n,
+      payee: "Brunch",
+    });
+
+    const r1 = await request(ctx.app).get(
+      `/v1/accounts/${dining}/balance?as_of=2026-02-20`,
+    );
+    expect(r1.status).toBe(200);
+    expect(r1.body.balance_minor).toBe(2500);
+    expect(r1.body.posting_count).toBe(1);
+
+    const r2 = await request(ctx.app).get(
+      `/v1/accounts/${dining}/balance?as_of=2026-12-31`,
+    );
+    expect(r2.body.balance_minor).toBe(3700);
+    expect(r2.body.posting_count).toBe(2);
+  });
+
+  it("include_children sums the whole subtree", async () => {
+    const expenses = await accountIdByName("Expenses");
+    const cash = await accountIdByName("Cash");
+    const transport = await accountIdByName("Transportation"); // renamed earlier
+    // Add a posting to Transportation
+    await insertBalancedTxn({
+      occurredOn: "2026-04-01",
+      debitAccountId: transport,
+      creditAccountId: cash,
+      amountMinor: 4321n,
+      payee: "Uber",
+    });
+
+    const withoutChildren = await request(ctx.app).get(
+      `/v1/accounts/${expenses}/balance?as_of=2026-12-31`,
+    );
+    expect(withoutChildren.body.balance_minor).toBe(0); // root itself has no postings
+
+    const withChildren = await request(ctx.app).get(
+      `/v1/accounts/${expenses}/balance?as_of=2026-12-31&include_children=true`,
+    );
+    expect(withChildren.body.includes_children).toBe(true);
+    expect(withChildren.body.balance_minor).toBeGreaterThan(0);
+    // Must include the Uber + Dining + Bodega rows.
+    expect(withChildren.body.balance_minor).toBeGreaterThanOrEqual(
+      500 + 2500 + 1200 + 4321,
+    );
+  });
+});
+
+describe("GET /v1/accounts/:id/register", () => {
+  it("returns items with monotonic running balance + counter_postings", async () => {
+    // Use a fresh asset account so we control the full posting sequence.
+    const ws = ctx.workspaceId;
+    const createRes = await request(ctx.app)
+      .post("/v1/accounts")
+      .send({ name: "RegTestChecking", type: "asset" });
+    expect(createRes.status).toBe(201);
+    const checking = createRes.body.id as string;
+    void ws;
+
+    const coffeeRes = await request(ctx.app)
+      .post("/v1/accounts")
+      .send({ name: "RegTestCoffee", type: "expense" });
+    const coffee = coffeeRes.body.id as string;
+
+    // 3 txns (chronological)
+    await insertBalancedTxn({
+      occurredOn: "2026-03-10",
+      debitAccountId: checking,
+      creditAccountId: coffee, // we'll put coffee as "income side" even though it's expense — flipped sign, just for a balanced test txn
+      amountMinor: 1000n,
+      payee: "Opening Deposit",
+    });
+    await insertBalancedTxn({
+      occurredOn: "2026-03-11",
+      debitAccountId: coffee,
+      creditAccountId: checking,
+      amountMinor: 500n,
+      payee: "Coffee Shop",
+    });
+    await insertBalancedTxn({
+      occurredOn: "2026-03-12",
+      debitAccountId: coffee,
+      creditAccountId: checking,
+      amountMinor: 300n,
+      payee: "Espresso Bar",
+    });
+
+    const res = await request(ctx.app).get(
+      `/v1/accounts/${checking}/register`,
+    );
+    expect(res.status).toBe(200);
+    const items = res.body.items as Array<{
+      occurred_on: string;
+      amount_minor: number;
+      running_balance_after_minor: number;
+      counter_postings: Array<{ name: string; amount_minor: number }>;
+    }>;
+    expect(items).toHaveLength(3);
+    // Most-recent first
+    expect(items.map((i) => i.occurred_on)).toEqual([
+      "2026-03-12",
+      "2026-03-11",
+      "2026-03-10",
+    ]);
+    // Running balance: chronological prefix sums (oldest first):
+    //   day 10: +1000 → 1000
+    //   day 11: -500 → 500
+    //   day 12: -300 → 200
+    // But rows are *displayed* most-recent first, so the top row should
+    // show the last cumulative value.
+    expect(items[0]!.running_balance_after_minor).toBe(200);
+    expect(items[1]!.running_balance_after_minor).toBe(500);
+    expect(items[2]!.running_balance_after_minor).toBe(1000);
+
+    // Every item should have exactly 1 counter posting (the other leg).
+    for (const it of items) {
+      expect(it.counter_postings).toHaveLength(1);
+      expect(typeof it.counter_postings[0]!.name).toBe("string");
+      expect(typeof it.counter_postings[0]!.amount_minor).toBe("number");
+    }
+    expect(res.body.next_cursor).toBeNull();
+  });
+
+  it("paginates via cursor (limit=2 → next → 3rd)", async () => {
+    // Reuse the RegTestChecking account with 3 postings.
+    const id = (
+      await ctx.db
+        .select({ id: accounts.id })
+        .from(accounts)
+        .where(sql`${accounts.workspaceId} = ${ctx.workspaceId} AND ${accounts.name} = 'RegTestChecking'`)
+    )[0]!.id;
+
+    const page1 = await request(ctx.app).get(
+      `/v1/accounts/${id}/register?limit=2`,
+    );
+    expect(page1.status).toBe(200);
+    expect(page1.body.items).toHaveLength(2);
+    expect(page1.body.next_cursor).toBeTruthy();
+    expect(page1.headers.link).toMatch(/rel="next"/);
+
+    const cursor = page1.body.next_cursor as string;
+    const page2 = await request(ctx.app).get(
+      `/v1/accounts/${id}/register?limit=2&cursor=${encodeURIComponent(cursor)}`,
+    );
+    expect(page2.status).toBe(200);
+    expect(page2.body.items).toHaveLength(1);
+    expect(page2.body.next_cursor).toBeNull();
+
+    // Combined should match the non-paginated listing.
+    const all = [
+      ...(page1.body.items as any[]),
+      ...(page2.body.items as any[]),
+    ];
+    expect(all.map((i) => i.occurred_on)).toEqual([
+      "2026-03-12",
+      "2026-03-11",
+      "2026-03-10",
+    ]);
+  });
+
+  it("register last-row running_balance equals balance.balance_minor for same as_of", async () => {
+    const id = (
+      await ctx.db
+        .select({ id: accounts.id })
+        .from(accounts)
+        .where(sql`${accounts.workspaceId} = ${ctx.workspaceId} AND ${accounts.name} = 'RegTestChecking'`)
+    )[0]!.id;
+
+    const reg = await request(ctx.app).get(
+      `/v1/accounts/${id}/register?to=2026-12-31`,
+    );
+    const items = reg.body.items as any[];
+    // Oldest row is at the end of the descending list.
+    const oldestRunning =
+      items[items.length - 1].running_balance_after_minor;
+    void oldestRunning;
+    // The top (most recent) row's running balance is the cumulative
+    // total as of that row, which — when no later rows exist — equals
+    // the as-of balance for the full set.
+    const mostRecentRunning = items[0].running_balance_after_minor;
+
+    const bal = await request(ctx.app).get(
+      `/v1/accounts/${id}/balance?as_of=2026-12-31`,
+    );
+    expect(bal.status).toBe(200);
+    expect(mostRecentRunning).toBe(bal.body.balance_minor);
+  });
+});

--- a/tests/integration/documents.test.ts
+++ b/tests/integration/documents.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Integration tests for `/v1/documents` and its links sub-resource.
+ *
+ * Covers:
+ *   1. Upload + sha256 content-dedup + mutation produces new doc
+ *   2. GET metadata + ETag / If-None-Match
+ *   3. GET /content streams the bytes with Content-Type
+ *   4. POST /links + idempotent replay
+ *   5. DELETE /links + 404 on re-delete
+ *   6. DELETE /documents with no links
+ *   7. DELETE /documents with a link → 409 document-has-links
+ *
+ * Note on test isolation: this suite builds its own minimal Express app
+ * with only the documents router mounted, rather than calling the
+ * project-wide `buildApp()`. That keeps the suite green even while
+ * sibling agents (transactions / accounts) are mid-implementation.
+ */
+import {
+  beforeAll,
+  beforeEach,
+  afterAll,
+  describe,
+  it,
+  expect,
+} from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+import type { Express } from "express";
+import request from "supertest";
+import { v7 as uuidv7 } from "uuid";
+import { sql } from "drizzle-orm";
+import pg from "pg";
+import { drizzle } from "drizzle-orm/node-postgres";
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+
+import * as schema from "../../src/schema/index.js";
+import { transactions, postings, accounts } from "../../src/schema/index.js";
+
+interface Ctx {
+  container: StartedPostgreSqlContainer;
+  pool: pg.Pool;
+  db: ReturnType<typeof drizzle<typeof schema>>;
+  app: Express;
+  workspaceId: string;
+}
+
+const ctx = {} as Ctx;
+let UPLOAD_DIR: string;
+
+beforeAll(async () => {
+  UPLOAD_DIR = mkdtempSync(path.join(tmpdir(), "ra-uploads-"));
+  process.env.UPLOAD_DIR = UPLOAD_DIR;
+
+  ctx.container = await new PostgreSqlContainer("postgres:17").start();
+  process.env.DATABASE_URL = ctx.container.getConnectionUri();
+
+  // Dynamic imports AFTER DATABASE_URL is set — otherwise the default
+  // `db/client.ts` pool binds to localhost:5432 at module-load time and
+  // the whole suite races Postgres.
+  const { runMigrations } = await import("../../src/db/migrate.js");
+  await runMigrations();
+
+  const { seed, SEED_WORKSPACE_ID } = await import("../../src/db/seed.js");
+  const r = await seed();
+  if (!r.created) throw new Error("Seed must run clean on empty container");
+
+  ctx.pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+  ctx.db = drizzle(ctx.pool, { schema });
+  ctx.workspaceId = SEED_WORKSPACE_ID;
+
+  const { default: express } = await import("express");
+  const { contextMiddleware } = await import("../../src/http/context.js");
+  const { problemHandler } = await import("../../src/http/problem.js");
+  const { documentsRouter } = await import("../../src/routes/documents.js");
+
+  // Minimal app — only `/v1/documents` is mounted, so sibling agents
+  // working on `/v1/transactions` can't break this suite.
+  const app = express();
+  app.set("trust proxy", true);
+  app.use(express.json({ limit: "25mb" }));
+  app.use(contextMiddleware);
+  app.use("/v1/documents", documentsRouter);
+  app.use(problemHandler);
+  ctx.app = app;
+}, 120_000);
+
+afterAll(async () => {
+  if (ctx.pool) await ctx.pool.end();
+  const { pool: seedPool } = await import("../../src/db/client.js");
+  await seedPool.end().catch(() => {});
+  if (ctx.container) await ctx.container.stop();
+  try {
+    rmSync(UPLOAD_DIR, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup only
+  }
+}, 120_000);
+
+let payloadCounter = 0;
+function makeBytes(tag: string): Buffer {
+  payloadCounter += 1;
+  return Buffer.from(
+    `fake-jpeg-${tag}-${payloadCounter}-${Date.now()}-${Math.random()}`,
+  );
+}
+
+async function accountIdByName(name: string): Promise<string> {
+  const rows = await ctx.db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(
+      sql`${accounts.workspaceId} = ${ctx.workspaceId} AND ${accounts.name} = ${name}`,
+    );
+  if (rows.length === 0) throw new Error(`Account not found: ${name}`);
+  return rows[0]!.id;
+}
+
+/**
+ * Seed a balanced, posted transaction so tests have a real target for
+ * document_links. Uses the DB layer directly — the Transactions API is
+ * being built in a sibling agent and is not a dependency.
+ */
+async function seedTransaction(): Promise<string> {
+  const groceries = await accountIdByName("Groceries");
+  const visa = await accountIdByName("Credit Card");
+  const txId = uuidv7();
+  await ctx.db.transaction(async (tx) => {
+    await tx.insert(transactions).values({
+      id: txId,
+      workspaceId: ctx.workspaceId,
+      occurredOn: "2026-04-19",
+      payee: "Test Vendor",
+    });
+    await tx.insert(postings).values([
+      {
+        id: uuidv7(),
+        workspaceId: ctx.workspaceId,
+        transactionId: txId,
+        accountId: groceries,
+        amountMinor: 1000n,
+        currency: "USD",
+        amountBaseMinor: 1000n,
+      },
+      {
+        id: uuidv7(),
+        workspaceId: ctx.workspaceId,
+        transactionId: txId,
+        accountId: visa,
+        amountMinor: -1000n,
+        currency: "USD",
+        amountBaseMinor: -1000n,
+      },
+    ]);
+  });
+  return txId;
+}
+
+describe("POST /v1/documents — upload + content-dedup", () => {
+  it("creates a new document on first upload, returns 201 + Location + ETag", async () => {
+    const bytes = makeBytes("upload-create");
+    const res = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytes, { filename: "r1.jpg", contentType: "image/jpeg" })
+      .field("kind", "receipt_image");
+
+    expect(res.status).toBe(201);
+    expect(res.headers.location).toBe(`/v1/documents/${res.body.id}`);
+    expect(res.headers.etag).toBe('W/"1"');
+    expect(res.body).toMatchObject({
+      kind: "receipt_image",
+      mime_type: "image/jpeg",
+      workspace_id: ctx.workspaceId,
+    });
+    expect(res.body.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(res.body.file_path).toContain(UPLOAD_DIR);
+  });
+
+  it("returns the existing row with 200 when the same bytes are re-uploaded", async () => {
+    const bytes = makeBytes("upload-dedup");
+
+    const first = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytes, { filename: "r2.jpg", contentType: "image/jpeg" })
+      .field("kind", "receipt_image");
+    expect(first.status).toBe(201);
+    const originalId = first.body.id;
+
+    const second = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytes, {
+        filename: "r2-again.jpg",
+        contentType: "image/jpeg",
+      });
+    expect(second.status).toBe(200);
+    expect(second.body.id).toBe(originalId);
+    expect(second.body.sha256).toBe(first.body.sha256);
+  });
+
+  it("creates a distinct document when a single byte changes", async () => {
+    const bytesA = makeBytes("upload-mutate-A");
+    const bytesB = Buffer.concat([bytesA, Buffer.from("X")]);
+
+    const a = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytesA, { filename: "a.jpg", contentType: "image/jpeg" });
+    const b = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytesB, { filename: "b.jpg", contentType: "image/jpeg" });
+
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+    expect(a.body.id).not.toBe(b.body.id);
+    expect(a.body.sha256).not.toBe(b.body.sha256);
+  });
+
+  it("defaults kind to `other` when the form field is omitted", async () => {
+    const bytes = makeBytes("default-kind");
+    const res = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytes, {
+        filename: "x.bin",
+        contentType: "application/octet-stream",
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.kind).toBe("other");
+  });
+
+  it("rejects a request with no `file` field", async () => {
+    const res = await request(ctx.app)
+      .post("/v1/documents")
+      .field("kind", "other");
+    expect(res.status).toBe(422);
+    expect(res.headers["content-type"]).toContain(
+      "application/problem+json",
+    );
+  });
+});
+
+describe("GET /v1/documents/:id", () => {
+  it("returns 200 + ETag on hit, and 304 when If-None-Match matches", async () => {
+    const bytes = makeBytes("get-meta");
+    const created = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytes, { filename: "g.jpg", contentType: "image/jpeg" });
+    expect(created.status).toBe(201);
+    const id = created.body.id;
+
+    const hit = await request(ctx.app).get(`/v1/documents/${id}`);
+    expect(hit.status).toBe(200);
+    expect(hit.headers.etag).toBe('W/"1"');
+    expect(hit.body.id).toBe(id);
+
+    const notModified = await request(ctx.app)
+      .get(`/v1/documents/${id}`)
+      .set("If-None-Match", 'W/"1"');
+    expect(notModified.status).toBe(304);
+  });
+
+  it("404s for an unknown id", async () => {
+    const res = await request(ctx.app).get(`/v1/documents/${uuidv7()}`);
+    expect(res.status).toBe(404);
+    expect(res.headers["content-type"]).toContain(
+      "application/problem+json",
+    );
+  });
+});
+
+describe("GET /v1/documents/:id/content", () => {
+  it("streams the bytes with the right Content-Type", async () => {
+    const bytes = makeBytes("content-stream");
+    const created = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytes, { filename: "c.jpg", contentType: "image/jpeg" });
+    const id = created.body.id;
+
+    const res = await request(ctx.app)
+      .get(`/v1/documents/${id}/content`)
+      .buffer(true)
+      .parse((r, cb) => {
+        const chunks: Buffer[] = [];
+        r.on("data", (c: Buffer) => chunks.push(c));
+        r.on("end", () => cb(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("image/jpeg");
+    expect(res.headers["content-disposition"]).toContain(
+      `inline; filename="${id}.jpg"`,
+    );
+    expect(Buffer.isBuffer(res.body)).toBe(true);
+    expect((res.body as Buffer).equals(bytes)).toBe(true);
+  });
+
+  it("404s for unknown id", async () => {
+    const res = await request(ctx.app).get(
+      `/v1/documents/${uuidv7()}/content`,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /v1/documents/:id/links — link + idempotent replay", () => {
+  let txId: string;
+  let docId: string;
+
+  beforeEach(async () => {
+    txId = await seedTransaction();
+    const bytes = makeBytes("link");
+    const created = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytes, { filename: "l.jpg", contentType: "image/jpeg" });
+    docId = created.body.id;
+  });
+
+  it("returns 204 on first link and on idempotent replay", async () => {
+    const first = await request(ctx.app)
+      .post(`/v1/documents/${docId}/links`)
+      .send({ transaction_id: txId });
+    expect(first.status).toBe(204);
+
+    const replay = await request(ctx.app)
+      .post(`/v1/documents/${docId}/links`)
+      .send({ transaction_id: txId });
+    expect(replay.status).toBe(204);
+  });
+
+  it("404s when the transaction does not exist in this workspace", async () => {
+    const res = await request(ctx.app)
+      .post(`/v1/documents/${docId}/links`)
+      .send({ transaction_id: uuidv7() });
+    expect(res.status).toBe(404);
+  });
+
+  it("404s when the document does not exist", async () => {
+    const res = await request(ctx.app)
+      .post(`/v1/documents/${uuidv7()}/links`)
+      .send({ transaction_id: txId });
+    expect(res.status).toBe(404);
+  });
+
+  it("422s when body is missing transaction_id", async () => {
+    const res = await request(ctx.app)
+      .post(`/v1/documents/${docId}/links`)
+      .send({});
+    expect(res.status).toBe(422);
+  });
+});
+
+describe("DELETE /v1/documents/:id/links/:txn_id", () => {
+  it("returns 204 when removing an existing link; 404 on second attempt", async () => {
+    const txId = await seedTransaction();
+    const bytes = makeBytes("unlink");
+    const created = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytes, { filename: "u.jpg", contentType: "image/jpeg" });
+    const docId = created.body.id;
+
+    const link = await request(ctx.app)
+      .post(`/v1/documents/${docId}/links`)
+      .send({ transaction_id: txId });
+    expect(link.status).toBe(204);
+
+    const unlink = await request(ctx.app).delete(
+      `/v1/documents/${docId}/links/${txId}`,
+    );
+    expect(unlink.status).toBe(204);
+
+    const again = await request(ctx.app).delete(
+      `/v1/documents/${docId}/links/${txId}`,
+    );
+    expect(again.status).toBe(404);
+  });
+});
+
+describe("DELETE /v1/documents/:id", () => {
+  it("204s when the doc has no links; 404 on re-delete", async () => {
+    const bytes = makeBytes("delete-clean");
+    const created = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytes, { filename: "d.jpg", contentType: "image/jpeg" });
+    const docId = created.body.id;
+
+    const first = await request(ctx.app).delete(`/v1/documents/${docId}`);
+    expect(first.status).toBe(204);
+
+    const second = await request(ctx.app).delete(`/v1/documents/${docId}`);
+    expect(second.status).toBe(404);
+  });
+
+  it("409s with errors/document-has-links when a link exists", async () => {
+    const txId = await seedTransaction();
+    const bytes = makeBytes("delete-linked");
+    const created = await request(ctx.app)
+      .post("/v1/documents")
+      .attach("file", bytes, { filename: "dl.jpg", contentType: "image/jpeg" });
+    const docId = created.body.id;
+
+    await request(ctx.app)
+      .post(`/v1/documents/${docId}/links`)
+      .send({ transaction_id: txId })
+      .expect(204);
+
+    const res = await request(ctx.app).delete(`/v1/documents/${docId}`);
+    expect(res.status).toBe(409);
+    expect(res.headers["content-type"]).toContain(
+      "application/problem+json",
+    );
+    expect(res.body.type).toContain("errors/document-has-links");
+    expect(res.body.document_id).toBe(docId);
+    expect(res.body.link_count).toBe(1);
+  });
+});

--- a/tests/integration/postings.test.ts
+++ b/tests/integration/postings.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Integration tests for `/v1/postings` (read-only flat list + single-id
+ * fetch). The postings are created by POSTing to `/v1/transactions`.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { sql } from "drizzle-orm";
+import { withTestDb } from "../setup/db.js";
+import { accounts } from "../../src/schema/index.js";
+
+const ctx = withTestDb();
+
+async function acctId(name: string): Promise<string> {
+  const rows = await ctx.db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(sql`${accounts.workspaceId} = ${ctx.workspaceId} AND ${accounts.name} = ${name}`);
+  if (rows.length === 0) throw new Error(`Account not found: ${name}`);
+  return rows[0]!.id;
+}
+
+describe("GET /v1/postings", () => {
+  let txId: string;
+  let postingIds: string[];
+
+  beforeAll(async () => {
+    const groceries = await acctId("Groceries");
+    const visa = await acctId("Credit Card");
+
+    const res = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", "postings-seed-1")
+      .send({
+        occurred_on: "2026-04-15",
+        payee: "Seed txn for postings test",
+        postings: [
+          { account_id: groceries, amount_minor: 5000 },
+          { account_id: visa, amount_minor: -5000 },
+        ],
+      });
+    expect(res.status).toBe(201);
+    txId = res.body.id;
+    postingIds = res.body.postings.map((p: any) => p.id);
+  });
+
+  it("lists postings filtered by transaction_id", async () => {
+    const res = await request(ctx.app).get(`/v1/postings?transaction_id=${txId}`);
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+    const ids = (res.body.items as any[]).map((p) => p.id).sort();
+    expect(ids).toEqual([...postingIds].sort());
+  });
+
+  it("lists postings filtered by account_id", async () => {
+    const groceries = await acctId("Groceries");
+    const res = await request(ctx.app).get(`/v1/postings?account_id=${groceries}`);
+    expect(res.status).toBe(200);
+    // At least the one from this test's seed.
+    expect((res.body.items as any[]).some((p) => p.transaction_id === txId)).toBe(true);
+  });
+
+  it("fetches a single posting by id", async () => {
+    const pid = postingIds[0]!;
+    const res = await request(ctx.app).get(`/v1/postings/${pid}`);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(pid);
+    expect(res.body.transaction_id).toBe(txId);
+    expect(typeof res.body.amount_minor).toBe("number");
+  });
+
+  it("returns 404 for unknown posting id", async () => {
+    const res = await request(ctx.app).get(
+      "/v1/postings/00000000-0000-7000-8000-0000deadbeef",
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers["content-type"]).toMatch(/problem\+json/);
+    expect(res.body.type).toMatch(/not-found/);
+  });
+});

--- a/tests/integration/transactions.test.ts
+++ b/tests/integration/transactions.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Integration tests for `/v1/transactions` + nested postings.
+ *
+ * Covers: create (+idempotency, imbalance), patch (+If-Match semantics),
+ * delete rules, void mirror, reconcile, bulk dispatch, document filter,
+ * and If-None-Match 304.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { sql } from "drizzle-orm";
+import { v7 as uuidv7 } from "uuid";
+import { withTestDb } from "../setup/db.js";
+import { accounts, documents } from "../../src/schema/index.js";
+
+const ctx = withTestDb();
+
+async function acctId(name: string): Promise<string> {
+  const rows = await ctx.db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(sql`${accounts.workspaceId} = ${ctx.workspaceId} AND ${accounts.name} = ${name}`);
+  if (rows.length === 0) throw new Error(`Account not found: ${name}`);
+  return rows[0]!.id;
+}
+
+async function waitForIdempotencyKey(key: string, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const res = await ctx.db.execute(
+      sql`SELECT 1 FROM idempotency_keys WHERE workspace_id = ${ctx.workspaceId}::uuid AND key = ${key}`,
+    );
+    if (res.rows.length > 0) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error(`Idempotency key ${key} not persisted within ${timeoutMs}ms`);
+}
+
+let groceries: string;
+let visa: string;
+let cash: string;
+
+beforeAll(async () => {
+  groceries = await acctId("Groceries");
+  visa = await acctId("Credit Card");
+  cash = await acctId("Cash");
+});
+
+function balancedBody(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    occurred_on: "2026-04-19",
+    payee: "Walmart",
+    postings: [
+      { account_id: groceries, amount_minor: 14723 },
+      { account_id: visa, amount_minor: -14723 },
+    ],
+    ...overrides,
+  };
+}
+
+describe("POST /v1/transactions", () => {
+  it("creates a balanced transaction (201 + ETag + Location + postings)", async () => {
+    const res = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "Create Test 1" }));
+    expect(res.status).toBe(201);
+    expect(res.headers["etag"]).toMatch(/^W\/"\d+"$/);
+    expect(res.headers["location"]).toMatch(/^\/v1\/transactions\//);
+    expect(res.body.status).toBe("posted");
+    expect(res.body.postings).toHaveLength(2);
+    expect(res.body.postings[0].amount_minor).toBe(14723);
+    expect(res.body.version).toBe(1);
+  });
+
+  it("requires Idempotency-Key header (428)", async () => {
+    const res = await request(ctx.app)
+      .post("/v1/transactions")
+      .send(balancedBody({ payee: "No key" }));
+    expect(res.status).toBe(428);
+    expect(res.headers["content-type"]).toMatch(/problem\+json/);
+    expect(res.body.type).toMatch(/precondition-required/);
+  });
+
+  it("replays the same idempotency key byte-for-byte", async () => {
+    const key = uuidv7();
+    const body = balancedBody({ payee: "Replay" });
+    const a = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", key)
+      .send(body);
+    expect(a.status).toBe(201);
+    // The middleware persists the memoized response on the response
+    // `finish` event (fire-and-forget), so the write may race a second
+    // request issued back-to-back. Wait for the row to land before the
+    // replay attempt.
+    await waitForIdempotencyKey(key);
+    const b = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", key)
+      .send(body);
+    expect(b.status).toBe(201);
+    expect(b.body.id).toBe(a.body.id);
+  });
+
+  it("rejects same key with different body (409 idempotency-conflict)", async () => {
+    const key = uuidv7();
+    const a = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", key)
+      .send(balancedBody({ payee: "First" }));
+    expect(a.status).toBe(201);
+    await waitForIdempotencyKey(key);
+    const b = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", key)
+      .send(balancedBody({ payee: "Second" }));
+    expect(b.status).toBe(409);
+    expect(b.body.type).toMatch(/idempotency-conflict/);
+  });
+
+  it("rejects imbalanced postings (422 postings-imbalance)", async () => {
+    const res = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send({
+        occurred_on: "2026-04-19",
+        payee: "Imbalanced",
+        postings: [
+          { account_id: groceries, amount_minor: 1000 },
+          { account_id: visa, amount_minor: -999 },
+        ],
+      });
+    expect(res.status).toBe(422);
+    expect(res.body.type).toMatch(/postings-imbalance/);
+  });
+
+  it("rejects unknown account_id (422 validation)", async () => {
+    const res = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send({
+        occurred_on: "2026-04-19",
+        payee: "Bad acct",
+        postings: [
+          { account_id: "00000000-0000-7000-8000-000000000099", amount_minor: 100 },
+          { account_id: visa, amount_minor: -100 },
+        ],
+      });
+    expect(res.status).toBe(422);
+    expect(res.body.type).toMatch(/validation/);
+  });
+});
+
+describe("PATCH /v1/transactions/:id", () => {
+  it("applies a valid If-Match patch, bumps version + updated_at", async () => {
+    const created = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "Before" }));
+    expect(created.status).toBe(201);
+    const id = created.body.id;
+    const etag = created.headers["etag"]!;
+    const updatedAtBefore = created.body.updated_at;
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const patch = await request(ctx.app)
+      .patch(`/v1/transactions/${id}`)
+      .set("If-Match", etag)
+      .set("Content-Type", "application/merge-patch+json")
+      .send({ payee: "After", narration: "note" });
+    expect(patch.status).toBe(200);
+    expect(patch.body.payee).toBe("After");
+    expect(patch.body.narration).toBe("note");
+    expect(patch.body.version).toBe(created.body.version + 1);
+    expect(new Date(patch.body.updated_at).getTime()).toBeGreaterThan(
+      new Date(updatedAtBefore).getTime(),
+    );
+    expect(patch.headers["etag"]).toBe(`W/"${patch.body.version}"`);
+  });
+
+  it("returns 428 when If-Match is missing", async () => {
+    const created = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "No-IfMatch" }));
+    const res = await request(ctx.app)
+      .patch(`/v1/transactions/${created.body.id}`)
+      .send({ payee: "Nope" });
+    expect(res.status).toBe(428);
+    expect(res.body.type).toMatch(/precondition-required/);
+  });
+
+  it("returns 412 when If-Match does not match current version", async () => {
+    const created = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "Wrong-IfMatch" }));
+    const res = await request(ctx.app)
+      .patch(`/v1/transactions/${created.body.id}`)
+      .set("If-Match", 'W/"999"')
+      .send({ payee: "Nope" });
+    expect(res.status).toBe(412);
+    expect(res.body.type).toMatch(/version-mismatch/);
+  });
+});
+
+describe("DELETE /v1/transactions/:id", () => {
+  it("rejects DELETE on a posted transaction (409 must-void-instead)", async () => {
+    const created = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "Posted-no-delete" }));
+    expect(created.status).toBe(201);
+    const res = await request(ctx.app)
+      .delete(`/v1/transactions/${created.body.id}`)
+      .set("If-Match", created.headers["etag"]!);
+    expect(res.status).toBe(409);
+    expect(res.body.type).toMatch(/must-void-instead/);
+  });
+
+  it("allows DELETE on a draft transaction (204)", async () => {
+    const created = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send({
+        occurred_on: "2026-04-19",
+        payee: "Draft-delete",
+        status: "draft",
+        postings: [
+          { account_id: groceries, amount_minor: 500 },
+          { account_id: visa, amount_minor: -500 },
+        ],
+      });
+    expect(created.status).toBe(201);
+    const res = await request(ctx.app)
+      .delete(`/v1/transactions/${created.body.id}`)
+      .set("If-Match", created.headers["etag"]!);
+    expect(res.status).toBe(204);
+
+    const after = await request(ctx.app).get(`/v1/transactions/${created.body.id}`);
+    expect(after.status).toBe(404);
+  });
+});
+
+describe("POST /v1/transactions/:id/void", () => {
+  it("creates a mirror with negated postings and flips original status", async () => {
+    const created = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "Void-target" }));
+    expect(created.status).toBe(201);
+    const origId = created.body.id;
+
+    const voided = await request(ctx.app)
+      .post(`/v1/transactions/${origId}/void`)
+      .set("If-Match", created.headers["etag"]!)
+      .send({ reason: "wrong amount" });
+    expect(voided.status).toBe(201);
+    const mirror = voided.body;
+    expect(mirror.status).toBe("posted");
+    expect(mirror.payee).toMatch(/^VOID:/);
+    expect(mirror.postings).toHaveLength(2);
+
+    // Sum of mirror postings (by base-minor) cancels original: each posting's
+    // sign flipped.
+    const origPostings = created.body.postings;
+    for (const mp of mirror.postings) {
+      const match = origPostings.find((op: any) => op.account_id === mp.account_id);
+      expect(match).toBeDefined();
+      expect(mp.amount_minor).toBe(-match.amount_minor);
+    }
+
+    // Net for the affected accounts (orig + mirror) sums to 0.
+    const netByAcct = new Map<string, number>();
+    for (const p of [...origPostings, ...mirror.postings]) {
+      netByAcct.set(p.account_id, (netByAcct.get(p.account_id) ?? 0) + p.amount_minor);
+    }
+    for (const [, net] of netByAcct) expect(net).toBe(0);
+
+    // Original is now voided.
+    const origAfter = await request(ctx.app).get(`/v1/transactions/${origId}`);
+    expect(origAfter.status).toBe(200);
+    expect(origAfter.body.status).toBe("voided");
+    expect(origAfter.body.voided_by_id).toBe(mirror.id);
+  });
+});
+
+describe("POST /v1/transactions/:id/reconcile", () => {
+  it("flips posted → reconciled", async () => {
+    const created = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "Reconcile-target" }));
+    const res = await request(ctx.app)
+      .post(`/v1/transactions/${created.body.id}/reconcile`)
+      .set("If-Match", created.headers["etag"]!);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("reconciled");
+  });
+});
+
+describe("POST /v1/transactions:bulk", () => {
+  it("runs each op independently; failures don't block successes", async () => {
+    const t1 = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "Bulk-1" }));
+    const t2 = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "Bulk-2" }));
+    expect(t1.status).toBe(201);
+    expect(t2.status).toBe(201);
+
+    const res = await request(ctx.app)
+      .post("/v1/transactions/bulk")
+      .send({
+        operations: [
+          // Valid update
+          {
+            op: "update",
+            id: t1.body.id,
+            if_match: t1.headers["etag"]!,
+            patch: { payee: "Bulk-1-updated" },
+          },
+          // Invalid: wrong if_match on t2
+          {
+            op: "update",
+            id: t2.body.id,
+            if_match: 'W/"999"',
+            patch: { payee: "bad" },
+          },
+          // Valid reconcile on t2
+          {
+            op: "reconcile",
+            id: t2.body.id,
+            if_match: t2.headers["etag"]!,
+          },
+        ],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(3);
+    expect(res.body.results[0].status).toBe(200);
+    expect(res.body.results[0].body.payee).toBe("Bulk-1-updated");
+    expect(res.body.results[1].status).toBe(412);
+    expect(res.body.results[2].status).toBe(200);
+    expect(res.body.results[2].body.status).toBe("reconciled");
+  });
+});
+
+describe("POST /v1/transactions/:id/postings (nested)", () => {
+  it("rejects a posting that makes the transaction imbalanced (422)", async () => {
+    const created = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "Add-posting-bad" }));
+    expect(created.status).toBe(201);
+
+    const res = await request(ctx.app)
+      .post(`/v1/transactions/${created.body.id}/postings`)
+      .set("If-Match", created.headers["etag"]!)
+      .send({ account_id: cash, amount_minor: 999 });
+    expect(res.status).toBe(422);
+    expect(res.body.type).toMatch(/postings-imbalance/);
+  });
+
+  it("accepts balanced add/delete pair on a draft", async () => {
+    // On a posted txn you can't add a third posting without another offsetting
+    // one — balance re-checks on every mutation. Use draft to exercise the
+    // add + update path.
+    const created = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send({
+        occurred_on: "2026-04-19",
+        payee: "Draft-nested",
+        status: "draft",
+        postings: [
+          { account_id: groceries, amount_minor: 1000 },
+          { account_id: visa, amount_minor: -1000 },
+        ],
+      });
+    expect(created.status).toBe(201);
+
+    const added = await request(ctx.app)
+      .post(`/v1/transactions/${created.body.id}/postings`)
+      .set("If-Match", created.headers["etag"]!)
+      .send({ account_id: cash, amount_minor: 200 });
+    // Draft txns bypass balance trigger — accept 201.
+    expect(added.status).toBe(201);
+
+    // Now refresh and try to delete it.
+    const refreshed = await request(ctx.app).get(`/v1/transactions/${created.body.id}`);
+    expect(refreshed.status).toBe(200);
+    expect(refreshed.body.postings).toHaveLength(3);
+
+    const del = await request(ctx.app)
+      .delete(`/v1/transactions/${refreshed.body.id}/postings/${added.body.id}`)
+      .set("If-Match", refreshed.headers["etag"]!);
+    expect(del.status).toBe(204);
+  });
+});
+
+describe("GET /v1/transactions (list filters)", () => {
+  it("has_document filter works (both directions)", async () => {
+    // Create a transaction with a linked document.
+    const docId = uuidv7();
+    await ctx.db.insert(documents).values({
+      id: docId,
+      workspaceId: ctx.workspaceId,
+      kind: "receipt_image",
+      sha256: `sha-${docId}`,
+    });
+
+    const withDoc = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "WithDoc", document_ids: [docId] }));
+    expect(withDoc.status).toBe(201);
+    expect(withDoc.body.documents).toHaveLength(1);
+
+    // Fetch with has_document=true
+    const yes = await request(ctx.app).get(
+      "/v1/transactions?has_document=true&payee_contains=WithDoc",
+    );
+    expect(yes.status).toBe(200);
+    expect((yes.body.items as any[]).some((i) => i.id === withDoc.body.id)).toBe(true);
+
+    // Create another without a doc, verify it's excluded.
+    const sansDoc = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "SansDoc" }));
+    expect(sansDoc.status).toBe(201);
+
+    const no = await request(ctx.app).get(
+      "/v1/transactions?has_document=false&payee_contains=SansDoc",
+    );
+    expect(no.status).toBe(200);
+    expect((no.body.items as any[]).some((i) => i.id === sansDoc.body.id)).toBe(true);
+    expect((no.body.items as any[]).some((i) => i.id === withDoc.body.id)).toBe(false);
+  });
+
+  it("payee_contains + q filters match", async () => {
+    await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "UniqueCostco123", narration: "gas trip" }));
+
+    const byPayee = await request(ctx.app).get("/v1/transactions?payee_contains=UniqueCostco");
+    expect(byPayee.status).toBe(200);
+    expect((byPayee.body.items as any[]).length).toBeGreaterThanOrEqual(1);
+
+    const byQ = await request(ctx.app).get("/v1/transactions?q=gas+trip");
+    expect(byQ.status).toBe(200);
+    expect((byQ.body.items as any[]).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("GET /v1/transactions/:id — If-None-Match", () => {
+  it("returns 304 when the current ETag matches If-None-Match", async () => {
+    const created = await request(ctx.app)
+      .post("/v1/transactions")
+      .set("Idempotency-Key", uuidv7())
+      .send(balancedBody({ payee: "INM test" }));
+    expect(created.status).toBe(201);
+    const etag = created.headers["etag"]!;
+
+    const res = await request(ctx.app)
+      .get(`/v1/transactions/${created.body.id}`)
+      .set("If-None-Match", etag);
+    expect(res.status).toBe(304);
+  });
+});

--- a/tests/setup/db.ts
+++ b/tests/setup/db.ts
@@ -4,11 +4,9 @@
  * Usage:
  *   import { withTestDb } from "../setup/db.js";
  *   const ctx = withTestDb();
- *   // Inside tests: ctx.db, ctx.pool, ctx.workspaceId are populated
- *   // after `beforeAll` runs.
+ *   // Inside tests: ctx.db / ctx.pool / ctx.app / ctx.workspaceId / ctx.userId
  *
- * One container per suite, migrations + seed applied once.
- * `ctx.db` is the drizzle client against the testcontainer.
+ * One container per suite. Migrations + seed applied once in beforeAll.
  */
 import {
   PostgreSqlContainer,
@@ -17,12 +15,14 @@ import {
 import pg from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { beforeAll, afterAll } from "vitest";
+import type { Express } from "express";
 import * as schema from "../../src/schema/index.js";
 
 export interface TestDbContext {
   container: StartedPostgreSqlContainer;
   pool: pg.Pool;
   db: ReturnType<typeof drizzle<typeof schema>>;
+  app: Express;
   workspaceId: string;
   userId: string;
 }
@@ -37,8 +37,6 @@ export function withTestDb(): TestDbContext {
     const { runMigrations } = await import("../../src/db/migrate.js");
     await runMigrations();
 
-    // Seed module reads DATABASE_URL at import time via src/db/client.ts,
-    // so dynamic-import after setting the env var to point at the container.
     const { seed, SEED_WORKSPACE_ID, SEED_USER_ID } = await import(
       "../../src/db/seed.js"
     );
@@ -49,12 +47,13 @@ export function withTestDb(): TestDbContext {
     ctx.db = drizzle(ctx.pool, { schema });
     ctx.workspaceId = SEED_WORKSPACE_ID;
     ctx.userId = SEED_USER_ID;
+
+    const { buildApp } = await import("../../src/app.js");
+    ctx.app = buildApp();
   });
 
   afterAll(async () => {
     if (ctx.pool) await ctx.pool.end();
-    // The seed module's own pool (imported from src/db/client.ts) is still
-    // open at this point. Close it so the process can exit cleanly.
     const { pool: seedPool } = await import("../../src/db/client.js");
     await seedPool.end().catch(() => {});
     if (ctx.container) await ctx.container.stop();


### PR DESCRIPTION
## Summary

Lands the full `/v1/*` resource surface from epic #28. Closes sub-issues **#35** (transactions + postings + documents) and **#36** (accounts).

**Base branch is `feat/double-entry-schema` (PR #37)** — this PR stacks on top. Merge #37 first, then rebase this one onto main.

Built in parallel by three coordinated subagents against a shared HTTP middleware layer. Total: 5 test files, **64 integration tests, all green** against real Postgres via testcontainers.

## What lands

### Shared HTTP infrastructure (`src/http/`)
- `problem.ts` — RFC 7807 `HttpProblem` class hierarchy + central error middleware. Every error response is `application/problem+json` with a machine-readable `type` URI.
- `etag.ts` — weak ETag format, `If-Match` / `If-None-Match` helpers.
- `idempotency.ts` — Stripe-style `Idempotency-Key` middleware backed by the `idempotency_keys` table (24h TTL, sha256 body fingerprint, 409 on same-key-different-body).
- `pagination.ts` — opaque base64url keyset cursor + `Link: rel=\"next\"`.
- `context.ts` — `req.ctx { workspaceId, userId, traceId }` (auth-ready hook).
- `validate.ts` · `uuid.ts` — Zod→problem+json, UUIDv7.

### Zod schemas (`src/schemas/v1/`)
Type-safe contracts for Account, Transaction, Posting, Document, ProblemDetails + all request/query variants. All `.openapi()`-registered — single source of truth driving runtime validation, OpenAPI spec, TypeScript types, and future client codegen.

### Accounts resource (#36)
- Chart-of-accounts CRUD tree with parent-type consistency validation.
- `GET /:id/balance` — point-in-time, optional subtree aggregation via recursive CTE.
- `GET /:id/register` — checkbook view with SQL-window `running_balance_after_minor`, `counter_postings[]`, linked `documents[]`. Keyset paginated.
- 7 MCP tools mirroring the HTTP surface.

### Transactions + postings (#35)
- `POST` requires `Idempotency-Key` (428 if missing). Balance trigger at commit → 422 `postings-imbalance` problem+json.
- `PATCH` `application/merge-patch+json` with `If-Match` (head fields only).
- `DELETE` hard-deletes draft/error; `posted`/`reconciled` must go through `/void`.
- `POST /:id/void` — compensating mirror transaction with negated postings.
- `POST /:id/reconcile` — status transition + audit event.
- `POST /bulk` — RPC-style per-op results.
- Nested `/postings` CRUD + flat `/v1/postings` read-only.
- 5 MCP tools.

### Documents (#35)
- Multipart `POST` with sha256 content-dedup — same bytes → existing row, 200 OK (not 201).
- `GET /:id` (ETag + 304), `GET /:id/content` (binary stream).
- Idempotent link/unlink via `ON CONFLICT DO NOTHING`.
- `DELETE` returns 409 `document-has-links` if references exist.
- 2 MCP tools.

### Infrastructure
- `src/app.ts` — Express app factory shared by `server.ts` and tests (supertest without opening a socket).
- `tests/setup/db.ts` exposes `ctx.app` for all integration tests.
- 19 OpenAPI paths, 28 component schemas.

## Known deviations (called out up front)

1. **Bulk endpoint uses `/v1/transactions/bulk`** instead of the AEIP-style `:bulk` colon-verb in epic #28. Express 5's path-to-regexp can't mount colon-verb routes at segment boundaries when the router is mounted at `/v1/transactions`. Functional semantics unchanged; the colon form can be added as a 308 redirect alias in a follow-up.
2. **Account tree OpenAPI schema** — `z.lazy()` recursion isn't introspectable by `@asteasolutions/zod-to-openapi`, so the list endpoint's 200 response is documented as `Account[]` while the runtime returns either flat `Account[]` or the same shape with `children[]`. Behavior correct; spec polish deferred.
3. **ID generation** is client-side UUIDv7 via the `uuid` package, not PG-native `uuidv7()` (requires PG 18 or `pg_uuidv7` extension).

## Test plan

- [x] `npx tsc --noEmit` — clean across the project
- [x] `npm test` — 64 passed (64). Covers schema triggers, accounts CRUD + balance + register, transactions CRUD + void + reconcile + bulk + nested postings, documents upload + dedup + link.
- [x] `npm run openapi:generate` — 19 paths, 28 schemas, diff-clean
- [x] `docker compose up -d --build receipts-postgres receipt-assistant` — boots cleanly
- [ ] Ensure CI runs against a testcontainers-compatible runner (ubuntu-latest; already configured in `.github/workflows/ci.yml`)

## Follow-ups

- Auth epic: flip RLS `ENABLE ROW LEVEL SECURITY` on business tables and wire `SET LOCAL app.current_workspace` per request.
- Batch ingest (#32) can now target the live `/v1/transactions` + `/v1/documents` paths.
- `/v1/reports/*` (summary, trends, net-worth, cashflow) — separate epic on this foundation.
- `POST /v1/transactions:bulk` redirect alias.
- Multi-currency FX lookup (fills `fx_rate` + `amount_base_minor` automatically when the posting currency differs from workspace base).

Refs #28. Closes #35. Closes #36.