### PR TITLE
#32 Phase 2a: reconcile pipeline (dedup + endpoints)

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1274,6 +1274,299 @@
           "poll"
         ]
       },
+      "ReconcileScope": {
+        "type": "string",
+        "enum": [
+          "batch",
+          "batch_plus_recent_90d"
+        ],
+        "default": "batch"
+      },
+      "ReconcileKind": {
+        "type": "string",
+        "enum": [
+          "dedup",
+          "payment_link",
+          "trip_group",
+          "inventory"
+        ]
+      },
+      "ReconcileRequest": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "$ref": "#/components/schemas/ReconcileScope"
+          },
+          "enable": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReconcileKind"
+            }
+          },
+          "auto_apply_threshold": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "default": 0.95
+          }
+        }
+      },
+      "ReconcileBatchStatus": {
+        "type": "string",
+        "enum": [
+          "extracted",
+          "reconciling",
+          "reconciled",
+          "reconcile_error"
+        ]
+      },
+      "ReconcileApplied": {
+        "type": "object",
+        "properties": {
+          "duplicates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "receiptId": {
+                  "type": "string",
+                  "format": "uuid",
+                  "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+                },
+                "duplicateOf": {
+                  "type": "string",
+                  "format": "uuid",
+                  "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+                }
+              },
+              "required": [
+                "receiptId",
+                "duplicateOf"
+              ]
+            },
+            "default": []
+          },
+          "payment_links": {
+            "type": "array",
+            "items": {},
+            "default": []
+          },
+          "inventory": {
+            "type": "array",
+            "items": {},
+            "default": []
+          },
+          "proposals_total": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "proposals_total"
+        ]
+      },
+      "ReconcileProposalStatus": {
+        "type": "string",
+        "enum": [
+          "proposed",
+          "auto_applied",
+          "user_applied",
+          "rejected"
+        ]
+      },
+      "ReconcileProposal": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "batch_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ReconcileKind"
+          },
+          "payload": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "score": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/ReconcileProposalStatus"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resolved_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "batch_id",
+          "kind",
+          "payload",
+          "score",
+          "status",
+          "created_at",
+          "resolved_at"
+        ]
+      },
+      "ReconcileResult": {
+        "type": "object",
+        "properties": {
+          "batchId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ReconcileBatchStatus"
+          },
+          "applied": {
+            "$ref": "#/components/schemas/ReconcileApplied"
+          },
+          "proposals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReconcileProposal"
+            }
+          },
+          "poll": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "batchId",
+          "status",
+          "applied",
+          "proposals"
+        ]
+      },
+      "ApplyRequest": {
+        "type": "object",
+        "properties": {
+          "proposal_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "proposal_ids"
+        ]
+      },
+      "ApplyResult": {
+        "type": "object",
+        "properties": {
+          "applied": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            }
+          },
+          "skipped": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "applied",
+          "skipped"
+        ]
+      },
+      "RejectRequest": {
+        "type": "object",
+        "properties": {
+          "proposal_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "minItems": 1
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "proposal_ids"
+        ]
+      },
+      "RejectResult": {
+        "type": "object",
+        "properties": {
+          "rejected": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            }
+          },
+          "skipped": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "rejected",
+          "skipped"
+        ]
+      },
       "NewPosting": {
         "type": "object",
         "properties": {
@@ -3467,6 +3760,240 @@
           },
           "404": {
             "description": "Ingest not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/batches/{id}/reconcile": {
+      "post": {
+        "summary": "Run the reconcile pipeline over an extracted batch. Idempotent: a second call on a reconciled batch returns the stored result.",
+        "tags": [
+          "reconcile"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReconcileRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Reconcile completed (or replayed)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReconcileResult"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Batch is already mid-reconcile on another caller; response carries a `poll` URL to fetch the final result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReconcileResult"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Batch not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Batch is not in a reconcilable state (still extracting, or entered reconcile_error).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReconcileResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "Fetch the latest reconcile result for a batch.",
+        "tags": [
+          "reconcile"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reconcile snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReconcileResult"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Batch not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/batches/{id}/reconcile/apply": {
+      "post": {
+        "summary": "Apply one or more reconcile proposals. For dedup proposals this voids the duplicate via the ledger service.",
+        "tags": [
+          "reconcile"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Per-id apply/skip outcomes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplyResult"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Batch not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/batches/{id}/reconcile/reject": {
+      "post": {
+        "summary": "Reject one or more reconcile proposals. Marks proposals as rejected with no ledger mutation.",
+        "tags": [
+          "reconcile"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RejectRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Per-id reject/skip outcomes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RejectResult"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Batch not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,7 @@ import {
   batchesRouter,
   ingestsRouter,
 } from "./routes/ingest.js";
+import { reconcileRouter } from "./routes/reconcile.js";
 
 export function buildApp(): Express {
   const app = express();
@@ -59,6 +60,10 @@ export function buildApp(): Express {
   app.use("/v1/postings", postingsRouter);
   app.use("/v1/documents", documentsRouter);
   app.use("/v1/ingest", ingestRouter);
+  // `reconcileRouter` owns `/v1/batches/:id/reconcile*`; mount it first
+  // so Express matches its more-specific paths before falling through to
+  // the generic `batchesRouter` (which handles `/` and `/:id`).
+  app.use("/v1/batches", reconcileRouter);
   app.use("/v1/batches", batchesRouter);
   app.use("/v1/ingests", ingestsRouter);
 

--- a/src/ingest/worker.ts
+++ b/src/ingest/worker.ts
@@ -493,8 +493,10 @@ async function onBatchChildTerminated(
   workspaceId: string,
 ): Promise<void> {
   // If all children of this batch are terminal (done/error/unsupported),
-  // flip the batch to `extracted` and stamp completed_at.
-  await db.execute(
+  // flip the batch to `extracted` and stamp completed_at. RETURNING
+  // tells us whether THIS call is the one that effected the transition
+  // — only then do we kick off auto-reconcile.
+  const res = await db.execute(
     sql`UPDATE batches
          SET status = 'extracted',
              completed_at = NOW()
@@ -505,8 +507,56 @@ async function onBatchChildTerminated(
            SELECT 1 FROM ingests
             WHERE batch_id = ${batchId}::uuid
               AND status NOT IN ('done','error','unsupported')
-         )`,
+         )
+      RETURNING auto_reconcile`,
   );
+  if (res.rows.length === 0) return;
+  const flipped = res.rows[0] as { auto_reconcile: boolean };
+  if (flipped.auto_reconcile) {
+    await triggerAutoReconcile(batchId, workspaceId);
+  }
+}
+
+// ── Auto-reconcile hook (#32 Phase 2a) ───────────────────────────────
+
+/**
+ * Fire-and-forget the reconcile pipeline for a batch that just reached
+ * `extracted`. The extractor path must not block on reconcile — a
+ * reconcile failure leaves the batch in `reconcile_error` but does NOT
+ * revert extraction, per the acceptance criteria in #32 Phase 2a.
+ *
+ * We wire the promise into the worker's `inflight` set so integration
+ * tests can `await drain()` and observe the post-reconcile state
+ * deterministically without sleeping.
+ */
+async function triggerAutoReconcile(
+  batchId: string,
+  workspaceId: string,
+): Promise<void> {
+  // Dynamic import avoids a circular import (engine → transactions.service
+  // → documents/service chains), plus delays work until genuinely needed.
+  const { runReconcile } = await import("../reconcile/engine.js");
+
+  const wsRows = await db
+    .select({ ownerId: workspaces.ownerId })
+    .from(workspaces)
+    .where(eq(workspaces.id, workspaceId));
+  const userId = wsRows[0]?.ownerId;
+  if (!userId) return;
+
+  const p = runReconcile({ workspaceId, userId, batchId })
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[ingest worker] auto-reconcile failed for batch ${batchId}:`,
+        err,
+      );
+    })
+    .finally(() => {
+      inflight.delete(p);
+      resolveDrainWaiters();
+    });
+  inflight.add(p);
 }
 
 // ── Startup recovery ──────────────────────────────────────────────────

--- a/src/mcp/reconcile.ts
+++ b/src/mcp/reconcile.ts
@@ -1,0 +1,106 @@
+/**
+ * FastMCP tools for the reconcile pipeline (#32 Phase 2a).
+ *
+ * Mirrors the `/v1/batches/:id/reconcile*` HTTP surface. Thin adapters
+ * that call the engine directly so the MCP and HTTP paths share all
+ * idempotency + ledger-mutation logic.
+ */
+import { z } from "zod";
+import type { FastMCP } from "fastmcp";
+import { SEED_USER_ID, SEED_WORKSPACE_ID } from "../db/seed.js";
+import {
+  applyProposals,
+  getReconcileResult,
+  rejectProposals,
+  runReconcile,
+  type ReconcileKind,
+} from "../reconcile/engine.js";
+
+function toJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+const KindSchema = z.enum([
+  "dedup",
+  "payment_link",
+  "trip_group",
+  "inventory",
+]);
+
+export function registerReconcileMcpTools(mcp: FastMCP): void {
+  mcp.addTool({
+    name: "reconcile_batch",
+    description:
+      "Run the reconcile pipeline on a batch. Idempotent: a second call on an already-reconciled batch returns the stored result without re-running the detectors.",
+    parameters: z.object({
+      batch_id: z.string().uuid(),
+      scope: z.enum(["batch", "batch_plus_recent_90d"]).optional(),
+      enable: z.array(KindSchema).optional(),
+      auto_apply_threshold: z.number().min(0).max(1).optional(),
+    }),
+    execute: async (args) => {
+      const out = await runReconcile({
+        workspaceId: SEED_WORKSPACE_ID,
+        userId: SEED_USER_ID,
+        batchId: args.batch_id,
+        options: {
+          scope: args.scope,
+          enable: args.enable as ReconcileKind[] | undefined,
+          auto_apply_threshold: args.auto_apply_threshold,
+        },
+      });
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "list_reconcile_proposals",
+    description:
+      "Return all reconcile proposals for a batch (including auto-applied and rejected) with the same payload shape the HTTP endpoint emits.",
+    parameters: z.object({ batch_id: z.string().uuid() }),
+    annotations: { readOnlyHint: true },
+    execute: async (args) => {
+      const out = await getReconcileResult(SEED_WORKSPACE_ID, args.batch_id);
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "apply_reconcile_proposal",
+    description:
+      "Apply one or more proposals by id. For dedup proposals this voids the duplicate transaction via the ledger service and marks the proposal `user_applied`.",
+    parameters: z.object({
+      batch_id: z.string().uuid(),
+      proposal_ids: z.array(z.string().uuid()).min(1),
+    }),
+    execute: async (args) => {
+      const out = await applyProposals({
+        workspaceId: SEED_WORKSPACE_ID,
+        userId: SEED_USER_ID,
+        batchId: args.batch_id,
+        proposalIds: args.proposal_ids,
+      });
+      return toJson(out);
+    },
+  });
+
+  mcp.addTool({
+    name: "reject_reconcile_proposal",
+    description:
+      "Reject one or more proposals by id without mutating the ledger.",
+    parameters: z.object({
+      batch_id: z.string().uuid(),
+      proposal_ids: z.array(z.string().uuid()).min(1),
+      reason: z.string().optional(),
+    }),
+    execute: async (args) => {
+      const out = await rejectProposals({
+        workspaceId: SEED_WORKSPACE_ID,
+        batchId: args.batch_id,
+        proposalIds: args.proposal_ids,
+        reason: args.reason,
+      });
+      return toJson(out);
+    },
+  });
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -25,6 +25,7 @@ import { registerTransactionsOpenApi } from "./routes/transactions.js";
 import { registerPostingsOpenApi } from "./routes/postings.js";
 import { registerDocumentsOpenApi } from "./routes/documents.js";
 import { registerIngestOpenApi } from "./routes/ingest.js";
+import { registerReconcileOpenApi } from "./routes/reconcile.js";
 
 export function buildRegistry(): OpenAPIRegistry {
   const registry = new OpenAPIRegistry();
@@ -59,6 +60,7 @@ export function buildRegistry(): OpenAPIRegistry {
   registerPostingsOpenApi(registry);
   registerDocumentsOpenApi(registry);
   registerIngestOpenApi(registry);
+  registerReconcileOpenApi(registry);
 
   return registry;
 }

--- a/src/reconcile/dedup.ts
+++ b/src/reconcile/dedup.ts
@@ -1,0 +1,126 @@
+/**
+ * Dedup detection — pure SQL, deterministic.
+ *
+ * Goal: within a batch, if two or more transactions share the same
+ * (workspace_id, occurred_on, payee, sum-of-expense-side amount_base_minor)
+ * they are almost certainly the same real-world purchase uploaded twice.
+ *
+ * We pick the earliest `created_at` as the canonical transaction and
+ * propose voiding the later ones. Each proposal scores 1.0 (exact-match
+ * on all four keys) so the engine's `auto_apply_threshold` treats them
+ * as auto-appliable when the operator allows it.
+ *
+ * Scope
+ * -----
+ * Phase 2a compares transactions *within the same batch*. The broader
+ * `batch_plus_recent_90d` scope (compare against the prior 90d window)
+ * will land alongside payment-link because it shares the same SQL shape.
+ *
+ * Why expense side?
+ * -----------------
+ * Every receipt-kind extraction produces two postings: the expense
+ * debit and the credit-card credit. Summing the expense-side postings
+ * gives us a positive total that's stable regardless of which expense
+ * category the agent picked. Summing both sides would be zero (it's a
+ * balanced transaction — that's the whole point of double-entry).
+ */
+import { sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+
+/**
+ * One detected duplicate group.
+ *
+ * `canonical_id` is the transaction we keep (earliest created_at in the
+ * batch). `duplicate_ids` are the later siblings the engine will flag
+ * with a dedup proposal each.
+ */
+export interface DuplicateGroup {
+  canonical_id: string;
+  duplicate_ids: string[];
+  occurred_on: string;
+  payee: string;
+  total_base_minor: number;
+}
+
+/**
+ * Run the dedup detection query and return duplicate groups.
+ *
+ * Only considers transactions with status IN ('posted','reconciled') —
+ * a transaction already voided by a human pre-reconcile must not be
+ * re-flagged. `source_ingest_id` must point inside the target batch.
+ */
+export async function detectDuplicates(params: {
+  workspaceId: string;
+  batchId: string;
+}): Promise<DuplicateGroup[]> {
+  const { workspaceId, batchId } = params;
+
+  // Per-transaction expense-side total. Exclude NULL payees (can't key
+  // on them reliably) and NULL occurred_on (should never happen — date
+  // is NOT NULL in schema — but belt-and-braces).
+  //
+  // amount_base_minor is signed: positive on the expense debit, negative
+  // on the credit-card credit. Summing only positive values keeps us on
+  // the expense side without hard-coding account IDs.
+  const res = await db.execute(sql`
+    WITH batch_txns AS (
+      SELECT t.id,
+             t.occurred_on,
+             t.payee,
+             t.created_at,
+             t.status,
+             COALESCE(SUM(GREATEST(p.amount_base_minor, 0)), 0) AS total_expense_base_minor
+        FROM transactions t
+        JOIN postings p ON p.transaction_id = t.id
+       WHERE t.workspace_id = ${workspaceId}::uuid
+         AND t.status IN ('posted', 'reconciled')
+         AND t.source_ingest_id IN (
+           SELECT id FROM ingests WHERE batch_id = ${batchId}::uuid
+         )
+       GROUP BY t.id, t.occurred_on, t.payee, t.created_at, t.status
+    ),
+    grouped AS (
+      SELECT occurred_on,
+             payee,
+             total_expense_base_minor,
+             ARRAY_AGG(id ORDER BY created_at ASC, id ASC) AS ids
+        FROM batch_txns
+       WHERE payee IS NOT NULL
+         AND total_expense_base_minor > 0
+       GROUP BY occurred_on, payee, total_expense_base_minor
+      HAVING COUNT(*) >= 2
+    )
+    SELECT occurred_on,
+           payee,
+           total_expense_base_minor,
+           ids
+      FROM grouped
+  `);
+
+  const rows = res.rows as Array<{
+    occurred_on: string | Date;
+    payee: string;
+    total_expense_base_minor: number | string;
+    ids: string[];
+  }>;
+
+  const groups: DuplicateGroup[] = [];
+  for (const r of rows) {
+    const ids = Array.isArray(r.ids) ? r.ids : [];
+    if (ids.length < 2) continue;
+    const canonical = ids[0]!;
+    const duplicates = ids.slice(1);
+    const occurredOn =
+      r.occurred_on instanceof Date
+        ? r.occurred_on.toISOString().slice(0, 10)
+        : String(r.occurred_on).slice(0, 10);
+    groups.push({
+      canonical_id: canonical,
+      duplicate_ids: duplicates,
+      occurred_on: occurredOn,
+      payee: r.payee,
+      total_base_minor: Number(r.total_expense_base_minor),
+    });
+  }
+  return groups;
+}

--- a/src/reconcile/engine.ts
+++ b/src/reconcile/engine.ts
@@ -1,0 +1,567 @@
+/**
+ * Reconcile pipeline orchestrator (#32 Phase 2a).
+ *
+ * Runs enabled detector steps against a batch that has reached
+ * `status='extracted'`, writes findings as `reconcile_proposals` rows,
+ * and flips the batch's status through the reconcile state machine:
+ *
+ *     extracted → reconciling → reconciled       (success)
+ *     extracted → reconciling → reconcile_error  (uncaught failure)
+ *
+ * Idempotency:
+ *   - A batch already in `reconciled` returns its stored proposals
+ *     without re-running the steps.
+ *   - A batch in `reconciling` is a concurrent run; the caller gets a
+ *     `{status:"reconciling", poll}` hint and the existing run finishes
+ *     on its own thread.
+ *
+ * Apply / reject:
+ *   - `applyProposals` handles each proposal kind. For `dedup` it voids
+ *     the duplicate transaction via the existing v1 service (so the
+ *     balance trigger + audit log still fire) and stamps the proposal
+ *     `status='user_applied'`.
+ *   - `rejectProposals` just flips `status='rejected'` — no ledger
+ *     mutation, proposal is frozen for future audit.
+ *
+ * Apply and auto-apply share the same action function so a dedup
+ * voided above the auto-apply threshold and one applied by a human
+ * produce identical ledger effects (one void + one voided-by link).
+ */
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { batches, reconcileProposals, transactions } from "../schema/index.js";
+import { newId } from "../http/uuid.js";
+import { NotFoundProblem } from "../http/problem.js";
+import { voidTransaction } from "../routes/transactions.service.js";
+import { detectDuplicates } from "./dedup.js";
+import {
+  paymentLinkStub,
+  inventoryStub,
+  tripGroupStub,
+  type StepResult,
+} from "./stubs.js";
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export type ReconcileKind = "dedup" | "payment_link" | "trip_group" | "inventory";
+export type ReconcileProposalStatus =
+  | "proposed"
+  | "auto_applied"
+  | "user_applied"
+  | "rejected";
+
+export interface ProposalRow {
+  id: string;
+  batch_id: string;
+  kind: ReconcileKind;
+  payload: Record<string, unknown>;
+  score: number | null;
+  status: ReconcileProposalStatus;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+export interface AppliedSummary {
+  duplicates: Array<{ receiptId: string; duplicateOf: string }>;
+  payment_links: unknown[];
+  inventory: unknown[];
+  proposals_total: number;
+}
+
+export interface ReconcileResultShape {
+  batchId: string;
+  status: "reconciling" | "reconciled" | "reconcile_error" | "extracted";
+  applied: AppliedSummary;
+  proposals: ProposalRow[];
+  poll?: string;
+}
+
+export interface ReconcileOptions {
+  scope?: "batch" | "batch_plus_recent_90d";
+  enable?: ReconcileKind[];
+  auto_apply_threshold?: number;
+}
+
+const DEFAULT_ENABLED: ReconcileKind[] = [
+  "dedup",
+  "payment_link",
+  "trip_group",
+  "inventory",
+];
+const DEFAULT_AUTO_APPLY_THRESHOLD = 0.95;
+
+// ── Mappers ───────────────────────────────────────────────────────────
+
+function toIso(v: Date | string | null | undefined): string | null {
+  if (v === null || v === undefined) return null;
+  if (v instanceof Date) return v.toISOString();
+  return new Date(v).toISOString();
+}
+
+function mapProposal(r: typeof reconcileProposals.$inferSelect): ProposalRow {
+  return {
+    id: r.id,
+    batch_id: r.batchId,
+    kind: r.kind as ReconcileKind,
+    payload: (r.payload ?? {}) as Record<string, unknown>,
+    score: r.score === null || r.score === undefined ? null : Number(r.score),
+    status: r.status as ReconcileProposalStatus,
+    created_at: toIso(r.createdAt)!,
+    resolved_at: toIso(r.resolvedAt),
+  };
+}
+
+// ── Load ──────────────────────────────────────────────────────────────
+
+async function loadBatchStrict(
+  workspaceId: string,
+  batchId: string,
+): Promise<typeof batches.$inferSelect> {
+  const rows = await db
+    .select()
+    .from(batches)
+    .where(and(eq(batches.id, batchId), eq(batches.workspaceId, workspaceId)));
+  if (rows.length === 0) throw new NotFoundProblem("Batch", batchId);
+  return rows[0]!;
+}
+
+async function loadProposals(batchId: string): Promise<ProposalRow[]> {
+  const rows = await db
+    .select()
+    .from(reconcileProposals)
+    .where(eq(reconcileProposals.batchId, batchId))
+    .orderBy(reconcileProposals.createdAt);
+  return rows.map(mapProposal);
+}
+
+function summarizeApplied(proposals: ProposalRow[]): AppliedSummary {
+  const duplicates: AppliedSummary["duplicates"] = [];
+  const payment_links: unknown[] = [];
+  const inventory: unknown[] = [];
+  for (const p of proposals) {
+    if (p.status !== "auto_applied" && p.status !== "user_applied") continue;
+    if (p.kind === "dedup") {
+      const payload = p.payload as {
+        duplicate?: string;
+        duplicate_of?: string;
+      };
+      if (payload.duplicate && payload.duplicate_of) {
+        duplicates.push({
+          receiptId: payload.duplicate,
+          duplicateOf: payload.duplicate_of,
+        });
+      }
+    } else if (p.kind === "payment_link") {
+      payment_links.push(p.payload);
+    } else if (p.kind === "inventory") {
+      inventory.push(p.payload);
+    }
+  }
+  return {
+    duplicates,
+    payment_links,
+    inventory,
+    proposals_total: proposals.length,
+  };
+}
+
+// ── Public read ───────────────────────────────────────────────────────
+
+export async function getReconcileResult(
+  workspaceId: string,
+  batchId: string,
+): Promise<ReconcileResultShape> {
+  const batch = await loadBatchStrict(workspaceId, batchId);
+  const proposals = await loadProposals(batchId);
+  const status = batch.status as ReconcileResultShape["status"];
+  return {
+    batchId,
+    status,
+    applied: summarizeApplied(proposals),
+    proposals,
+    ...(status === "reconciling"
+      ? { poll: `/v1/batches/${batchId}/reconcile` }
+      : {}),
+  };
+}
+
+// ── Dedup application (shared by auto-apply + user apply) ─────────────
+
+/**
+ * Void the duplicate transaction via the ledger service. Returns true
+ * if the void happened; false if the row was already voided (idempotent
+ * replay).
+ */
+async function voidDuplicate(params: {
+  workspaceId: string;
+  userId: string;
+  duplicateId: string;
+  canonicalId: string;
+}): Promise<boolean> {
+  const { workspaceId, userId, duplicateId, canonicalId } = params;
+  const rows = await db
+    .select({ version: transactions.version, status: transactions.status })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.id, duplicateId),
+        eq(transactions.workspaceId, workspaceId),
+      ),
+    );
+  if (rows.length === 0) return false;
+  const cur = rows[0]!;
+  if (cur.status === "voided" || cur.status === "draft" || cur.status === "error") {
+    return false;
+  }
+  await voidTransaction(
+    workspaceId,
+    userId,
+    duplicateId,
+    Number(cur.version),
+    `reconcile: duplicate of ${canonicalId}`,
+  );
+  return true;
+}
+
+// ── Orchestrator ──────────────────────────────────────────────────────
+
+/**
+ * Run the reconcile pipeline on a batch.
+ *
+ * Returns the final result synchronously. The HTTP route fires
+ * this in-process: for Phase 2a batches with a handful of files the
+ * dedup query dominates and completes in a few milliseconds. The
+ * worker-triggered auto-reconcile path wraps the call in a fire-and-
+ * forget promise so extraction's success isn't gated on reconcile.
+ */
+export async function runReconcile(params: {
+  workspaceId: string;
+  userId: string;
+  batchId: string;
+  options?: ReconcileOptions;
+}): Promise<ReconcileResultShape> {
+  const { workspaceId, userId, batchId, options = {} } = params;
+  const enable = options.enable ?? DEFAULT_ENABLED;
+  const threshold = options.auto_apply_threshold ?? DEFAULT_AUTO_APPLY_THRESHOLD;
+
+  // Idempotency: take a conditional lock on the batch's status. Only a
+  // batch currently `extracted` transitions to `reconciling`; anything
+  // else short-circuits to a no-op read.
+  const lock = await db.execute(
+    sql`UPDATE batches
+         SET status = 'reconciling'
+       WHERE id = ${batchId}::uuid
+         AND workspace_id = ${workspaceId}::uuid
+         AND status = 'extracted'
+      RETURNING id`,
+  );
+  if (lock.rows.length === 0) {
+    // Not transitioning — either not-extracted, already reconciled, or
+    // mid-reconcile by another caller. Return the authoritative view.
+    return await getReconcileResult(workspaceId, batchId);
+  }
+
+  try {
+    const newProposals: Array<{
+      id: string;
+      kind: ReconcileKind;
+      payload: Record<string, unknown>;
+      score: number;
+      status: ReconcileProposalStatus;
+      resolvedAt: Date | null;
+    }> = [];
+
+    // ── Step 1: dedup ────────────────────────────────────────────────
+    if (enable.includes("dedup")) {
+      const groups = await detectDuplicates({ workspaceId, batchId });
+      for (const g of groups) {
+        for (const dupId of g.duplicate_ids) {
+          newProposals.push({
+            id: newId(),
+            kind: "dedup",
+            payload: {
+              duplicate: dupId,
+              duplicate_of: g.canonical_id,
+              key: {
+                occurred_on: g.occurred_on,
+                payee: g.payee,
+                total_base_minor: g.total_base_minor,
+              },
+            },
+            // Dedup is an exact match on four keys → always 1.0.
+            score: 1.0,
+            // Auto-apply later if threshold allows.
+            status: "proposed",
+            resolvedAt: null,
+          });
+        }
+      }
+    }
+
+    // ── Step 2-4: stubs ──────────────────────────────────────────────
+    const stubSteps: Array<{ kind: ReconcileKind; run: () => Promise<StepResult> }> = [];
+    if (enable.includes("payment_link")) {
+      stubSteps.push({
+        kind: "payment_link",
+        run: () => paymentLinkStub({ workspaceId, batchId }),
+      });
+    }
+    if (enable.includes("inventory")) {
+      stubSteps.push({
+        kind: "inventory",
+        run: () => inventoryStub({ workspaceId, batchId }),
+      });
+    }
+    if (enable.includes("trip_group")) {
+      stubSteps.push({
+        kind: "trip_group",
+        run: () => tripGroupStub({ workspaceId, batchId }),
+      });
+    }
+
+    for (const step of stubSteps) {
+      const r = await step.run();
+      if (r.reason) {
+        // eslint-disable-next-line no-console
+        console.info(
+          `[reconcile] batch=${batchId} step=${step.kind} skipped: ${r.reason}`,
+        );
+      }
+      for (const p of r.proposals) {
+        newProposals.push({
+          id: newId(),
+          kind: step.kind,
+          payload: p.payload,
+          score: p.score,
+          status: "proposed",
+          resolvedAt: null,
+        });
+      }
+    }
+
+    // ── Insert proposals row-by-row so we have IDs for auto-apply ────
+    if (newProposals.length > 0) {
+      await db.insert(reconcileProposals).values(
+        newProposals.map((p) => ({
+          id: p.id,
+          batchId,
+          kind: p.kind,
+          payload: p.payload,
+          score: p.score,
+          status: p.status,
+          resolvedAt: p.resolvedAt,
+        })),
+      );
+    }
+
+    // ── Auto-apply above threshold ───────────────────────────────────
+    // Only dedup has a real action today; the stubs never produce
+    // proposals so their auto-apply paths never fire.
+    for (const p of newProposals) {
+      if (p.score < threshold) continue;
+      if (p.kind !== "dedup") continue;
+      const payload = p.payload as {
+        duplicate: string;
+        duplicate_of: string;
+      };
+      try {
+        const voided = await voidDuplicate({
+          workspaceId,
+          userId,
+          duplicateId: payload.duplicate,
+          canonicalId: payload.duplicate_of,
+        });
+        if (voided) {
+          await db
+            .update(reconcileProposals)
+            .set({ status: "auto_applied", resolvedAt: new Date() })
+            .where(eq(reconcileProposals.id, p.id));
+        } else {
+          // Row was already voided — mark the proposal resolved as
+          // user_applied-retroactive so we don't leave a stuck
+          // `proposed` row pointing at a void.
+          await db
+            .update(reconcileProposals)
+            .set({ status: "auto_applied", resolvedAt: new Date() })
+            .where(eq(reconcileProposals.id, p.id));
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[reconcile] auto-apply failed for proposal ${p.id}:`,
+          err,
+        );
+        // Leave proposal as `proposed` so a human can retry via apply.
+      }
+    }
+
+    // ── Flip batch to reconciled ─────────────────────────────────────
+    await db
+      .update(batches)
+      .set({ status: "reconciled", reconciledAt: new Date() })
+      .where(
+        and(eq(batches.id, batchId), eq(batches.workspaceId, workspaceId)),
+      );
+
+    return await getReconcileResult(workspaceId, batchId);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(`[reconcile] batch=${batchId} failed:`, err);
+    await db
+      .update(batches)
+      .set({ status: "reconcile_error" })
+      .where(
+        and(eq(batches.id, batchId), eq(batches.workspaceId, workspaceId)),
+      );
+    // Still return the current view so callers see the failure state.
+    return await getReconcileResult(workspaceId, batchId);
+  }
+}
+
+// ── Apply / reject ────────────────────────────────────────────────────
+
+export interface ApplyOutcome {
+  applied: string[];
+  skipped: Array<{ id: string; reason: string }>;
+}
+
+export async function applyProposals(params: {
+  workspaceId: string;
+  userId: string;
+  batchId: string;
+  proposalIds: string[];
+}): Promise<ApplyOutcome> {
+  const { workspaceId, userId, batchId, proposalIds } = params;
+  // Sanity-check batch ownership.
+  await loadBatchStrict(workspaceId, batchId);
+
+  if (proposalIds.length === 0) return { applied: [], skipped: [] };
+
+  const rows = await db
+    .select()
+    .from(reconcileProposals)
+    .where(
+      and(
+        eq(reconcileProposals.batchId, batchId),
+        inArray(reconcileProposals.id, proposalIds),
+      ),
+    );
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  const applied: string[] = [];
+  const skipped: ApplyOutcome["skipped"] = [];
+
+  for (const pid of proposalIds) {
+    const row = byId.get(pid);
+    if (!row) {
+      skipped.push({ id: pid, reason: "not_found" });
+      continue;
+    }
+    if (row.status === "user_applied" || row.status === "auto_applied") {
+      // Already applied — idempotent success.
+      applied.push(pid);
+      continue;
+    }
+    if (row.status === "rejected") {
+      skipped.push({ id: pid, reason: "rejected" });
+      continue;
+    }
+
+    if (row.kind === "dedup") {
+      const payload = (row.payload ?? {}) as {
+        duplicate?: string;
+        duplicate_of?: string;
+      };
+      if (!payload.duplicate || !payload.duplicate_of) {
+        skipped.push({ id: pid, reason: "malformed_payload" });
+        continue;
+      }
+      try {
+        await voidDuplicate({
+          workspaceId,
+          userId,
+          duplicateId: payload.duplicate,
+          canonicalId: payload.duplicate_of,
+        });
+        await db
+          .update(reconcileProposals)
+          .set({ status: "user_applied", resolvedAt: new Date() })
+          .where(eq(reconcileProposals.id, pid));
+        applied.push(pid);
+      } catch (err) {
+        skipped.push({
+          id: pid,
+          reason:
+            err instanceof Error ? `void_failed: ${err.message}` : "void_failed",
+        });
+      }
+    } else {
+      // Stubbed kinds have no backing action yet.
+      skipped.push({
+        id: pid,
+        reason: `kind=${row.kind} not applicable in Phase 2a`,
+      });
+    }
+  }
+
+  return { applied, skipped };
+}
+
+export interface RejectOutcome {
+  rejected: string[];
+  skipped: Array<{ id: string; reason: string }>;
+}
+
+export async function rejectProposals(params: {
+  workspaceId: string;
+  batchId: string;
+  proposalIds: string[];
+  // `reason` is accepted by the API but not persisted — the
+  // reconcile_proposals schema has no reason column, and a free-text
+  // audit note fits better in the future audit_events table. We accept
+  // it for forward-compat without writing anywhere.
+  reason?: string;
+}): Promise<RejectOutcome> {
+  const { workspaceId, batchId, proposalIds } = params;
+  await loadBatchStrict(workspaceId, batchId);
+
+  if (proposalIds.length === 0) return { rejected: [], skipped: [] };
+
+  const rows = await db
+    .select()
+    .from(reconcileProposals)
+    .where(
+      and(
+        eq(reconcileProposals.batchId, batchId),
+        inArray(reconcileProposals.id, proposalIds),
+      ),
+    );
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  const rejected: string[] = [];
+  const skipped: RejectOutcome["skipped"] = [];
+
+  for (const pid of proposalIds) {
+    const row = byId.get(pid);
+    if (!row) {
+      skipped.push({ id: pid, reason: "not_found" });
+      continue;
+    }
+    if (row.status === "rejected") {
+      rejected.push(pid);
+      continue;
+    }
+    if (row.status === "user_applied" || row.status === "auto_applied") {
+      skipped.push({ id: pid, reason: "already_applied" });
+      continue;
+    }
+
+    await db
+      .update(reconcileProposals)
+      .set({ status: "rejected", resolvedAt: new Date() })
+      .where(eq(reconcileProposals.id, pid));
+    rejected.push(pid);
+  }
+
+  return { rejected, skipped };
+}

--- a/src/reconcile/stubs.ts
+++ b/src/reconcile/stubs.ts
@@ -1,0 +1,96 @@
+/**
+ * Stub implementations for the three reconcile steps whose backing data
+ * does not exist yet in the Phase 2a schema.
+ *
+ * Each stub returns `{ proposals: [], reason }` synchronously so the
+ * engine can still emit a complete audit trail (which steps ran, which
+ * skipped, why) to operators.
+ *
+ * Lifecycle
+ *   payment_link  — unblocks when `statement_pdf` ingestion lands
+ *                   (Phase 2b of #32 + #28's bank-statement consumer).
+ *   inventory     — unblocks when the `inventory_items` +
+ *                   `receipt_items` tables land (separate feature).
+ *   trip_group    — unblocks when the `trips` table lands and the
+ *                   geo/cluster proposal call is wired.
+ *
+ * When one of these steps ships, replace the corresponding stub with a
+ * real detector module under `src/reconcile/<kind>.ts` and keep the
+ * same return contract (`StubResult` → `{ proposals, reason? }`).
+ */
+
+/**
+ * Return shape shared by every step detector (real or stubbed).
+ *
+ * `proposals` is a list of proto-proposal payloads; the engine wraps
+ * each one in a `reconcile_proposals` row. `reason` is a free-text log
+ * entry included in the step's skip note when `proposals.length === 0`.
+ */
+export interface StepResult {
+  proposals: Array<{
+    payload: Record<string, unknown>;
+    score: number;
+  }>;
+  reason?: string;
+}
+
+/**
+ * TODO(#32 Phase 2b): statement-line ↔ receipt payment linking.
+ *
+ * Requires `statement_pdf` ingestion to write N transactions per
+ * statement row with a distinguishable source classification, so this
+ * step can match them to receipt-sourced transactions by
+ * fuzzy(merchant) + date±1 + amount. Blocked until statement ingestion
+ * lands — Phase 1 explicitly maps statements to `unsupported` in the
+ * worker.
+ */
+export async function paymentLinkStub(_params: {
+  workspaceId: string;
+  batchId: string;
+}): Promise<StepResult> {
+  return {
+    proposals: [],
+    reason:
+      "payment_link step is stubbed until statement_pdf ingestion lands (Phase 2b of #32).",
+  };
+}
+
+/**
+ * TODO(separate feature): inventory aggregation.
+ *
+ * Needs `receipt_items` + `inventory_items` tables. Current schema
+ * carries neither — transactions are headline-level only. When the
+ * inventory feature lands, this stub is replaced by a detector that
+ * upserts inventory rows from `receipt_items` and proposes consumption
+ * stats updates.
+ */
+export async function inventoryStub(_params: {
+  workspaceId: string;
+  batchId: string;
+}): Promise<StepResult> {
+  return {
+    proposals: [],
+    reason:
+      "inventory step is stubbed; receipt_items + inventory_items tables do not exist yet.",
+  };
+}
+
+/**
+ * TODO(separate feature): trip proposal from date/geo clustering.
+ *
+ * Requires a `trips` table + a `claude -p` clustering call. Deliberately
+ * a stub in Phase 2a because the per-batch reconcile pipeline ships
+ * before the trip module. Once trips exist, replace with a small
+ * classifier that groups transactions by proximity and proposes a
+ * trip_id assignment.
+ */
+export async function tripGroupStub(_params: {
+  workspaceId: string;
+  batchId: string;
+}): Promise<StepResult> {
+  return {
+    proposals: [],
+    reason:
+      "trip_group step is stubbed until the trips table + clustering call ship.",
+  };
+}

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,0 +1,241 @@
+/**
+ * `/v1/batches/:id/reconcile` family — Phase 2a of issue #32.
+ *
+ *   POST   /v1/batches/:id/reconcile          — run or replay (idempotent)
+ *   GET    /v1/batches/:id/reconcile          — latest result
+ *   POST   /v1/batches/:id/reconcile/apply    — accept proposal(s)
+ *   POST   /v1/batches/:id/reconcile/reject   — reject proposal(s)
+ *
+ * Mounted from `src/app.ts` at `/v1/batches` via a separate router. The
+ * path shape `POST /v1/batches/:id/reconcile` cannot be colocated on
+ * the existing `batchesRouter` without reshuffling the `/v1/batches/:id`
+ * GET handler's param parsing; keeping a sibling router is simpler and
+ * leaves the ingest module owned by #32 Phase 1.
+ *
+ * All four endpoints delegate to `src/reconcile/engine.ts`. The route
+ * layer only handles HTTP details: param parsing, status-code mapping
+ * (200 when idempotent replay, 201 on first-time reconcile, 202 when
+ * the batch is mid-reconcile on another caller's thread), and OpenAPI
+ * registration.
+ */
+import { Router, type Request, type Response, type NextFunction } from "express";
+import { z } from "zod";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+import { parseOrThrow } from "../http/validate.js";
+import { ProblemDetails, Uuid } from "../schemas/v1/common.js";
+import {
+  ApplyRequest,
+  ApplyResult,
+  ReconcileRequest,
+  ReconcileResult,
+  RejectRequest,
+  RejectResult,
+} from "../schemas/v1/reconcile.js";
+import {
+  applyProposals,
+  getReconcileResult,
+  rejectProposals,
+  runReconcile,
+} from "../reconcile/engine.js";
+
+function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<void>,
+) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    fn(req, res, next).catch(next);
+  };
+}
+
+export const reconcileRouter: Router = Router({ mergeParams: true });
+
+// Params arrive on the nested router under `:id` as the batch id.
+const BatchIdParams = z.object({ id: Uuid });
+
+// ── POST /v1/batches/:id/reconcile ────────────────────────────────────
+
+reconcileRouter.post(
+  "/:id/reconcile",
+  asyncHandler(async (req, res) => {
+    const { id: batchId } = parseOrThrow(BatchIdParams, req.params);
+    const body = parseOrThrow(ReconcileRequest, req.body ?? {});
+
+    const out = await runReconcile({
+      workspaceId: req.ctx.workspaceId,
+      userId: req.ctx.userId,
+      batchId,
+      options: {
+        scope: body.scope,
+        enable: body.enable,
+        auto_apply_threshold: body.auto_apply_threshold,
+      },
+    });
+
+    // Status-code mapping:
+    //   reconciled  — either the run just completed (201) OR we short-
+    //                 circuited an already-reconciled batch (200).
+    //   reconciling — run is in-flight on another caller; hint + 202.
+    //   reconcile_error — surface the failure state as 409 so clients
+    //                 don't mistake it for success; body still carries
+    //                 proposals-so-far for debugging.
+    //   extracted   — the conditional lock didn't take hold and the
+    //                 batch is still pre-reconcile; should not happen
+    //                 under normal flow, return 409.
+    let statusCode = 200;
+    if (out.status === "reconciling") statusCode = 202;
+    else if (out.status === "reconcile_error") statusCode = 409;
+    else if (out.status === "extracted") statusCode = 409;
+    // For `reconciled` keep 200 — 201 is reserved for created resources
+    // and the proposals rows can exist from an earlier run. Clients key
+    // on body.status, not the status code.
+
+    res.status(statusCode).json(out);
+  }),
+);
+
+// ── GET /v1/batches/:id/reconcile ─────────────────────────────────────
+
+reconcileRouter.get(
+  "/:id/reconcile",
+  asyncHandler(async (req, res) => {
+    const { id: batchId } = parseOrThrow(BatchIdParams, req.params);
+    const out = await getReconcileResult(req.ctx.workspaceId, batchId);
+    res.json(out);
+  }),
+);
+
+// ── POST /v1/batches/:id/reconcile/apply ──────────────────────────────
+
+reconcileRouter.post(
+  "/:id/reconcile/apply",
+  asyncHandler(async (req, res) => {
+    const { id: batchId } = parseOrThrow(BatchIdParams, req.params);
+    const body = parseOrThrow(ApplyRequest, req.body ?? {});
+    const out = await applyProposals({
+      workspaceId: req.ctx.workspaceId,
+      userId: req.ctx.userId,
+      batchId,
+      proposalIds: body.proposal_ids,
+    });
+    res.json(out);
+  }),
+);
+
+// ── POST /v1/batches/:id/reconcile/reject ─────────────────────────────
+
+reconcileRouter.post(
+  "/:id/reconcile/reject",
+  asyncHandler(async (req, res) => {
+    const { id: batchId } = parseOrThrow(BatchIdParams, req.params);
+    const body = parseOrThrow(RejectRequest, req.body ?? {});
+    const out = await rejectProposals({
+      workspaceId: req.ctx.workspaceId,
+      batchId,
+      proposalIds: body.proposal_ids,
+      reason: body.reason,
+    });
+    res.json(out);
+  }),
+);
+
+// ── OpenAPI registration ──────────────────────────────────────────────
+
+export function registerReconcileOpenApi(registry: OpenAPIRegistry): void {
+  registry.register("ReconcileRequest", ReconcileRequest);
+  registry.register("ReconcileResult", ReconcileResult);
+  registry.register("ApplyRequest", ApplyRequest);
+  registry.register("ApplyResult", ApplyResult);
+  registry.register("RejectRequest", RejectRequest);
+  registry.register("RejectResult", RejectResult);
+
+  const problemContent = {
+    "application/problem+json": { schema: ProblemDetails },
+  };
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/batches/{id}/reconcile",
+    summary:
+      "Run the reconcile pipeline over an extracted batch. Idempotent: a second call on a reconciled batch returns the stored result.",
+    tags: ["reconcile"],
+    request: {
+      params: z.object({ id: Uuid }),
+      body: {
+        required: false,
+        content: { "application/json": { schema: ReconcileRequest } },
+      },
+    },
+    responses: {
+      200: {
+        description: "Reconcile completed (or replayed)",
+        content: { "application/json": { schema: ReconcileResult } },
+      },
+      202: {
+        description:
+          "Batch is already mid-reconcile on another caller; response carries a `poll` URL to fetch the final result.",
+        content: { "application/json": { schema: ReconcileResult } },
+      },
+      404: { description: "Batch not found", content: problemContent },
+      409: {
+        description:
+          "Batch is not in a reconcilable state (still extracting, or entered reconcile_error).",
+        content: { "application/json": { schema: ReconcileResult } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/batches/{id}/reconcile",
+    summary: "Fetch the latest reconcile result for a batch.",
+    tags: ["reconcile"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: {
+        description: "Reconcile snapshot",
+        content: { "application/json": { schema: ReconcileResult } },
+      },
+      404: { description: "Batch not found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/batches/{id}/reconcile/apply",
+    summary:
+      "Apply one or more reconcile proposals. For dedup proposals this voids the duplicate via the ledger service.",
+    tags: ["reconcile"],
+    request: {
+      params: z.object({ id: Uuid }),
+      body: { content: { "application/json": { schema: ApplyRequest } } },
+    },
+    responses: {
+      200: {
+        description: "Per-id apply/skip outcomes",
+        content: { "application/json": { schema: ApplyResult } },
+      },
+      404: { description: "Batch not found", content: problemContent },
+      422: { description: "Validation failed", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/batches/{id}/reconcile/reject",
+    summary:
+      "Reject one or more reconcile proposals. Marks proposals as rejected with no ledger mutation.",
+    tags: ["reconcile"],
+    request: {
+      params: z.object({ id: Uuid }),
+      body: { content: { "application/json": { schema: RejectRequest } } },
+    },
+    responses: {
+      200: {
+        description: "Per-id reject/skip outcomes",
+        content: { "application/json": { schema: RejectResult } },
+      },
+      404: { description: "Batch not found", content: problemContent },
+      422: { description: "Validation failed", content: problemContent },
+    },
+  });
+}

--- a/src/schemas/v1/index.ts
+++ b/src/schemas/v1/index.ts
@@ -3,3 +3,4 @@ export * from "./account.js";
 export * from "./transaction.js";
 export * from "./document.js";
 export * from "./ingest.js";
+export * from "./reconcile.js";

--- a/src/schemas/v1/reconcile.ts
+++ b/src/schemas/v1/reconcile.ts
@@ -1,0 +1,147 @@
+/**
+ * Zod schemas for `/v1/batches/:id/reconcile*` (Phase 2 of #32).
+ *
+ * The reconcile pipeline runs four steps over the extracted outputs of a
+ * batch. Only the dedup step writes proposals today; `payment_link`,
+ * `inventory`, and `trip_group` are registered as no-op stubs so the
+ * payload shape + wiring is stable before backing data exists.
+ *
+ * Proposal shape is intentionally permissive — `payload` is a JSONB blob
+ * whose schema varies by `kind`. Clients branch on `kind` and read
+ * kind-specific fields from `payload`.
+ */
+import { z } from "zod";
+import { IsoDateTime, Uuid } from "./common.js";
+
+// ── Enumerations ──────────────────────────────────────────────────────
+
+export const ReconcileKind = z
+  .enum(["dedup", "payment_link", "trip_group", "inventory"])
+  .openapi("ReconcileKind");
+
+export const ReconcileProposalStatus = z
+  .enum(["proposed", "auto_applied", "user_applied", "rejected"])
+  .openapi("ReconcileProposalStatus");
+
+export const ReconcileScope = z
+  .enum(["batch", "batch_plus_recent_90d"])
+  .openapi("ReconcileScope");
+
+// ── Proposal ──────────────────────────────────────────────────────────
+
+/**
+ * A single reconcile finding.
+ *
+ * `payload` shape by kind:
+ *   dedup         → { duplicate_of: <txn_id>, duplicate: <txn_id>, key: {...} }
+ *   payment_link  → (stubbed) never emitted in Phase 2a
+ *   inventory     → (stubbed) never emitted in Phase 2a
+ *   trip_group    → (stubbed) never emitted in Phase 2a
+ */
+export const ReconcileProposal = z
+  .object({
+    id: Uuid,
+    batch_id: Uuid,
+    kind: ReconcileKind,
+    payload: z.record(z.string(), z.unknown()),
+    score: z.number().nullable(),
+    status: ReconcileProposalStatus,
+    created_at: IsoDateTime,
+    resolved_at: IsoDateTime.nullable(),
+  })
+  .openapi("ReconcileProposal");
+
+// ── Applied summary (read-model) ──────────────────────────────────────
+
+export const ReconcileApplied = z
+  .object({
+    duplicates: z
+      .array(
+        z.object({
+          receiptId: Uuid,
+          duplicateOf: Uuid,
+        }),
+      )
+      .default([]),
+    payment_links: z.array(z.unknown()).default([]),
+    inventory: z.array(z.unknown()).default([]),
+    proposals_total: z.number().int(),
+  })
+  .openapi("ReconcileApplied");
+
+// ── Request shapes ────────────────────────────────────────────────────
+
+/**
+ * Default behavior: enable all four steps, scope=batch, threshold=0.95.
+ * Body is optional — `POST /v1/batches/:id/reconcile` with no body uses
+ * the defaults above.
+ */
+export const ReconcileRequest = z
+  .object({
+    scope: ReconcileScope.optional().default("batch"),
+    enable: z.array(ReconcileKind).optional(),
+    // Scores are in [0, 1], so any value ≤ 1 *can* auto-apply, and any
+    // value > 1 effectively disables auto-apply. We allow up to 2 so
+    // callers can pass a sentinel like `1.01` to mean "propose only".
+    auto_apply_threshold: z.number().min(0).max(2).optional().default(0.95),
+  })
+  .openapi("ReconcileRequest");
+
+export const ApplyRequest = z
+  .object({
+    proposal_ids: z.array(Uuid).min(1),
+  })
+  .openapi("ApplyRequest");
+
+export const RejectRequest = z
+  .object({
+    proposal_ids: z.array(Uuid).min(1),
+    reason: z.string().optional(),
+  })
+  .openapi("RejectRequest");
+
+// ── Response shapes ───────────────────────────────────────────────────
+
+export const ReconcileBatchStatus = z
+  .enum([
+    "extracted",
+    "reconciling",
+    "reconciled",
+    "reconcile_error",
+  ])
+  .openapi("ReconcileBatchStatus");
+
+export const ReconcileResult = z
+  .object({
+    batchId: Uuid,
+    status: ReconcileBatchStatus,
+    applied: ReconcileApplied,
+    proposals: z.array(ReconcileProposal),
+    /** Present only when the batch is mid-reconcile (status=reconciling). */
+    poll: z.string().optional(),
+  })
+  .openapi("ReconcileResult");
+
+export const ApplyResult = z
+  .object({
+    applied: z.array(Uuid),
+    skipped: z.array(
+      z.object({
+        id: Uuid,
+        reason: z.string(),
+      }),
+    ),
+  })
+  .openapi("ApplyResult");
+
+export const RejectResult = z
+  .object({
+    rejected: z.array(Uuid),
+    skipped: z.array(
+      z.object({
+        id: Uuid,
+        reason: z.string(),
+      }),
+    ),
+  })
+  .openapi("RejectResult");

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { seed } from "./db/seed.js";
 import { registerAccountsMcpTools } from "./mcp/accounts.js";
 import { registerTransactionsMcpTools } from "./mcp/transactions.js";
 import { registerDocumentsMcpTools } from "./mcp/documents.js";
+import { registerReconcileMcpTools } from "./mcp/reconcile.js";
 import { start as startIngestWorker } from "./ingest/worker.js";
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
@@ -28,6 +29,7 @@ const mcp = new FastMCP({
 registerAccountsMcpTools(mcp);
 registerTransactionsMcpTools(mcp);
 registerDocumentsMcpTools(mcp);
+registerReconcileMcpTools(mcp);
 
 async function main(): Promise<void> {
   console.log("🗄️  Running Drizzle migrations…");

--- a/tests/integration/ingest.test.ts
+++ b/tests/integration/ingest.test.ts
@@ -135,8 +135,12 @@ async function waitForBatchExtracted(
 
 describe("POST /v1/ingest/batch", () => {
   it("returns 202 with batchId + per-file ingestIds; worker drains to extracted", async () => {
+    // auto_reconcile=false so the batch stops at `extracted` and the
+    // Phase 2a reconcile hook (introduced in #32 Phase 2a) doesn't
+    // advance the state machine to `reconciled` before our assertions.
     const res = await request(ctx.app)
       .post("/v1/ingest/batch")
+      .field("auto_reconcile", "false")
       .attach("files", uniqueBytes("a"), { filename: "image-a.jpg", contentType: "image/jpeg" })
       .attach("files", uniqueBytes("b"), { filename: "email-b.eml", contentType: "message/rfc822" })
       .attach("files", uniqueBytes("c"), { filename: "pdf-c.pdf", contentType: "application/pdf" });
@@ -178,6 +182,7 @@ describe("GET /v1/ingests/:id — produced reverse-lookup", () => {
   it("populates transaction_ids + document_ids for each successful extraction", async () => {
     const res = await request(ctx.app)
       .post("/v1/ingest/batch")
+      .field("auto_reconcile", "false")
       .attach("files", uniqueBytes("d"), { filename: "image-d.jpg", contentType: "image/jpeg" })
       .attach("files", uniqueBytes("e"), { filename: "email-e.eml", contentType: "message/rfc822" });
     expect(res.status).toBe(202);
@@ -199,6 +204,7 @@ describe("GET /v1/ingests/:id — produced reverse-lookup", () => {
   it("GET /v1/transactions?source_ingest_id=<x> returns the produced txn", async () => {
     const res = await request(ctx.app)
       .post("/v1/ingest/batch")
+      .field("auto_reconcile", "false")
       .attach("files", uniqueBytes("src-ingest"), {
         filename: "image-source-link.jpg",
         contentType: "image/jpeg",
@@ -227,6 +233,7 @@ describe("failure isolation", () => {
   it("one file failing does not fail the batch (ingest=error, others done, batch=extracted)", async () => {
     const res = await request(ctx.app)
       .post("/v1/ingest/batch")
+      .field("auto_reconcile", "false")
       .attach("files", uniqueBytes("ok1"), { filename: "image-ok1.jpg", contentType: "image/jpeg" })
       .attach("files", uniqueBytes("bad"), { filename: "throw-me.jpg", contentType: "image/jpeg" })
       .attach("files", uniqueBytes("ok2"), { filename: "image-ok2.jpg", contentType: "image/jpeg" });
@@ -250,6 +257,7 @@ describe("failure isolation", () => {
   it("unsupported classification produces no transaction/document and ingest.status='unsupported'", async () => {
     const res = await request(ctx.app)
       .post("/v1/ingest/batch")
+      .field("auto_reconcile", "false")
       .attach("files", uniqueBytes("unsup"), {
         filename: "unsupported-W2.pdf",
         contentType: "application/pdf",
@@ -275,6 +283,7 @@ describe("failure isolation", () => {
   it("statement_pdf is deferred → marked unsupported with a clear note", async () => {
     const res = await request(ctx.app)
       .post("/v1/ingest/batch")
+      .field("auto_reconcile", "false")
       .attach("files", uniqueBytes("stmt"), {
         filename: "statement-april.pdf",
         contentType: "application/pdf",

--- a/tests/integration/reconcile.test.ts
+++ b/tests/integration/reconcile.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Integration tests for the reconcile pipeline (#32 Phase 2a).
+ *
+ * Strategy: drive the full batch pipeline through HTTP + the injectable
+ * extractor stub, then exercise the four reconcile endpoints. The stub
+ * returns identical `ExtractorResult` payloads for two uploads so the
+ * worker produces two transactions with matching (payee, occurred_on,
+ * total) — the exact dedup trigger.
+ */
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+import { sql } from "drizzle-orm";
+import { withTestDb } from "../setup/db.js";
+import type { Extractor } from "../../src/ingest/extractor.js";
+
+type WorkerModule = typeof import("../../src/ingest/worker.js");
+let workerApi: WorkerModule;
+
+const UPLOAD_DIR = mkdtempSync(path.join(tmpdir(), "ra-reconcile-"));
+process.env.UPLOAD_DIR = UPLOAD_DIR;
+
+const ctx = withTestDb();
+
+// Each key slot fed into `setDuplicateExtractor` forces all files whose
+// filename starts with that key to produce the same extraction output.
+// Keeps tests deterministic without depending on filename content
+// beyond the dispatch prefix.
+type DuplicateKey = {
+  prefix: string;
+  payee: string;
+  occurred_on: string;
+  total_minor: number;
+};
+
+const DEFAULT_DUPLICATE: DuplicateKey = {
+  prefix: "dup",
+  payee: "Costco",
+  occurred_on: "2026-04-10",
+  total_minor: 8421,
+};
+
+function makeExtractor(keys: DuplicateKey[]): Extractor {
+  return async ({ filename }) => {
+    const stem = filename.toLowerCase();
+    for (const k of keys) {
+      if (stem.startsWith(k.prefix)) {
+        return {
+          classification: "receipt_image",
+          extracted: {
+            payee: k.payee,
+            occurred_on: k.occurred_on,
+            total_minor: k.total_minor,
+            currency: "USD",
+            category_hint: "groceries",
+          },
+          sessionId: `stub-${k.prefix}`,
+        };
+      }
+    }
+    // Unique-per-file fallback so non-duplicate uploads stay distinct.
+    return {
+      classification: "receipt_image",
+      extracted: {
+        payee: `Unique ${filename}`,
+        occurred_on: "2026-04-01",
+        total_minor: 100 + filename.length,
+        currency: "USD",
+        category_hint: "groceries",
+      },
+      sessionId: `stub-unique-${filename}`,
+    };
+  };
+}
+
+beforeAll(async () => {
+  workerApi = await import("../../src/ingest/worker.js");
+  workerApi.setExtractor(makeExtractor([DEFAULT_DUPLICATE]));
+});
+
+afterEach(() => {
+  workerApi.setExtractor(makeExtractor([DEFAULT_DUPLICATE]));
+});
+
+function uniqueBytes(tag: string): Buffer {
+  return Buffer.from(`reconcile-${tag}-${Math.random()}-${Date.now()}`, "utf8");
+}
+
+async function waitForBatchStatus(
+  batchId: string,
+  targets: string[],
+  timeoutMs = 20_000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  await workerApi.drain();
+  while (Date.now() < deadline) {
+    const res = await ctx.db.execute(
+      sql`SELECT status FROM batches WHERE id = ${batchId}::uuid`,
+    );
+    const s = (res.rows[0] as { status: string } | undefined)?.status;
+    if (s && targets.includes(s)) return s;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error(
+    `batch ${batchId} did not reach any of [${targets.join(", ")}] in ${timeoutMs}ms`,
+  );
+}
+
+interface UploadOpts {
+  autoReconcile?: boolean;
+  duplicatePrefix?: string;
+  count?: number;
+}
+
+async function uploadDuplicateBatch(
+  opts: UploadOpts = {},
+): Promise<{ batchId: string; ingestIds: string[] }> {
+  const autoReconcile = opts.autoReconcile ?? false;
+  const prefix = opts.duplicatePrefix ?? DEFAULT_DUPLICATE.prefix;
+  const count = opts.count ?? 2;
+  const req = request(ctx.app).post("/v1/ingest/batch");
+  for (let i = 0; i < count; i++) {
+    req.attach("files", uniqueBytes(`${prefix}-${i}`), {
+      filename: `${prefix}-${i}.jpg`,
+      contentType: "image/jpeg",
+    });
+  }
+  req.field("auto_reconcile", String(autoReconcile));
+  const res = await req;
+  if (res.status !== 202) {
+    throw new Error(`upload failed: ${res.status} ${JSON.stringify(res.body)}`);
+  }
+  return {
+    batchId: res.body.batchId,
+    ingestIds: (res.body.items as Array<{ ingestId: string }>).map(
+      (i) => i.ingestId,
+    ),
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+
+describe("POST /v1/batches/:id/reconcile — dedup detection + auto-apply", () => {
+  it("detects duplicate transactions, flips batch to reconciled, auto-applies above threshold", async () => {
+    const { batchId } = await uploadDuplicateBatch({ autoReconcile: false });
+    await waitForBatchStatus(batchId, ["extracted"]);
+
+    const res = await request(ctx.app)
+      .post(`/v1/batches/${batchId}/reconcile`)
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body.batchId).toBe(batchId);
+    expect(res.body.status).toBe("reconciled");
+    // Two uploads → one dedup proposal pointing at the canonical.
+    expect(res.body.proposals).toHaveLength(1);
+    const p = res.body.proposals[0];
+    expect(p.kind).toBe("dedup");
+    expect(p.score).toBeCloseTo(1.0);
+    // Default threshold = 0.95, so the exact-match proposal auto-applies.
+    expect(p.status).toBe("auto_applied");
+    expect(p.payload.duplicate).toBeDefined();
+    expect(p.payload.duplicate_of).toBeDefined();
+    expect(p.payload.duplicate).not.toBe(p.payload.duplicate_of);
+
+    expect(res.body.applied.proposals_total).toBe(1);
+    expect(res.body.applied.duplicates).toHaveLength(1);
+    expect(res.body.applied.duplicates[0].receiptId).toBe(p.payload.duplicate);
+    expect(res.body.applied.duplicates[0].duplicateOf).toBe(
+      p.payload.duplicate_of,
+    );
+
+    // Ledger side-effect: duplicate transaction must now be voided.
+    const txRes = await request(ctx.app).get(
+      `/v1/transactions/${p.payload.duplicate}`,
+    );
+    expect(txRes.status).toBe(200);
+    expect(txRes.body.status).toBe("voided");
+    expect(txRes.body.voided_by_id).toBeDefined();
+
+    // Canonical transaction remains posted.
+    const canonicalRes = await request(ctx.app).get(
+      `/v1/transactions/${p.payload.duplicate_of}`,
+    );
+    expect(canonicalRes.body.status).toBe("posted");
+  });
+
+  it("is idempotent: a second POST on a reconciled batch returns the stored result", async () => {
+    const { batchId } = await uploadDuplicateBatch({
+      autoReconcile: false,
+      duplicatePrefix: "idem",
+    });
+    // Override the extractor so this prefix also produces duplicates.
+    workerApi.setExtractor(
+      makeExtractor([
+        { prefix: "idem", payee: "IdemShop", occurred_on: "2026-03-03", total_minor: 1200 },
+        DEFAULT_DUPLICATE,
+      ]),
+    );
+    await waitForBatchStatus(batchId, ["extracted"]);
+
+    const first = await request(ctx.app)
+      .post(`/v1/batches/${batchId}/reconcile`)
+      .send({});
+    expect(first.status).toBe(200);
+    const firstIds = (first.body.proposals as Array<{ id: string }>)
+      .map((p) => p.id)
+      .sort();
+    expect(firstIds.length).toBe(1);
+
+    const second = await request(ctx.app)
+      .post(`/v1/batches/${batchId}/reconcile`)
+      .send({});
+    expect(second.status).toBe(200);
+    expect(second.body.status).toBe("reconciled");
+    const secondIds = (second.body.proposals as Array<{ id: string }>)
+      .map((p) => p.id)
+      .sort();
+    // Same IDs on replay — no new rows were written.
+    expect(secondIds).toEqual(firstIds);
+  });
+
+  it("GET /v1/batches/:id/reconcile returns the stored result", async () => {
+    const { batchId } = await uploadDuplicateBatch({
+      autoReconcile: false,
+      duplicatePrefix: "getread",
+    });
+    workerApi.setExtractor(
+      makeExtractor([
+        { prefix: "getread", payee: "ReadBack", occurred_on: "2026-02-14", total_minor: 399 },
+        DEFAULT_DUPLICATE,
+      ]),
+    );
+    await waitForBatchStatus(batchId, ["extracted"]);
+
+    // Pre-reconcile GET: batch still extracted, no proposals yet.
+    const pre = await request(ctx.app).get(
+      `/v1/batches/${batchId}/reconcile`,
+    );
+    expect(pre.status).toBe(200);
+    expect(pre.body.status).toBe("extracted");
+    expect(pre.body.proposals).toHaveLength(0);
+
+    await request(ctx.app).post(`/v1/batches/${batchId}/reconcile`).send({});
+    const post = await request(ctx.app).get(
+      `/v1/batches/${batchId}/reconcile`,
+    );
+    expect(post.status).toBe(200);
+    expect(post.body.status).toBe("reconciled");
+    expect(post.body.proposals).toHaveLength(1);
+  });
+});
+
+describe("auto-reconcile hook from worker", () => {
+  it("auto_reconcile=true triggers reconcile without an explicit POST", async () => {
+    workerApi.setExtractor(
+      makeExtractor([
+        { prefix: "auto", payee: "AutoShop", occurred_on: "2026-01-05", total_minor: 4200 },
+        DEFAULT_DUPLICATE,
+      ]),
+    );
+    const { batchId } = await uploadDuplicateBatch({
+      autoReconcile: true,
+      duplicatePrefix: "auto",
+    });
+    // Auto-reconcile is chained inside the worker so drain() waits for it.
+    await waitForBatchStatus(batchId, ["reconciled", "reconcile_error"]);
+
+    const view = await request(ctx.app).get(
+      `/v1/batches/${batchId}/reconcile`,
+    );
+    expect(view.status).toBe(200);
+    expect(view.body.status).toBe("reconciled");
+    expect(view.body.proposals).toHaveLength(1);
+    expect(view.body.proposals[0].status).toBe("auto_applied");
+    // The duplicate transaction voided automatically via the hook.
+    const dup = view.body.proposals[0].payload.duplicate as string;
+    const dupRes = await request(ctx.app).get(`/v1/transactions/${dup}`);
+    expect(dupRes.body.status).toBe("voided");
+  });
+});
+
+describe("apply / reject", () => {
+  it("apply on a proposed dedup proposal voids the duplicate and marks user_applied", async () => {
+    workerApi.setExtractor(
+      makeExtractor([
+        { prefix: "manual", payee: "ManualCo", occurred_on: "2026-03-15", total_minor: 9900 },
+        DEFAULT_DUPLICATE,
+      ]),
+    );
+    const { batchId } = await uploadDuplicateBatch({
+      autoReconcile: false,
+      duplicatePrefix: "manual",
+    });
+    await waitForBatchStatus(batchId, ["extracted"]);
+
+    // Run reconcile with threshold=1.01 so no proposal auto-applies.
+    const rec = await request(ctx.app)
+      .post(`/v1/batches/${batchId}/reconcile`)
+      .send({ auto_apply_threshold: 1.01 });
+    expect(rec.status).toBe(200);
+    const [prop] = rec.body.proposals;
+    expect(prop.status).toBe("proposed");
+    const dupId = prop.payload.duplicate as string;
+
+    // Duplicate still posted (not auto-applied).
+    let dupView = await request(ctx.app).get(`/v1/transactions/${dupId}`);
+    expect(dupView.body.status).toBe("posted");
+
+    const applyRes = await request(ctx.app)
+      .post(`/v1/batches/${batchId}/reconcile/apply`)
+      .send({ proposal_ids: [prop.id] });
+    expect(applyRes.status).toBe(200);
+    expect(applyRes.body.applied).toContain(prop.id);
+    expect(applyRes.body.skipped).toHaveLength(0);
+
+    // Duplicate now voided; proposal status user_applied.
+    dupView = await request(ctx.app).get(`/v1/transactions/${dupId}`);
+    expect(dupView.body.status).toBe("voided");
+
+    const view = await request(ctx.app).get(
+      `/v1/batches/${batchId}/reconcile`,
+    );
+    const stored = (view.body.proposals as Array<{ id: string; status: string }>).find(
+      (p) => p.id === prop.id,
+    );
+    expect(stored?.status).toBe("user_applied");
+  });
+
+  it("reject marks the proposal rejected without mutating the ledger", async () => {
+    workerApi.setExtractor(
+      makeExtractor([
+        { prefix: "reject", payee: "RejectCo", occurred_on: "2026-03-20", total_minor: 5555 },
+        DEFAULT_DUPLICATE,
+      ]),
+    );
+    const { batchId } = await uploadDuplicateBatch({
+      autoReconcile: false,
+      duplicatePrefix: "reject",
+    });
+    await waitForBatchStatus(batchId, ["extracted"]);
+
+    const rec = await request(ctx.app)
+      .post(`/v1/batches/${batchId}/reconcile`)
+      .send({ auto_apply_threshold: 1.01 });
+    const [prop] = rec.body.proposals;
+    expect(prop.status).toBe("proposed");
+    const dupId = prop.payload.duplicate as string;
+
+    const rej = await request(ctx.app)
+      .post(`/v1/batches/${batchId}/reconcile/reject`)
+      .send({ proposal_ids: [prop.id], reason: "not actually dup" });
+    expect(rej.status).toBe(200);
+    expect(rej.body.rejected).toContain(prop.id);
+
+    // Duplicate transaction remains posted (no ledger mutation).
+    const dupView = await request(ctx.app).get(`/v1/transactions/${dupId}`);
+    expect(dupView.body.status).toBe("posted");
+
+    const view = await request(ctx.app).get(
+      `/v1/batches/${batchId}/reconcile`,
+    );
+    const stored = (view.body.proposals as Array<{ id: string; status: string }>).find(
+      (p) => p.id === prop.id,
+    );
+    expect(stored?.status).toBe("rejected");
+  });
+});
+
+describe("no-false-positives: unique batches", () => {
+  it("a batch with three distinct payees produces zero proposals", async () => {
+    // The default extractor makes each non-prefixed file unique by name,
+    // so three uploads yield three unique (payee, total) tuples.
+    workerApi.setExtractor(makeExtractor([]));
+    const r = await request(ctx.app)
+      .post("/v1/ingest/batch")
+      .field("auto_reconcile", "false")
+      .attach("files", uniqueBytes("u1"), { filename: "unique-one.jpg", contentType: "image/jpeg" })
+      .attach("files", uniqueBytes("u2"), { filename: "unique-two.jpg", contentType: "image/jpeg" })
+      .attach("files", uniqueBytes("u3"), { filename: "unique-three.jpg", contentType: "image/jpeg" });
+    expect(r.status).toBe(202);
+    const batchId = r.body.batchId as string;
+    await waitForBatchStatus(batchId, ["extracted"]);
+
+    const rec = await request(ctx.app)
+      .post(`/v1/batches/${batchId}/reconcile`)
+      .send({});
+    expect(rec.status).toBe(200);
+    expect(rec.body.status).toBe("reconciled");
+    expect(rec.body.proposals).toHaveLength(0);
+    expect(rec.body.applied.proposals_total).toBe(0);
+  });
+});
+
+describe("stubs remain no-ops in Phase 2a", () => {
+  it("enable=[payment_link,inventory,trip_group] produces zero proposals", async () => {
+    workerApi.setExtractor(
+      makeExtractor([
+        { prefix: "stub", payee: "StubCo", occurred_on: "2026-04-02", total_minor: 333 },
+        DEFAULT_DUPLICATE,
+      ]),
+    );
+    const { batchId } = await uploadDuplicateBatch({
+      autoReconcile: false,
+      duplicatePrefix: "stub",
+    });
+    await waitForBatchStatus(batchId, ["extracted"]);
+
+    const rec = await request(ctx.app)
+      .post(`/v1/batches/${batchId}/reconcile`)
+      .send({ enable: ["payment_link", "inventory", "trip_group"] });
+    expect(rec.status).toBe(200);
+    expect(rec.body.status).toBe("reconciled");
+    // dedup was NOT enabled → stubs wrote nothing.
+    expect(rec.body.proposals).toHaveLength(0);
+  });
+});

--- a/tests/integration/reconcile.test.ts
+++ b/tests/integration/reconcile.test.ts
@@ -187,17 +187,20 @@ describe("POST /v1/batches/:id/reconcile — dedup detection + auto-apply", () =
   });
 
   it("is idempotent: a second POST on a reconciled batch returns the stored result", async () => {
-    const { batchId } = await uploadDuplicateBatch({
-      autoReconcile: false,
-      duplicatePrefix: "idem",
-    });
-    // Override the extractor so this prefix also produces duplicates.
+    // Register the extractor BEFORE upload — on fast CI runners the
+    // worker can start processing files as soon as the POST completes,
+    // racing past `setExtractor` and falling back to the unique-per-file
+    // extractor, which produces no duplicates for dedup to find.
     workerApi.setExtractor(
       makeExtractor([
         { prefix: "idem", payee: "IdemShop", occurred_on: "2026-03-03", total_minor: 1200 },
         DEFAULT_DUPLICATE,
       ]),
     );
+    const { batchId } = await uploadDuplicateBatch({
+      autoReconcile: false,
+      duplicatePrefix: "idem",
+    });
     await waitForBatchStatus(batchId, ["extracted"]);
 
     const first = await request(ctx.app)
@@ -222,16 +225,16 @@ describe("POST /v1/batches/:id/reconcile — dedup detection + auto-apply", () =
   });
 
   it("GET /v1/batches/:id/reconcile returns the stored result", async () => {
-    const { batchId } = await uploadDuplicateBatch({
-      autoReconcile: false,
-      duplicatePrefix: "getread",
-    });
     workerApi.setExtractor(
       makeExtractor([
         { prefix: "getread", payee: "ReadBack", occurred_on: "2026-02-14", total_minor: 399 },
         DEFAULT_DUPLICATE,
       ]),
     );
+    const { batchId } = await uploadDuplicateBatch({
+      autoReconcile: false,
+      duplicatePrefix: "getread",
+    });
     await waitForBatchStatus(batchId, ["extracted"]);
 
     // Pre-reconcile GET: batch still extracted, no proposals yet.


### PR DESCRIPTION
## Summary

Phase 2a of #32 — the reconcile pipeline over an extracted batch. Only the **dedup** step ships a real detector today; `payment_link`, `inventory`, and `trip_group` land as documented no-op stubs until their backing data exists (statement ingestion, inventory/trips tables). SSE is explicitly out of scope for this PR.

New surface under `/v1/batches/:id/reconcile*`:

| Endpoint | Behavior |
|---|---|
| `POST /v1/batches/:id/reconcile` | Runs enabled detectors, writes `reconcile_proposals` rows, transitions `extracted → reconciling → reconciled`. Idempotent on replay. |
| `GET  /v1/batches/:id/reconcile` | Returns the stored result. |
| `POST /v1/batches/:id/reconcile/apply` | Accepts `{ proposal_ids[] }`. For dedup proposals, voids the duplicate via the existing v1 ledger service and marks `user_applied`. |
| `POST /v1/batches/:id/reconcile/reject` | Flips proposals to `rejected` with no ledger mutation. |

**Auto-reconcile hook** (`src/ingest/worker.ts`): when the last child of a batch terminates and `batches.auto_reconcile=true`, the worker fires reconcile in-process as a non-blocking promise. A reconcile failure flips the batch to `reconcile_error` but does *not* revert extraction. The promise is tracked in the existing `inflight` set so integration tests can `await drain()` for deterministic observation.

**Dedup detection** (`src/reconcile/dedup.ts`): pure SQL. Groups transactions within the batch by `(workspace_id, occurred_on, payee, SUM(positive amount_base_minor))` and emits N-1 proposals per group (earliest `created_at` is canonical). Every dedup proposal scores 1.0 — exact match on all four keys — so the default `auto_apply_threshold=0.95` auto-applies them.

**Stubs** (`src/reconcile/stubs.ts`): each returns `{ proposals: [], reason }` synchronously and logs the skip reason. `payment_link` waits on statement-PDF ingestion (Phase 2b). `inventory` waits on the `inventory_items` + `receipt_items` tables. `trip_group` waits on the `trips` module + clustering call.

**MCP parity**: `reconcile_batch`, `list_reconcile_proposals`, `apply_reconcile_proposal`, `reject_reconcile_proposal` route through the same `src/reconcile/engine.ts` as HTTP.

**Schema** is unchanged — `reconcile_proposals` already existed as a placeholder since Phase 1 (#32). No new migrations.

Closes the reconcile scope of #32 modulo SSE and statement-side payment linking (both explicitly deferred).

## Files

Created:
- `src/reconcile/engine.ts` — orchestrator, state machine, auto/user apply, reject
- `src/reconcile/dedup.ts` — pure-SQL detector
- `src/reconcile/stubs.ts` — `payment_link` / `inventory` / `trip_group` no-ops
- `src/routes/reconcile.ts` — Express router + OpenAPI paths
- `src/mcp/reconcile.ts` — four MCP tools
- `src/schemas/v1/reconcile.ts` — Zod schemas
- `tests/integration/reconcile.test.ts` — 8 cases

Modified:
- `src/app.ts` — mount the new router ahead of the batch lister so Express matches the specific `/reconcile*` paths first
- `src/openapi.ts` — register reconcile paths
- `src/server.ts` — register MCP tools
- `src/schemas/v1/index.ts` — re-export
- `src/ingest/worker.ts` — auto-reconcile hook on `extracted` transition
- `tests/integration/ingest.test.ts` — existing tests now pin `auto_reconcile=false` so their `extracted` assertions aren't raced by the new hook

## Acceptance criteria

- [x] `POST /v1/batches/:id/reconcile` on an `extracted` batch runs dedup + writes proposals + flips to `reconciled`
- [x] Re-calling on a `reconciled` batch returns the previous result without re-running
- [x] `GET` returns the last result
- [x] `apply` on a dedup proposal voids the duplicate via `voidTransaction` and marks `user_applied`
- [x] `reject` marks proposals `rejected` without DB mutation
- [x] Auto-reconcile triggers when worker flips a batch to `extracted` + `auto_reconcile=true`; verified with a duplicate-producing stub extractor
- [x] All prior tests still pass (80 total, was 72; +8 delta from reconcile suite)
- [x] OpenAPI regenerates clean (527 additions, 0 removals in `openapi/openapi.json`)
- [x] `npx tsc --noEmit` clean

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 80 passed (`reconcile.test.ts` covers auto-apply, idempotent replay, GET read-back, worker auto-reconcile hook, apply, reject, no-false-positives, stub-only enablement)
- [x] `npm run openapi:generate` — 27 paths, 50 schemas, additive diff
- [ ] Manual verification on real receipts deferred to a follow-up once the stack is available to this worktree

## Notes

- Dedup's `auto_apply_threshold` accepts up to `2` rather than `1` so callers can pass `> 1` (e.g. `1.01`) as a "propose-only" sentinel without us having to add a separate boolean. Scores themselves remain in `[0, 1]`.
- `payment_link` is explicitly blocked on statement-PDF ingestion — Phase 1 currently marks statements as `unsupported` in `src/ingest/worker.ts`, so there's nothing to link to yet. The stub's doc comment points at the unblocking work.
- No migration needed: `reconcile_proposals` was created in `drizzle/0002_batch_ingest.sql` as a forward-compat shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)