### PR TITLE
#43 Emit Langfuse traces from v1 ingest pipeline

### DIFF
--- a/src/ingest/worker.ts
+++ b/src/ingest/worker.ts
@@ -41,6 +41,7 @@ import {
 } from "../routes/transactions.service.js";
 import { linkDocumentToTransaction } from "../routes/documents.service.js";
 import { emit as busEmit, type BatchCountsPayload } from "../events/bus.js";
+import { ingestSession, getSessionJsonlPath } from "../langfuse.js";
 
 // ── Configuration ─────────────────────────────────────────────────────
 
@@ -63,6 +64,28 @@ export function resetExtractor(): void {
 }
 export function getExtractor(): Extractor {
   return currentExtractor;
+}
+
+// ── Injectable Langfuse ingestor ──────────────────────────────────────
+
+export type LangfuseIngestor = (
+  sessionId: string,
+  tags: string[],
+) => Promise<void>;
+
+const defaultLangfuseIngestor: LangfuseIngestor = async (sessionId, tags) => {
+  await ingestSession(getSessionJsonlPath(sessionId), tags);
+};
+
+let currentLangfuseIngestor: LangfuseIngestor = defaultLangfuseIngestor;
+export function setLangfuseIngestor(fn: LangfuseIngestor): void {
+  currentLangfuseIngestor = fn;
+}
+export function resetLangfuseIngestor(): void {
+  currentLangfuseIngestor = defaultLangfuseIngestor;
+}
+export function getLangfuseIngestor(): LangfuseIngestor {
+  return currentLangfuseIngestor;
 }
 
 // ── In-process queue ──────────────────────────────────────────────────
@@ -453,6 +476,10 @@ async function runOne(item: QueueItem): Promise<void> {
     return;
   }
 
+  if (result.sessionId) {
+    trackLangfuse(result.sessionId, [batchId, ingestId, result.classification]);
+  }
+
   try {
     if (result.classification === "unsupported") {
       await markUnsupported(ingestId, workspaceId, result.reason);
@@ -591,6 +618,28 @@ async function onBatchChildTerminated(
   if (flipped.auto_reconcile) {
     await triggerAutoReconcile(batchId, workspaceId);
   }
+}
+
+// ── Langfuse trace ingestion (fire-and-forget) ───────────────────────
+
+/**
+ * Kick off Langfuse ingestion for a finished extraction without blocking
+ * the worker. The promise is wired into `inflight` so `drain()` still
+ * waits for it — integration tests can assert on the spy synchronously.
+ * `ingestSession` itself swallows errors, so Langfuse downtime never
+ * fails a batch.
+ */
+function trackLangfuse(sessionId: string, tags: string[]): void {
+  const p = currentLangfuseIngestor(sessionId, tags)
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error("[ingest worker] langfuse ingestion failed:", err);
+    })
+    .finally(() => {
+      inflight.delete(p);
+      resolveDrainWaiters();
+    });
+  inflight.add(p);
 }
 
 // ── Auto-reconcile hook (#32 Phase 2a) ───────────────────────────────

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -9,11 +9,29 @@
  */
 import fs from "fs/promises";
 import path from "path";
+import os from "os";
 import { randomUUID } from "crypto";
 
 const LANGFUSE_HOST = process.env.LANGFUSE_HOST || "http://localhost:3333";
 const LANGFUSE_PUBLIC_KEY = process.env.LANGFUSE_PUBLIC_KEY || "pk-receipt-local";
 const LANGFUSE_SECRET_KEY = process.env.LANGFUSE_SECRET_KEY || "sk-receipt-local";
+
+/**
+ * Resolve where Claude Code dumps the JSONL transcript for a given
+ * `--session-id`. The CLI mangles CWD by replacing "/" and "_" with "-"
+ * and writes to `~/.claude/projects/<mangled-cwd>/<sessionId>.jsonl`.
+ * Stable across host mode (`$HOME=/Users/…`) and container (`/home/node`).
+ */
+export function getSessionJsonlPath(sessionId: string): string {
+  const mangledCwd = process.cwd().replace(/[/_]/g, "-");
+  return path.join(
+    os.homedir(),
+    ".claude",
+    "projects",
+    mangledCwd,
+    `${sessionId}.jsonl`,
+  );
+}
 
 // ── JSONL message helpers ──────────────────────────────────────────
 

--- a/tests/integration/ingest.test.ts
+++ b/tests/integration/ingest.test.ts
@@ -15,6 +15,7 @@ import * as path from "path";
 import { sql } from "drizzle-orm";
 import { withTestDb } from "../setup/db.js";
 import type { Extractor } from "../../src/ingest/extractor.js";
+import type { LangfuseIngestor } from "../../src/ingest/worker.js";
 
 // Worker module touches the drizzle pool at import-time. Defer the load
 // until beforeAll() has set DATABASE_URL via `withTestDb()` — otherwise
@@ -97,15 +98,25 @@ const FakeExtractor: Extractor = async ({ filename }) => {
   };
 };
 
+// Langfuse spy — captures (sessionId, tags) per extraction without
+// touching the real ingestion HTTP path. See worker.ts::trackLangfuse.
+const langfuseCalls: Array<{ sessionId: string; tags: string[] }> = [];
+const SpyLangfuseIngestor: LangfuseIngestor = async (sessionId, tags) => {
+  langfuseCalls.push({ sessionId, tags });
+};
+
 beforeAll(async () => {
   workerApi = await import("../../src/ingest/worker.js");
   workerApi.setExtractor(FakeExtractor);
+  workerApi.setLangfuseIngestor(SpyLangfuseIngestor);
 });
 
 afterEach(() => {
-  // Tests may override, but default back to the deterministic stub so
+  // Tests may override, but default back to the deterministic stubs so
   // the suite ordering doesn't matter.
   workerApi.setExtractor(FakeExtractor);
+  workerApi.setLangfuseIngestor(SpyLangfuseIngestor);
+  langfuseCalls.length = 0;
 });
 
 // Distinct bytes per file so sha256 dedup doesn't collapse them.
@@ -175,6 +186,27 @@ describe("POST /v1/ingest/batch", () => {
     const res = await request(ctx.app).post("/v1/ingest/batch");
     expect(res.status).toBe(422);
     expect(res.body.type).toMatch(/validation/);
+  });
+
+  it("invokes Langfuse ingestor with sessionId + tags after extraction (#43)", async () => {
+    const res = await request(ctx.app)
+      .post("/v1/ingest/batch")
+      .field("auto_reconcile", "false")
+      .attach("files", uniqueBytes("lf"), {
+        filename: "image-lf.jpg",
+        contentType: "image/jpeg",
+      });
+
+    expect(res.status).toBe(202);
+    const ingestId = res.body.items[0].ingestId;
+    await waitForBatchExtracted(res.body.batchId);
+
+    expect(langfuseCalls).toHaveLength(1);
+    const call = langfuseCalls[0]!;
+    expect(call.sessionId).toBe("stub-session-image");
+    expect(call.tags).toContain(res.body.batchId);
+    expect(call.tags).toContain(ingestId);
+    expect(call.tags).toContain("receipt_image");
   });
 });
 


### PR DESCRIPTION
Fixes #43.

## Summary

The v1 worker spawned `claude -p` with a pre-allocated `--session-id` but threw the id away when the extractor returned. Claude wrote the full JSONL to disk; nobody called `ingestSession()` on it. Langfuse dashboard stayed empty regardless of upload volume.

This wires the two ends together.

## Changes

- `src/langfuse.ts` — export `getSessionJsonlPath(sessionId)` (moved from the orphaned `src/claude.ts`). Resolves to `~/.claude/projects/<mangled-cwd>/<sessionId>.jsonl` in both host mode and container.
- `src/ingest/worker.ts` — add an injectable `LangfuseIngestor` seam matching the existing `setExtractor` pattern; call it once per `runOne` after the extractor returns, fire-and-forget via the existing `inflight` set so `drain()` still waits for ingestion deterministically in tests. `ingestSession` swallows errors internally — Langfuse downtime never fails a batch.
- `tests/integration/ingest.test.ts` — spy ingestor asserts the hook fires with the session id and tags (`batchId`, `ingestId`, `classification`) after a happy-path upload.

Leaves `src/claude.ts` alone — it's dead code and deleting it is a separate cleanup.

## Test plan

- [x] `npm test` — 96/96 green (95 existing + 1 new `#43` assertion)
- [x] `npm run build` — typecheck clean
- [x] Manual end-to-end: uploaded a receipt via the frontend against real Langfuse; trace appears with expected tags, per-turn timings, token counts, tool-call metadata (see screenshot in issue #43).
- [x] Resilience: trace ingestion failure does not fail the batch (fire-and-forget via `inflight` set + errors swallowed by `ingestSession`).