### PR TITLE
Reports API: /v1/reports/{summary,trends,net_worth,cashflow}

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1274,6 +1274,361 @@
           "poll"
         ]
       },
+      "SummaryItem": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "total_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "avg_per_txn_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          }
+        },
+        "required": [
+          "key",
+          "count",
+          "total_minor",
+          "avg_per_txn_minor"
+        ]
+      },
+      "SummaryReport": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "to": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "group_by": {
+            "type": "string",
+            "enum": [
+              "category",
+              "account",
+              "payee"
+            ]
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SummaryItem"
+            }
+          },
+          "grand_total_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          }
+        },
+        "required": [
+          "from",
+          "to",
+          "group_by",
+          "currency",
+          "items",
+          "grand_total_minor"
+        ]
+      },
+      "TrendsItem": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "total_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "key",
+          "total_minor",
+          "count"
+        ]
+      },
+      "TrendsBucket": {
+        "type": "object",
+        "properties": {
+          "bucket": {
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrendsItem"
+            }
+          },
+          "total_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          }
+        },
+        "required": [
+          "bucket",
+          "items",
+          "total_minor"
+        ]
+      },
+      "TrendsReport": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "to": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "period": {
+            "type": "string",
+            "enum": [
+              "month",
+              "year"
+            ]
+          },
+          "group_by": {
+            "type": "string",
+            "enum": [
+              "category",
+              "total"
+            ]
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "buckets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrendsBucket"
+            }
+          }
+        },
+        "required": [
+          "from",
+          "to",
+          "period",
+          "group_by",
+          "currency",
+          "buckets"
+        ]
+      },
+      "NetWorthAccount": {
+        "type": "object",
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "asset",
+              "liability",
+              "equity",
+              "income",
+              "expense"
+            ]
+          },
+          "balance_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          }
+        },
+        "required": [
+          "account_id",
+          "name",
+          "type",
+          "balance_minor"
+        ]
+      },
+      "NetWorthReport": {
+        "type": "object",
+        "properties": {
+          "as_of": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "assets_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "liabilities_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "equity_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "net_worth_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "by_account": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetWorthAccount"
+            }
+          }
+        },
+        "required": [
+          "as_of",
+          "currency",
+          "assets_minor",
+          "liabilities_minor",
+          "equity_minor",
+          "net_worth_minor",
+          "by_account"
+        ]
+      },
+      "CashflowBucket": {
+        "type": "object",
+        "properties": {
+          "month": {
+            "type": "string"
+          },
+          "income_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "expense_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "net_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          }
+        },
+        "required": [
+          "month",
+          "income_minor",
+          "expense_minor",
+          "net_minor"
+        ]
+      },
+      "CashflowReport": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "to": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "currency": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}$",
+            "example": "USD"
+          },
+          "income_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "expense_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "net_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "buckets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CashflowBucket"
+            }
+          }
+        },
+        "required": [
+          "from",
+          "to",
+          "currency",
+          "income_minor",
+          "expense_minor",
+          "net_minor",
+          "buckets"
+        ]
+      },
       "NewPosting": {
         "type": "object",
         "properties": {
@@ -3467,6 +3822,288 @@
           },
           "404": {
             "description": "Ingest not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/reports/summary": {
+      "get": {
+        "summary": "Spend aggregated by category / account / payee",
+        "tags": [
+          "reports"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "category",
+                "account",
+                "payee"
+              ]
+            },
+            "required": false,
+            "name": "group_by",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{3}$",
+              "example": "USD"
+            },
+            "required": false,
+            "name": "currency",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Summary report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SummaryReport"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/reports/trends": {
+      "get": {
+        "summary": "Time-series trend (MoM / YoY) of expense spend",
+        "tags": [
+          "reports"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "month",
+                "year"
+              ]
+            },
+            "required": false,
+            "name": "period",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "category",
+                "total"
+              ]
+            },
+            "required": false,
+            "name": "group_by",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{3}$",
+              "example": "USD"
+            },
+            "required": false,
+            "name": "currency",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trends report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrendsReport"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/reports/net_worth": {
+      "get": {
+        "summary": "Assets - liabilities at a point in time",
+        "tags": [
+          "reports"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "as_of",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{3}$",
+              "example": "USD"
+            },
+            "required": false,
+            "name": "currency",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Net worth report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NetWorthReport"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/reports/cashflow": {
+      "get": {
+        "summary": "Inflows vs outflows over a range, bucketed by month",
+        "tags": [
+          "reports"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2026-04-19"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{3}$",
+              "example": "USD"
+            },
+            "required": false,
+            "name": "currency",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cashflow report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CashflowReport"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workspace not found",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,7 @@ import {
   batchesRouter,
   ingestsRouter,
 } from "./routes/ingest.js";
+import { reportsRouter } from "./routes/reports.js";
 
 export function buildApp(): Express {
   const app = express();
@@ -61,6 +62,7 @@ export function buildApp(): Express {
   app.use("/v1/ingest", ingestRouter);
   app.use("/v1/batches", batchesRouter);
   app.use("/v1/ingests", ingestsRouter);
+  app.use("/v1/reports", reportsRouter);
 
   // ── Final error handler ─────────────────────────────────────────────
   app.use(problemHandler);

--- a/src/mcp/reports.ts
+++ b/src/mcp/reports.ts
@@ -1,0 +1,119 @@
+/**
+ * FastMCP tools for the `/v1/reports/*` surface.
+ *
+ * Thin adapters: each tool calls the service function exported from
+ * `src/routes/reports.ts` directly. Workspace is pinned to the seeded
+ * default until the auth epic lands (same pattern as accounts.ts).
+ */
+import { z } from "zod";
+import type { FastMCP } from "fastmcp";
+import { SEED_WORKSPACE_ID } from "../db/seed.js";
+import {
+  getSummaryReport,
+  getTrendsReport,
+  getNetWorthReport,
+  getCashflowReport,
+} from "../routes/reports.js";
+
+function toJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+const IsoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+const Currency = z.string().regex(/^[A-Z]{3}$/);
+
+export function registerReportsMcpTools(mcp: FastMCP): void {
+  mcp.addTool({
+    name: "get_summary_report",
+    description:
+      "Aggregate spend over a date range, grouped by category (default), account, or payee. " +
+      "Returns per-group count + total + average, plus a grand total. " +
+      "Voided transactions are excluded.",
+    parameters: z.object({
+      from: IsoDate.optional(),
+      to: IsoDate.optional(),
+      group_by: z.enum(["category", "account", "payee"]).optional(),
+      currency: Currency.optional(),
+    }),
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await getSummaryReport({
+        workspaceId: SEED_WORKSPACE_ID,
+        from: args.from,
+        to: args.to,
+        groupBy: args.group_by,
+        currency: args.currency,
+      });
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "get_trends_report",
+    description:
+      "Time-series trend of expense spend. period=month (default) or year. " +
+      "group_by=total (default) for a single series, category for one series per category.",
+    parameters: z.object({
+      period: z.enum(["month", "year"]).optional(),
+      from: IsoDate.optional(),
+      to: IsoDate.optional(),
+      group_by: z.enum(["category", "total"]).optional(),
+      currency: Currency.optional(),
+    }),
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await getTrendsReport({
+        workspaceId: SEED_WORKSPACE_ID,
+        period: args.period,
+        from: args.from,
+        to: args.to,
+        groupBy: args.group_by,
+        currency: args.currency,
+      });
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "get_net_worth_report",
+    description:
+      "Point-in-time net worth: assets + liabilities + equity (liabilities are " +
+      "typically negative; the sum is the intuitive 'what I own minus what I owe'). " +
+      "Includes a per-account balance breakdown.",
+    parameters: z.object({
+      as_of: IsoDate.optional(),
+      currency: Currency.optional(),
+    }),
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await getNetWorthReport({
+        workspaceId: SEED_WORKSPACE_ID,
+        asOf: args.as_of,
+        currency: args.currency,
+      });
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "get_cashflow_report",
+    description:
+      "Inflows vs. outflows over a range, bucketed by month. income - expense = net. " +
+      "Voided transactions are excluded.",
+    parameters: z.object({
+      from: IsoDate.optional(),
+      to: IsoDate.optional(),
+      currency: Currency.optional(),
+    }),
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await getCashflowReport({
+        workspaceId: SEED_WORKSPACE_ID,
+        from: args.from,
+        to: args.to,
+        currency: args.currency,
+      });
+      return toJson(out);
+    },
+  });
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -25,6 +25,7 @@ import { registerTransactionsOpenApi } from "./routes/transactions.js";
 import { registerPostingsOpenApi } from "./routes/postings.js";
 import { registerDocumentsOpenApi } from "./routes/documents.js";
 import { registerIngestOpenApi } from "./routes/ingest.js";
+import { registerReportsOpenApi } from "./routes/reports.js";
 
 export function buildRegistry(): OpenAPIRegistry {
   const registry = new OpenAPIRegistry();
@@ -59,6 +60,7 @@ export function buildRegistry(): OpenAPIRegistry {
   registerPostingsOpenApi(registry);
   registerDocumentsOpenApi(registry);
   registerIngestOpenApi(registry);
+  registerReportsOpenApi(registry);
 
   return registry;
 }

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -1,0 +1,575 @@
+/**
+ * `/v1/reports/*` — read-only aggregate endpoints on top of the ledger.
+ *
+ * All rollups query `postings` ⨝ `transactions` ⨝ `accounts`. No new
+ * tables; no migrations. Voided transactions (`status='voided'`) are
+ * excluded from every report.
+ *
+ * The aggregates are small relative to raw ledger size (bounded by
+ * user-supplied date range and the number of accounts), so these
+ * endpoints return full arrays without keyset pagination.
+ *
+ * Service functions are exported so the MCP tools in `src/mcp/reports.ts`
+ * can invoke them directly without doing HTTP self-calls.
+ */
+import { Router, type Request, type Response, type NextFunction } from "express";
+import { sql } from "drizzle-orm";
+import type { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { db } from "../db/client.js";
+import { parseOrThrow } from "../http/validate.js";
+import { NotFoundProblem } from "../http/problem.js";
+import {
+  SummaryQuery,
+  SummaryReport,
+  TrendsQuery,
+  TrendsReport,
+  NetWorthQuery,
+  NetWorthReport,
+  CashflowQuery,
+  CashflowReport,
+} from "../schemas/v1/report.js";
+import { ProblemDetails } from "../schemas/v1/common.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+type AsyncHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<unknown>;
+
+function ah(fn: AsyncHandler) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    fn(req, res, next).catch(next);
+  };
+}
+
+async function fetchWorkspaceBaseCurrency(workspaceId: string): Promise<string> {
+  const res = await db.execute(
+    sql`SELECT base_currency FROM workspaces WHERE id = ${workspaceId}::uuid`,
+  );
+  if (res.rows.length === 0) {
+    throw new NotFoundProblem("Workspace", workspaceId);
+  }
+  return (res.rows[0] as { base_currency: string }).base_currency;
+}
+
+function toInt(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  return Number(value);
+}
+
+// ── Service: summary ───────────────────────────────────────────────────
+
+export interface SummaryArgs {
+  workspaceId: string;
+  from?: string;
+  to?: string;
+  groupBy?: "category" | "account" | "payee";
+  currency?: string;
+}
+
+/**
+ * Aggregate spend on the expense side of each transaction.
+ *
+ * - `category` groups by the expense account's name (the first-level
+ *   child of Expenses is treated as the category label; siblings further
+ *   down collapse to their own name). We use the account name directly —
+ *   keeps the query simple and mirrors the register UX.
+ * - `account` groups by account id (surfacing account_id as the `key`).
+ * - `payee` groups by `transactions.payee` (NULL → "(unspecified)").
+ *
+ * Only postings on expense-type accounts with positive `amount_base_minor`
+ * are counted — this matches the double-entry convention where buying
+ * groceries debits Expenses:Groceries (positive) and credits Cash
+ * (negative), so summing only the positive expense leg gives the spend
+ * amount per transaction without double-counting the settlement side.
+ */
+export async function getSummaryReport(
+  args: SummaryArgs,
+): Promise<z.infer<typeof SummaryReport>> {
+  const currency =
+    args.currency ?? (await fetchWorkspaceBaseCurrency(args.workspaceId));
+  const groupBy = args.groupBy ?? "category";
+
+  const fromFilter = args.from
+    ? sql`AND t.occurred_on >= ${args.from}::date`
+    : sql``;
+  const toFilter = args.to
+    ? sql`AND t.occurred_on <= ${args.to}::date`
+    : sql``;
+
+  // The grouping key (both the returned `key` string and the GROUP BY
+  // column) differs per mode. We pre-select it as `group_key` in a CTE
+  // so the outer aggregate is uniform.
+  let keyExpr;
+  if (groupBy === "account") {
+    keyExpr = sql`a.id::text`;
+  } else if (groupBy === "payee") {
+    keyExpr = sql`COALESCE(NULLIF(t.payee, ''), '(unspecified)')`;
+  } else {
+    // category
+    keyExpr = sql`a.name`;
+  }
+
+  const result = await db.execute(sql`
+    WITH filtered AS (
+      SELECT
+        ${keyExpr} AS group_key,
+        p.transaction_id,
+        p.amount_base_minor
+      FROM postings p
+      JOIN transactions t ON t.id = p.transaction_id
+      JOIN accounts a ON a.id = p.account_id
+      WHERE p.workspace_id = ${args.workspaceId}::uuid
+        AND t.status <> 'voided'
+        AND a.type = 'expense'
+        AND p.amount_base_minor > 0
+        ${fromFilter}
+        ${toFilter}
+    )
+    SELECT
+      group_key,
+      COUNT(DISTINCT transaction_id)::int AS txn_count,
+      COALESCE(SUM(amount_base_minor), 0)::bigint AS total_minor
+    FROM filtered
+    GROUP BY group_key
+    ORDER BY total_minor DESC, group_key ASC
+  `);
+
+  const items = (
+    result.rows as Array<{
+      group_key: string;
+      txn_count: number;
+      total_minor: string | number | bigint;
+    }>
+  ).map((r) => {
+    const total = toInt(r.total_minor);
+    const count = toInt(r.txn_count);
+    return {
+      key: r.group_key,
+      count,
+      total_minor: total,
+      avg_per_txn_minor: count > 0 ? Math.round(total / count) : 0,
+    };
+  });
+
+  const grandTotal = items.reduce((acc, it) => acc + it.total_minor, 0);
+
+  return {
+    from: args.from ?? null,
+    to: args.to ?? null,
+    group_by: groupBy,
+    currency,
+    items,
+    grand_total_minor: grandTotal,
+  };
+}
+
+// ── Service: trends ────────────────────────────────────────────────────
+
+export interface TrendsArgs {
+  workspaceId: string;
+  period?: "month" | "year";
+  from?: string;
+  to?: string;
+  groupBy?: "category" | "total";
+  currency?: string;
+}
+
+export async function getTrendsReport(
+  args: TrendsArgs,
+): Promise<z.infer<typeof TrendsReport>> {
+  const currency =
+    args.currency ?? (await fetchWorkspaceBaseCurrency(args.workspaceId));
+  const period = args.period ?? "month";
+  const groupBy = args.groupBy ?? "total";
+
+  const fromFilter = args.from
+    ? sql`AND t.occurred_on >= ${args.from}::date`
+    : sql``;
+  const toFilter = args.to
+    ? sql`AND t.occurred_on <= ${args.to}::date`
+    : sql``;
+
+  // Bucket label: 'YYYY-MM' for month, 'YYYY' for year.
+  const bucketExpr =
+    period === "year"
+      ? sql`TO_CHAR(date_trunc('year', t.occurred_on), 'YYYY')`
+      : sql`TO_CHAR(date_trunc('month', t.occurred_on), 'YYYY-MM')`;
+
+  const keyExpr =
+    groupBy === "category" ? sql`a.name` : sql`'__total__'::text`;
+
+  const result = await db.execute(sql`
+    WITH filtered AS (
+      SELECT
+        ${bucketExpr} AS bucket,
+        ${keyExpr} AS group_key,
+        p.transaction_id,
+        p.amount_base_minor
+      FROM postings p
+      JOIN transactions t ON t.id = p.transaction_id
+      JOIN accounts a ON a.id = p.account_id
+      WHERE p.workspace_id = ${args.workspaceId}::uuid
+        AND t.status <> 'voided'
+        AND a.type = 'expense'
+        AND p.amount_base_minor > 0
+        ${fromFilter}
+        ${toFilter}
+    )
+    SELECT
+      bucket,
+      group_key,
+      COUNT(DISTINCT transaction_id)::int AS txn_count,
+      COALESCE(SUM(amount_base_minor), 0)::bigint AS total_minor
+    FROM filtered
+    GROUP BY bucket, group_key
+    ORDER BY bucket ASC, total_minor DESC, group_key ASC
+  `);
+
+  const rows = result.rows as Array<{
+    bucket: string;
+    group_key: string;
+    txn_count: number;
+    total_minor: string | number | bigint;
+  }>;
+
+  const bucketMap = new Map<
+    string,
+    { items: Array<{ key: string; total_minor: number; count: number }>; total_minor: number }
+  >();
+  for (const r of rows) {
+    const slot = bucketMap.get(r.bucket) ?? { items: [], total_minor: 0 };
+    const total = toInt(r.total_minor);
+    const count = toInt(r.txn_count);
+    slot.items.push({
+      key: groupBy === "total" ? "total" : r.group_key,
+      total_minor: total,
+      count,
+    });
+    slot.total_minor += total;
+    bucketMap.set(r.bucket, slot);
+  }
+
+  const buckets = Array.from(bucketMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([bucket, v]) => ({
+      bucket,
+      items: v.items,
+      total_minor: v.total_minor,
+    }));
+
+  return {
+    from: args.from ?? null,
+    to: args.to ?? null,
+    period,
+    group_by: groupBy,
+    currency,
+    buckets,
+  };
+}
+
+// ── Service: net worth ─────────────────────────────────────────────────
+
+export interface NetWorthArgs {
+  workspaceId: string;
+  asOf?: string;
+  currency?: string;
+}
+
+/**
+ * Balance every non-closed account at `as_of`, then roll up by type.
+ *
+ * Sign conventions (same as account balances in the ledger):
+ *  - asset accounts → positive balances typically.
+ *  - liability accounts → negative balances (amounts you owe).
+ *  - equity accounts → often near zero / opening balance.
+ *
+ * `net_worth_minor = assets_minor + liabilities_minor + equity_minor`.
+ * Because liabilities are already negative, the addition yields the
+ * intuitive "what I own minus what I owe" figure.
+ */
+export async function getNetWorthReport(
+  args: NetWorthArgs,
+): Promise<z.infer<typeof NetWorthReport>> {
+  const currency =
+    args.currency ?? (await fetchWorkspaceBaseCurrency(args.workspaceId));
+  const asOf = args.asOf ?? new Date().toISOString().slice(0, 10);
+
+  const result = await db.execute(sql`
+    SELECT
+      a.id::text      AS account_id,
+      a.name          AS name,
+      a.type::text    AS type,
+      COALESCE(SUM(p.amount_base_minor) FILTER (
+        WHERE t.status = 'posted' AND t.occurred_on <= ${asOf}::date
+      ), 0)::bigint AS balance_minor
+    FROM accounts a
+    LEFT JOIN postings p ON p.account_id = a.id AND p.workspace_id = a.workspace_id
+    LEFT JOIN transactions t ON t.id = p.transaction_id
+    WHERE a.workspace_id = ${args.workspaceId}::uuid
+      AND a.closed_at IS NULL
+      AND a.type IN ('asset', 'liability', 'equity')
+    GROUP BY a.id, a.name, a.type
+    ORDER BY a.type ASC, a.name ASC
+  `);
+
+  const byAccount = (
+    result.rows as Array<{
+      account_id: string;
+      name: string;
+      type: "asset" | "liability" | "equity" | "income" | "expense";
+      balance_minor: string | number | bigint;
+    }>
+  ).map((r) => ({
+    account_id: r.account_id,
+    name: r.name,
+    type: r.type,
+    balance_minor: toInt(r.balance_minor),
+  }));
+
+  let assets = 0;
+  let liabilities = 0;
+  let equity = 0;
+  for (const a of byAccount) {
+    if (a.type === "asset") assets += a.balance_minor;
+    else if (a.type === "liability") liabilities += a.balance_minor;
+    else if (a.type === "equity") equity += a.balance_minor;
+  }
+
+  return {
+    as_of: asOf,
+    currency,
+    assets_minor: assets,
+    liabilities_minor: liabilities,
+    equity_minor: equity,
+    net_worth_minor: assets + liabilities + equity,
+    by_account: byAccount,
+  };
+}
+
+// ── Service: cashflow ──────────────────────────────────────────────────
+
+export interface CashflowArgs {
+  workspaceId: string;
+  from?: string;
+  to?: string;
+  currency?: string;
+}
+
+/**
+ * Income vs. expense over a date range, bucketed by month.
+ *
+ * `income_minor` sums positive postings on income-type accounts; in
+ * double-entry a paycheck credits Income:Salary (negative) and debits
+ * Checking (positive). To surface income as a positive cashflow figure
+ * we NEGATE the income posting sum (it's naturally <= 0 on the income
+ * leg), then add expenses and compute `net = income - expense`.
+ */
+export async function getCashflowReport(
+  args: CashflowArgs,
+): Promise<z.infer<typeof CashflowReport>> {
+  const currency =
+    args.currency ?? (await fetchWorkspaceBaseCurrency(args.workspaceId));
+
+  const fromFilter = args.from
+    ? sql`AND t.occurred_on >= ${args.from}::date`
+    : sql``;
+  const toFilter = args.to
+    ? sql`AND t.occurred_on <= ${args.to}::date`
+    : sql``;
+
+  const result = await db.execute(sql`
+    WITH filtered AS (
+      SELECT
+        TO_CHAR(date_trunc('month', t.occurred_on), 'YYYY-MM') AS month,
+        a.type::text AS acct_type,
+        p.amount_base_minor
+      FROM postings p
+      JOIN transactions t ON t.id = p.transaction_id
+      JOIN accounts a ON a.id = p.account_id
+      WHERE p.workspace_id = ${args.workspaceId}::uuid
+        AND t.status <> 'voided'
+        AND a.type IN ('income', 'expense')
+        ${fromFilter}
+        ${toFilter}
+    )
+    SELECT
+      month,
+      COALESCE(-SUM(amount_base_minor) FILTER (WHERE acct_type = 'income'), 0)::bigint AS income_minor,
+      COALESCE(SUM(amount_base_minor)  FILTER (WHERE acct_type = 'expense' AND amount_base_minor > 0), 0)::bigint AS expense_minor
+    FROM filtered
+    GROUP BY month
+    ORDER BY month ASC
+  `);
+
+  const buckets = (
+    result.rows as Array<{
+      month: string;
+      income_minor: string | number | bigint;
+      expense_minor: string | number | bigint;
+    }>
+  ).map((r) => {
+    const income = toInt(r.income_minor);
+    const expense = toInt(r.expense_minor);
+    return {
+      month: r.month,
+      income_minor: income,
+      expense_minor: expense,
+      net_minor: income - expense,
+    };
+  });
+
+  const totalIncome = buckets.reduce((a, b) => a + b.income_minor, 0);
+  const totalExpense = buckets.reduce((a, b) => a + b.expense_minor, 0);
+
+  return {
+    from: args.from ?? null,
+    to: args.to ?? null,
+    currency,
+    income_minor: totalIncome,
+    expense_minor: totalExpense,
+    net_minor: totalIncome - totalExpense,
+    buckets,
+  };
+}
+
+// ── Router ─────────────────────────────────────────────────────────────
+
+export const reportsRouter: Router = Router();
+
+reportsRouter.get(
+  "/summary",
+  ah(async (req, res) => {
+    const q = parseOrThrow(SummaryQuery, req.query);
+    const out = await getSummaryReport({
+      workspaceId: req.ctx.workspaceId,
+      from: q.from,
+      to: q.to,
+      groupBy: q.group_by,
+      currency: q.currency,
+    });
+    res.json(out);
+  }),
+);
+
+reportsRouter.get(
+  "/trends",
+  ah(async (req, res) => {
+    const q = parseOrThrow(TrendsQuery, req.query);
+    const out = await getTrendsReport({
+      workspaceId: req.ctx.workspaceId,
+      period: q.period,
+      from: q.from,
+      to: q.to,
+      groupBy: q.group_by,
+      currency: q.currency,
+    });
+    res.json(out);
+  }),
+);
+
+reportsRouter.get(
+  "/net_worth",
+  ah(async (req, res) => {
+    const q = parseOrThrow(NetWorthQuery, req.query);
+    const out = await getNetWorthReport({
+      workspaceId: req.ctx.workspaceId,
+      asOf: q.as_of,
+      currency: q.currency,
+    });
+    res.json(out);
+  }),
+);
+
+reportsRouter.get(
+  "/cashflow",
+  ah(async (req, res) => {
+    const q = parseOrThrow(CashflowQuery, req.query);
+    const out = await getCashflowReport({
+      workspaceId: req.ctx.workspaceId,
+      from: q.from,
+      to: q.to,
+      currency: q.currency,
+    });
+    res.json(out);
+  }),
+);
+
+// ── OpenAPI registration ───────────────────────────────────────────────
+
+const problemResponse = {
+  content: { "application/problem+json": { schema: ProblemDetails } },
+};
+
+export function registerReportsOpenApi(registry: OpenAPIRegistry): void {
+  registry.register("SummaryReport", SummaryReport);
+  registry.register("TrendsReport", TrendsReport);
+  registry.register("NetWorthReport", NetWorthReport);
+  registry.register("CashflowReport", CashflowReport);
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/reports/summary",
+    summary: "Spend aggregated by category / account / payee",
+    tags: ["reports"],
+    request: { query: SummaryQuery },
+    responses: {
+      200: {
+        description: "Summary report",
+        content: { "application/json": { schema: SummaryReport } },
+      },
+      404: { description: "Workspace not found", ...problemResponse },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/reports/trends",
+    summary: "Time-series trend (MoM / YoY) of expense spend",
+    tags: ["reports"],
+    request: { query: TrendsQuery },
+    responses: {
+      200: {
+        description: "Trends report",
+        content: { "application/json": { schema: TrendsReport } },
+      },
+      404: { description: "Workspace not found", ...problemResponse },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/reports/net_worth",
+    summary: "Assets - liabilities at a point in time",
+    tags: ["reports"],
+    request: { query: NetWorthQuery },
+    responses: {
+      200: {
+        description: "Net worth report",
+        content: { "application/json": { schema: NetWorthReport } },
+      },
+      404: { description: "Workspace not found", ...problemResponse },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/reports/cashflow",
+    summary: "Inflows vs outflows over a range, bucketed by month",
+    tags: ["reports"],
+    request: { query: CashflowQuery },
+    responses: {
+      200: {
+        description: "Cashflow report",
+        content: { "application/json": { schema: CashflowReport } },
+      },
+      404: { description: "Workspace not found", ...problemResponse },
+    },
+  });
+}

--- a/src/schemas/v1/index.ts
+++ b/src/schemas/v1/index.ts
@@ -3,3 +3,4 @@ export * from "./account.js";
 export * from "./transaction.js";
 export * from "./document.js";
 export * from "./ingest.js";
+export * from "./report.js";

--- a/src/schemas/v1/report.ts
+++ b/src/schemas/v1/report.ts
@@ -1,0 +1,146 @@
+/**
+ * Zod schemas for `/v1/reports/*` — read-only aggregate endpoints.
+ *
+ * All aggregates roll up `postings` + `transactions` + `accounts`; no
+ * new tables. Money is always returned as integer minor units via
+ * `AmountMinor` (safe as JS `number` up to 2^53).
+ *
+ * Voided transactions are excluded from every report at the service
+ * layer — the schema does not model `status`.
+ */
+import { z } from "zod";
+import {
+  AmountMinor,
+  CurrencyCode,
+  IsoDate,
+  Uuid,
+} from "./common.js";
+
+// ── Shared query primitives ────────────────────────────────────────────
+
+export const SummaryGroupBy = z.enum(["category", "account", "payee"]);
+export const TrendsPeriod = z.enum(["month", "year"]);
+export const TrendsGroupBy = z.enum(["category", "total"]);
+
+// ── Summary ────────────────────────────────────────────────────────────
+
+export const SummaryQuery = z.object({
+  from: IsoDate.optional(),
+  to: IsoDate.optional(),
+  group_by: SummaryGroupBy.optional(),
+  currency: CurrencyCode.optional(),
+});
+
+export const SummaryItem = z
+  .object({
+    key: z.string(),
+    count: z.number().int(),
+    total_minor: AmountMinor,
+    avg_per_txn_minor: AmountMinor,
+  })
+  .openapi("SummaryItem");
+
+export const SummaryReport = z
+  .object({
+    from: IsoDate.nullable(),
+    to: IsoDate.nullable(),
+    group_by: SummaryGroupBy,
+    currency: CurrencyCode,
+    items: z.array(SummaryItem),
+    grand_total_minor: AmountMinor,
+  })
+  .openapi("SummaryReport");
+
+// ── Trends ─────────────────────────────────────────────────────────────
+
+export const TrendsQuery = z.object({
+  period: TrendsPeriod.optional(),
+  from: IsoDate.optional(),
+  to: IsoDate.optional(),
+  group_by: TrendsGroupBy.optional(),
+  currency: CurrencyCode.optional(),
+});
+
+export const TrendsItem = z
+  .object({
+    key: z.string(),
+    total_minor: AmountMinor,
+    count: z.number().int(),
+  })
+  .openapi("TrendsItem");
+
+export const TrendsBucket = z
+  .object({
+    bucket: z.string(),
+    items: z.array(TrendsItem),
+    total_minor: AmountMinor,
+  })
+  .openapi("TrendsBucket");
+
+export const TrendsReport = z
+  .object({
+    from: IsoDate.nullable(),
+    to: IsoDate.nullable(),
+    period: TrendsPeriod,
+    group_by: TrendsGroupBy,
+    currency: CurrencyCode,
+    buckets: z.array(TrendsBucket),
+  })
+  .openapi("TrendsReport");
+
+// ── Net worth ──────────────────────────────────────────────────────────
+
+export const NetWorthQuery = z.object({
+  as_of: IsoDate.optional(),
+  currency: CurrencyCode.optional(),
+});
+
+export const NetWorthAccount = z
+  .object({
+    account_id: Uuid,
+    name: z.string(),
+    type: z.enum(["asset", "liability", "equity", "income", "expense"]),
+    balance_minor: AmountMinor,
+  })
+  .openapi("NetWorthAccount");
+
+export const NetWorthReport = z
+  .object({
+    as_of: IsoDate,
+    currency: CurrencyCode,
+    assets_minor: AmountMinor,
+    liabilities_minor: AmountMinor,
+    equity_minor: AmountMinor,
+    net_worth_minor: AmountMinor,
+    by_account: z.array(NetWorthAccount),
+  })
+  .openapi("NetWorthReport");
+
+// ── Cashflow ───────────────────────────────────────────────────────────
+
+export const CashflowQuery = z.object({
+  from: IsoDate.optional(),
+  to: IsoDate.optional(),
+  currency: CurrencyCode.optional(),
+});
+
+export const CashflowBucket = z
+  .object({
+    month: z.string(),
+    income_minor: AmountMinor,
+    expense_minor: AmountMinor,
+    net_minor: AmountMinor,
+  })
+  .openapi("CashflowBucket");
+
+export const CashflowReport = z
+  .object({
+    from: IsoDate.nullable(),
+    to: IsoDate.nullable(),
+    currency: CurrencyCode,
+    income_minor: AmountMinor,
+    expense_minor: AmountMinor,
+    net_minor: AmountMinor,
+    buckets: z.array(CashflowBucket),
+  })
+  .openapi("CashflowReport");

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { seed } from "./db/seed.js";
 import { registerAccountsMcpTools } from "./mcp/accounts.js";
 import { registerTransactionsMcpTools } from "./mcp/transactions.js";
 import { registerDocumentsMcpTools } from "./mcp/documents.js";
+import { registerReportsMcpTools } from "./mcp/reports.js";
 import { start as startIngestWorker } from "./ingest/worker.js";
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
@@ -28,6 +29,7 @@ const mcp = new FastMCP({
 registerAccountsMcpTools(mcp);
 registerTransactionsMcpTools(mcp);
 registerDocumentsMcpTools(mcp);
+registerReportsMcpTools(mcp);
 
 async function main(): Promise<void> {
   console.log("🗄️  Running Drizzle migrations…");

--- a/tests/integration/reports.test.ts
+++ b/tests/integration/reports.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Integration tests for /v1/reports/* — summary, trends, net_worth, cashflow.
+ *
+ * Exercises the full Express app via supertest against the per-suite
+ * testcontainers Postgres. A small fixture set (see `beforeAll`) covers
+ * multiple months, categories, accounts, and a voided transaction to
+ * verify aggregation correctness and voided exclusion.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { sql } from "drizzle-orm";
+import { v7 as uuidv7 } from "uuid";
+
+import { withTestDb } from "../setup/db.js";
+import {
+  accounts,
+  transactions,
+  postings,
+} from "../../src/schema/index.js";
+
+const ctx = withTestDb();
+
+async function acctId(name: string): Promise<string> {
+  const rows = await ctx.db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(
+      sql`${accounts.workspaceId} = ${ctx.workspaceId} AND ${accounts.name} = ${name}`,
+    );
+  if (rows.length === 0) throw new Error(`Account not found: ${name}`);
+  return rows[0]!.id;
+}
+
+/**
+ * Insert a double-entry transaction with two postings that sum to zero.
+ * debit  → +amount on debitAccountId
+ * credit → -amount on creditAccountId
+ * Both use USD and populate amount_base_minor = amount_minor.
+ */
+async function insertTxn(opts: {
+  occurredOn: string;
+  debitAccountId: string;
+  creditAccountId: string;
+  amountMinor: bigint;
+  payee?: string;
+  status?: "posted" | "voided";
+}): Promise<string> {
+  const txId = uuidv7();
+  await ctx.db.transaction(async (tx) => {
+    await tx.insert(transactions).values({
+      id: txId,
+      workspaceId: ctx.workspaceId,
+      occurredOn: opts.occurredOn,
+      payee: opts.payee ?? "Test Payee",
+      status: opts.status ?? "posted",
+    });
+    await tx.insert(postings).values([
+      {
+        id: uuidv7(),
+        workspaceId: ctx.workspaceId,
+        transactionId: txId,
+        accountId: opts.debitAccountId,
+        amountMinor: opts.amountMinor,
+        currency: "USD",
+        amountBaseMinor: opts.amountMinor,
+      },
+      {
+        id: uuidv7(),
+        workspaceId: ctx.workspaceId,
+        transactionId: txId,
+        accountId: opts.creditAccountId,
+        amountMinor: -opts.amountMinor,
+        currency: "USD",
+        amountBaseMinor: -opts.amountMinor,
+      },
+    ]);
+  });
+  return txId;
+}
+
+// ── Fixture seed ────────────────────────────────────────────────────────
+//
+// 8 posted transactions across Jan / Feb / Mar 2026, plus one voided
+// March transaction that must NOT appear in any aggregate.
+//
+//   Jan 2026:  Groceries 3000 (Checking), Groceries 2000 (Credit Card)
+//              Dining    5000 (Checking)
+//              Salary inflow: +200000 to Checking from Salary income
+//   Feb 2026:  Groceries 4000 (Checking)
+//              Dining    6000 (Credit Card)
+//   Mar 2026:  Groceries 1500 (Checking)
+//              Dining    3500 (Checking)
+//              Salary inflow: +250000 to Checking from Salary income
+//              VOIDED    Dining 9999 (Checking)    ← must be excluded
+
+let groceries: string;
+let dining: string;
+let checking: string;
+let visa: string;
+let salary: string;
+
+beforeAll(async () => {
+  groceries = await acctId("Groceries");
+  dining = await acctId("Dining");
+  checking = await acctId("Checking");
+  visa = await acctId("Credit Card");
+  salary = await acctId("Salary");
+
+  // Jan 2026
+  await insertTxn({
+    occurredOn: "2026-01-05",
+    debitAccountId: groceries,
+    creditAccountId: checking,
+    amountMinor: 3000n,
+    payee: "Whole Foods",
+  });
+  await insertTxn({
+    occurredOn: "2026-01-12",
+    debitAccountId: groceries,
+    creditAccountId: visa,
+    amountMinor: 2000n,
+    payee: "Trader Joes",
+  });
+  await insertTxn({
+    occurredOn: "2026-01-20",
+    debitAccountId: dining,
+    creditAccountId: checking,
+    amountMinor: 5000n,
+    payee: "Bistro",
+  });
+  // Income: Checking ← Salary. In double-entry, income is the CREDIT
+  // (negative on Salary); Checking receives the positive debit.
+  await insertTxn({
+    occurredOn: "2026-01-31",
+    debitAccountId: checking,
+    creditAccountId: salary,
+    amountMinor: 200000n,
+    payee: "Paycheck Jan",
+  });
+
+  // Feb 2026
+  await insertTxn({
+    occurredOn: "2026-02-08",
+    debitAccountId: groceries,
+    creditAccountId: checking,
+    amountMinor: 4000n,
+    payee: "Whole Foods",
+  });
+  await insertTxn({
+    occurredOn: "2026-02-18",
+    debitAccountId: dining,
+    creditAccountId: visa,
+    amountMinor: 6000n,
+    payee: "Bistro",
+  });
+
+  // Mar 2026
+  await insertTxn({
+    occurredOn: "2026-03-03",
+    debitAccountId: groceries,
+    creditAccountId: checking,
+    amountMinor: 1500n,
+    payee: "Corner Store",
+  });
+  await insertTxn({
+    occurredOn: "2026-03-14",
+    debitAccountId: dining,
+    creditAccountId: checking,
+    amountMinor: 3500n,
+    payee: "Bistro",
+  });
+  await insertTxn({
+    occurredOn: "2026-03-28",
+    debitAccountId: checking,
+    creditAccountId: salary,
+    amountMinor: 250000n,
+    payee: "Paycheck Mar",
+  });
+
+  // Voided dining spend — must be excluded.
+  // Trick: insert as 'posted' first (trigger requires balance), then flip.
+  const voidedId = await insertTxn({
+    occurredOn: "2026-03-20",
+    debitAccountId: dining,
+    creditAccountId: checking,
+    amountMinor: 9999n,
+    payee: "Voided Bistro",
+  });
+  await ctx.db.execute(
+    sql`UPDATE transactions SET status = 'voided' WHERE id = ${voidedId}::uuid`,
+  );
+});
+
+// ── /v1/reports/summary ────────────────────────────────────────────────
+
+describe("GET /v1/reports/summary", () => {
+  it("groups by category (default) and returns per-category totals", async () => {
+    const res = await request(ctx.app)
+      .get("/v1/reports/summary")
+      .query({ from: "2026-01-01", to: "2026-03-31" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.group_by).toBe("category");
+    expect(res.body.currency).toBe("USD");
+    expect(res.body.from).toBe("2026-01-01");
+    expect(res.body.to).toBe("2026-03-31");
+
+    const byKey = new Map<string, { count: number; total_minor: number; avg_per_txn_minor: number }>();
+    for (const it of res.body.items) byKey.set(it.key, it);
+
+    // Groceries: 3000 + 2000 + 4000 + 1500 = 10500, 4 txns
+    expect(byKey.get("Groceries")).toMatchObject({ count: 4, total_minor: 10500 });
+    // Dining: 5000 + 6000 + 3500 = 14500, 3 txns (voided 9999 excluded)
+    expect(byKey.get("Dining")).toMatchObject({ count: 3, total_minor: 14500 });
+    // Avg check for Groceries = 10500/4 = 2625
+    expect(byKey.get("Groceries")!.avg_per_txn_minor).toBe(2625);
+
+    expect(res.body.grand_total_minor).toBe(10500 + 14500);
+
+    // Voided txn must not bleed in
+    const hasVoidKey = res.body.items.some((it: any) =>
+      String(it.key).toLowerCase().includes("void"),
+    );
+    expect(hasVoidKey).toBe(false);
+  });
+
+  it("groups by account when group_by=account", async () => {
+    const res = await request(ctx.app)
+      .get("/v1/reports/summary")
+      .query({ from: "2026-01-01", to: "2026-03-31", group_by: "account" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.group_by).toBe("account");
+    // The expense side is what we aggregate, and the expense accounts
+    // in the fixture are Groceries + Dining — so exactly 2 keys.
+    expect(res.body.items).toHaveLength(2);
+    const ids = res.body.items.map((i: any) => i.key).sort();
+    expect(ids).toEqual([groceries, dining].sort());
+  });
+
+  it("groups by payee when group_by=payee", async () => {
+    const res = await request(ctx.app)
+      .get("/v1/reports/summary")
+      .query({ from: "2026-01-01", to: "2026-03-31", group_by: "payee" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.group_by).toBe("payee");
+    const keys = new Set(res.body.items.map((i: any) => i.key));
+    // Whole Foods appears twice (Jan + Feb), Trader Joes once, Bistro 3x,
+    // Corner Store once. Payees for the two Paycheck txns are income-
+    // side so they DO NOT contribute — summary counts expense side only.
+    expect(keys.has("Whole Foods")).toBe(true);
+    expect(keys.has("Trader Joes")).toBe(true);
+    expect(keys.has("Bistro")).toBe(true);
+    expect(keys.has("Corner Store")).toBe(true);
+    expect(keys.has("Voided Bistro")).toBe(false);
+    expect(keys.has("Paycheck Jan")).toBe(false);
+
+    const bistro = res.body.items.find((i: any) => i.key === "Bistro");
+    // Bistro expense total = 5000 (Jan Dining) + 6000 (Feb Dining) + 3500
+    //   (Mar Dining) = 14500. The voided 9999 is excluded.
+    expect(bistro.total_minor).toBe(14500);
+    expect(bistro.count).toBe(3);
+  });
+
+  it("filters by from/to (Feb only slice)", async () => {
+    const res = await request(ctx.app)
+      .get("/v1/reports/summary")
+      .query({ from: "2026-02-01", to: "2026-02-28" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.from).toBe("2026-02-01");
+    expect(res.body.to).toBe("2026-02-28");
+    // Feb: Groceries 4000 + Dining 6000 = 10000
+    expect(res.body.grand_total_minor).toBe(10000);
+    const byKey = new Map<string, any>(
+      res.body.items.map((it: any) => [it.key, it]),
+    );
+    expect(byKey.get("Groceries").total_minor).toBe(4000);
+    expect(byKey.get("Dining").total_minor).toBe(6000);
+  });
+});
+
+// ── /v1/reports/trends ─────────────────────────────────────────────────
+
+describe("GET /v1/reports/trends", () => {
+  it("buckets by month and shows MoM change", async () => {
+    const res = await request(ctx.app)
+      .get("/v1/reports/trends")
+      .query({ period: "month", from: "2026-01-01", to: "2026-03-31" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.period).toBe("month");
+    expect(res.body.buckets).toHaveLength(3);
+    const byBucket = new Map<string, any>(
+      res.body.buckets.map((b: any) => [b.bucket, b]),
+    );
+
+    // Jan expense total: 3000 + 2000 + 5000 = 10000
+    // Feb expense total: 4000 + 6000 = 10000
+    // Mar expense total: 1500 + 3500 = 5000 (voided 9999 excluded)
+    expect(byBucket.get("2026-01").total_minor).toBe(10000);
+    expect(byBucket.get("2026-02").total_minor).toBe(10000);
+    expect(byBucket.get("2026-03").total_minor).toBe(5000);
+
+    // Buckets arrive in ascending order.
+    expect(res.body.buckets.map((b: any) => b.bucket)).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+    ]);
+  });
+});
+
+// ── /v1/reports/net_worth ──────────────────────────────────────────────
+
+describe("GET /v1/reports/net_worth", () => {
+  it("computes assets + liabilities + equity = net_worth at as_of", async () => {
+    const res = await request(ctx.app)
+      .get("/v1/reports/net_worth")
+      .query({ as_of: "2026-03-31" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.as_of).toBe("2026-03-31");
+    expect(res.body.currency).toBe("USD");
+
+    const { assets_minor, liabilities_minor, equity_minor, net_worth_minor } =
+      res.body;
+
+    // Equation invariant: assets + liabilities + equity = net_worth.
+    expect(assets_minor + liabilities_minor + equity_minor).toBe(
+      net_worth_minor,
+    );
+
+    // Sanity: the fixture has two paychecks landing in Checking
+    // (+200000, +250000) minus grocery/dining spent from Checking
+    // (3000 + 5000 + 4000 + 1500 + 3500 = 17000) = +433000 on assets
+    // from Checking. Credit Card (liability) has -2000 -6000 = -8000
+    // (negative on liability → amounts owed).
+    expect(assets_minor).toBe(433000);
+    expect(liabilities_minor).toBe(-8000);
+    // Equity accounts untouched by fixture → 0.
+    expect(equity_minor).toBe(0);
+    expect(net_worth_minor).toBe(433000 + -8000 + 0);
+
+    // by_account sanity: every asset/liability/equity account present.
+    const types = new Set(res.body.by_account.map((a: any) => a.type));
+    expect(types.has("asset")).toBe(true);
+    expect(types.has("liability")).toBe(true);
+    expect(types.has("equity")).toBe(true);
+
+    const checkingRow = res.body.by_account.find(
+      (a: any) => a.account_id === checking,
+    );
+    expect(checkingRow.balance_minor).toBe(433000);
+  });
+});
+
+// ── /v1/reports/cashflow ───────────────────────────────────────────────
+
+describe("GET /v1/reports/cashflow", () => {
+  it("computes income - expense = net over range", async () => {
+    const res = await request(ctx.app)
+      .get("/v1/reports/cashflow")
+      .query({ from: "2026-01-01", to: "2026-03-31" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe("USD");
+
+    // Income: Jan 200000 + Mar 250000 = 450000
+    // Expense: Jan 10000 + Feb 10000 + Mar 5000 = 25000
+    expect(res.body.income_minor).toBe(450000);
+    expect(res.body.expense_minor).toBe(25000);
+    expect(res.body.net_minor).toBe(450000 - 25000);
+    expect(res.body.income_minor - res.body.expense_minor).toBe(
+      res.body.net_minor,
+    );
+
+    // Per-month buckets
+    const byMonth = new Map<string, any>(
+      res.body.buckets.map((b: any) => [b.month, b]),
+    );
+    expect(byMonth.get("2026-01").income_minor).toBe(200000);
+    expect(byMonth.get("2026-01").expense_minor).toBe(10000);
+    expect(byMonth.get("2026-01").net_minor).toBe(190000);
+    expect(byMonth.get("2026-02").income_minor).toBe(0);
+    expect(byMonth.get("2026-02").expense_minor).toBe(10000);
+    expect(byMonth.get("2026-03").income_minor).toBe(250000);
+    expect(byMonth.get("2026-03").expense_minor).toBe(5000);
+  });
+});
+
+// ── Voided exclusion ──────────────────────────────────────────────────
+
+describe("voided transactions are excluded from every report", () => {
+  it("the 9999 voided Dining row is not present in any aggregate", async () => {
+    // Summary: Dining total must NOT include the 9999 voided row.
+    const s = await request(ctx.app)
+      .get("/v1/reports/summary")
+      .query({ from: "2026-01-01", to: "2026-03-31" });
+    const diningRow = s.body.items.find((i: any) => i.key === "Dining");
+    expect(diningRow.total_minor).toBe(14500);
+    expect(diningRow.total_minor).not.toBe(14500 + 9999);
+
+    // Trends: March total must exclude the voided 9999.
+    const t = await request(ctx.app)
+      .get("/v1/reports/trends")
+      .query({ period: "month", from: "2026-03-01", to: "2026-03-31" });
+    const marchBucket = t.body.buckets.find((b: any) => b.bucket === "2026-03");
+    expect(marchBucket.total_minor).toBe(5000);
+
+    // Cashflow: March expense must exclude the voided 9999.
+    const c = await request(ctx.app)
+      .get("/v1/reports/cashflow")
+      .query({ from: "2026-03-01", to: "2026-03-31" });
+    const marchCash = c.body.buckets.find((b: any) => b.month === "2026-03");
+    expect(marchCash.expense_minor).toBe(5000);
+  });
+});
+
+// ── Empty-range fallbacks ─────────────────────────────────────────────
+
+describe("empty ranges / no matches return zeros, not 500", () => {
+  it("summary over a date range with no txns returns empty items and grand_total=0", async () => {
+    const res = await request(ctx.app)
+      .get("/v1/reports/summary")
+      .query({ from: "2027-01-01", to: "2027-12-31" });
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.grand_total_minor).toBe(0);
+    expect(res.body.currency).toBe("USD");
+  });
+
+  it("cashflow over an empty range returns zero totals", async () => {
+    const res = await request(ctx.app)
+      .get("/v1/reports/cashflow")
+      .query({ from: "2027-01-01", to: "2027-12-31" });
+    expect(res.status).toBe(200);
+    expect(res.body.income_minor).toBe(0);
+    expect(res.body.expense_minor).toBe(0);
+    expect(res.body.net_minor).toBe(0);
+    expect(res.body.buckets).toEqual([]);
+  });
+
+  it("net_worth at a date before any activity returns zero balances", async () => {
+    const res = await request(ctx.app)
+      .get("/v1/reports/net_worth")
+      .query({ as_of: "2025-01-01" });
+    expect(res.status).toBe(200);
+    expect(res.body.assets_minor).toBe(0);
+    expect(res.body.liabilities_minor).toBe(0);
+    expect(res.body.equity_minor).toBe(0);
+    expect(res.body.net_worth_minor).toBe(0);
+    // But the account rows should still enumerate (just with zero balances)
+    expect(res.body.by_account.length).toBeGreaterThan(0);
+    for (const a of res.body.by_account) {
+      expect(a.balance_minor).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds 4 read-only aggregate endpoints on top of the double-entry ledger. All queries run over `postings` ⨝ `transactions` ⨝ `accounts` — no new tables, no migrations. Voided transactions are excluded from every report.

| Endpoint | Purpose |
|----------|---------|
| `GET /v1/reports/summary` | Spend by category / account / payee |
| `GET /v1/reports/trends` | MoM or YoY time-series of expenses |
| `GET /v1/reports/net_worth` | assets + liabilities + equity at a point in time |
| `GET /v1/reports/cashflow` | Income vs expense over a range, bucketed by month |

Part of the `/v1/reports/*` track noted in #28 as a follow-up epic; net-new surface that doesn't overlap with in-flight work.

## Example responses

`GET /v1/reports/summary?from=2026-01-01&to=2026-04-19`:
```json
{
  "from": "2026-01-01", "to": "2026-04-19",
  "group_by": "category", "currency": "USD",
  "items": [
    { "key": "Groceries", "count": 17, "total_minor": 52340, "avg_per_txn_minor": 3079 }
  ],
  "grand_total_minor": 124560
}
```

`GET /v1/reports/net_worth?as_of=2026-04-19`:
```json
{
  "as_of": "2026-04-19", "currency": "USD",
  "assets_minor": 433000, "liabilities_minor": -8000, "equity_minor": 0,
  "net_worth_minor": 425000,
  "by_account": [{ "account_id": "...", "name": "Checking", "type": "asset", "balance_minor": 433000 }]
}
```

`GET /v1/reports/cashflow?from=2026-01-01&to=2026-03-31`:
```json
{
  "from": "2026-01-01", "to": "2026-03-31", "currency": "USD",
  "income_minor": 450000, "expense_minor": 25000, "net_minor": 425000,
  "buckets": [
    { "month": "2026-01", "income_minor": 200000, "expense_minor": 10000, "net_minor": 190000 }
  ]
}
```

## Implementation notes

- **Money**: BIGINT minor units in SQL, returned as JS `number` (safe ≤ 2^53).
- **Currency**: defaults to workspace base currency (`workspaces.base_currency`).
- **Expense aggregation** (summary / trends): sums positive `amount_base_minor` on expense-type accounts. This captures the expense side of each transaction without double-counting the settlement side (a $30 grocery run debits Expenses:Groceries +3000 and credits Cash -3000; only the +3000 expense leg counts).
- **Income aggregation** (cashflow): Salary credits Income:Salary (negative); we negate that sum so `income_minor` surfaces as a positive inflow figure.
- **Net worth**: balances every non-closed asset/liability/equity account as of `as_of`, then rolls up by type. `net_worth = assets + liabilities + equity` — liabilities are naturally negative (amounts owed), so the sum yields the intuitive "what I own minus what I owe".
- **Voided exclusion**: every query filters `t.status <> 'voided'`.
- **No pagination**: aggregates are bounded by date range + account count; all reports return complete arrays.

## MCP parity

4 tools registered via `registerReportsMcpTools`:
`get_summary_report`, `get_trends_report`, `get_net_worth_report`, `get_cashflow_report`.

## OpenAPI

`openapi/openapi.json` regenerated: 28 paths total (4 new under `/v1/reports/`), 47 schemas.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Baseline 72 tests still green
- [x] 11 new integration tests in `tests/integration/reports.test.ts`:
  - [x] summary grouped by category / account / payee (3)
  - [x] summary filtered by from/to (1)
  - [x] trends period=month with MoM change across 3 buckets (1)
  - [x] net_worth equation `assets + liabilities + equity = net_worth` (1)
  - [x] cashflow `income - expense = net` per-month and over range (1)
  - [x] voided transaction excluded from summary / trends / cashflow (1)
  - [x] empty date range returns zeros (summary / cashflow / net_worth) (3)
- [x] Total: 83/83 tests passing

## Files

Created:
- `src/schemas/v1/report.ts`
- `src/routes/reports.ts`
- `src/mcp/reports.ts`
- `tests/integration/reports.test.ts`

Modified:
- `src/app.ts` — mount `/v1/reports`
- `src/openapi.ts` — `registerReportsOpenApi(registry)`
- `src/schemas/v1/index.ts` — re-export `report.ts`
- `src/server.ts` — `registerReportsMcpTools(mcp)`
- `openapi/openapi.json` — regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)