### PR TITLE
refactor: move Claude Code auth to named Docker volume + in-container /login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 # Copy this file to .env and fill in the values. .env is gitignored.
 # docker compose reads .env automatically at `up` time.
 #
-# Claude Code authentication does NOT live here — credentials are mounted
-# from ~/.claude/.credentials.json on the host (seeded from Keychain by the
-# `setup` skill on first run) and the in-container CLI self-refreshes. See
-# docker-compose.yml for the mount line.
+# Claude Code authentication does NOT live here — credentials live in the
+# `claude-code-config` named Docker volume, populated once by running
+# `docker exec -it receipt-assistant claude /login` inside the container.
+# The in-container CLI self-refreshes on expiry. See the `setup` skill for
+# bootstrap and recovery, and docker-compose.yml for the volume definition.
 
 # ── Optional ────────────────────────────────────────────────────────
 # Everything below has sensible defaults; only override when needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,18 +181,25 @@ that trap.)
 - **CI-ready**: verification scripts can hit the API directly
 - **No context switching**: stay in terminal, no browser navigation
 
-## Claude Code OAuth credentials — volume-mounted, self-refreshing
+## Claude Code OAuth credentials — named volume, in-container login
 
-Auth is **not** an env var. `docker-compose.yml` mounts `${HOME}/.claude/.credentials.json` into the container RW; the in-container `claude` CLI refreshes both `accessToken` and `refreshToken` on expiry and writes the rotation back to the same file. No `CLAUDE_CODE_OAUTH_TOKEN` env var, no entrypoint-side credentials synthesis — both were removed in the migration commit that introduced this section.
+Auth is **not** an env var, and is **not** a bind mount of the host's `~/.claude/.credentials.json`. `docker-compose.yml` mounts the Docker-managed named volume `claude-code-config` at `/home/node/.claude`; the container holds its own independent OAuth session, seeded once by running `docker exec -it receipt-assistant claude /login`. The in-container `claude` CLI refreshes both `accessToken` and `refreshToken` on expiry and writes rotation back into the volume. This matches the Anthropic-official devcontainer pattern (`anthropics/claude-code/.devcontainer/devcontainer.json`).
 
-**Operate this via the `setup` skill**, not via shell scripts. The skill lives at `~/Documents/10_Projects/2026_Dev_ReceiptAssistant/.claude/skills/setup/SKILL.md` and covers first-time seeding, the old-to-new architecture migration, and 401 diagnosis. A prior design had an `refresh-token.sh` that poked `.env` — it's been removed, and re-adding it would silently disable self-refresh (env var overrides the file; see the skill for the empirical evidence).
+**Operate this via the `setup` skill**, not via shell scripts. The skill lives at `~/Documents/10_Projects/2026_Dev_ReceiptAssistant/.claude/skills/setup/SKILL.md` and covers first-time bootstrap, migration from the earlier bind-mount / env-var architectures, and 401 diagnosis.
+
+**Three-era timeline of what has and has not worked:**
+
+- **Era 1 (pre-2026-04-19) — `CLAUDE_CODE_OAUTH_TOKEN` env var + entrypoint-synthesized credentials file.** Broke because the env var overrides the file and disables self-refresh; the synthesized file had `refreshToken: ""` so couldn't refresh even if the env var were removed. Result: 24h 401 cycle.
+- **Era 2 (2026-04-19 → 2026-04-20) — host `~/.claude/.credentials.json` bind-mounted RW into the container.** Broke because host and container shared a single OAuth session: host's native `claude` CLI rotates the refresh token on every interactive use (Anthropic docs: "Refresh tokens rotate on each use"), which invalidates the container's next call. Result: 401 every few hours instead of every 24h.
+- **Era 3 (2026-04-20 onward) — named volume `claude-code-config` + in-container `claude /login`.** Container has its own OAuth session, isolated from host and other containers. No drift, no rotation collisions. Refresh token eventually expires server-side (~weeks to months); at that point rerun `claude /login` inside the container.
 
 **Hard rules, in one place so it's harder to lose:**
 
-- Never re-introduce `CLAUDE_CODE_OAUTH_TOKEN` to `.env` or `docker-compose.yml`. Presence of the env var makes the CLI skip the file entirely → no refresh → 24h 401s.
-- Never switch the mount to `:ro`. RO kills self-refresh; the rotated tokens have nowhere to land.
-- Never mount `~/.claude/` as a directory — only the single `.credentials.json` file. The host dir contains `projects/`, `skills/`, `settings.json` etc. that the container has no business seeing.
-- If Keychain (macOS) and the file drift far enough that host `claude` stops working, run `claude /login` on the host, then re-invoke the `setup` skill — that's the whole recovery procedure, and it's fine for this to happen occasionally.
+- **Never re-introduce `CLAUDE_CODE_OAUTH_TOKEN`** to `.env` or `docker-compose.yml`. Presence of the env var makes the CLI skip the file entirely (Anthropic auth precedence) → no refresh → Era 1's 24h 401s.
+- **Never bind-mount the host's `~/.claude/` or `~/.claude/.credentials.json`** into the container. The host/container session collision is Era 2's 401-every-few-hours bug. Always use the Docker-managed named volume `claude-code-config`.
+- **Never `docker compose down -v`** on this stack unless you want to re-run `claude /login`. The `-v` flag wipes named volumes, including `claude-code-config`. Use plain `docker compose down` or `docker compose stop`.
+- **Never periodically sync host Keychain → the volume.** It re-introduces rotation collisions; Anthropic's in-container auto-refresh is the intended mechanism.
+- **Recovery on 401:** `docker exec -it receipt-assistant claude /login`, follow the OAuth code flow, done. Do not touch host Keychain or host `~/.claude/` as part of recovery — they're unrelated to the container's OAuth session.
 
 ## GitHub Issues
 

--- a/README.md
+++ b/README.md
@@ -61,22 +61,9 @@ Everything runs in Docker — there is no `npm run dev` on the host.
 ### Prerequisites
 
 - Docker Desktop (or Docker Engine) with Compose v2.20+ (for `include:` support)
-- Claude Code CLI signed in on the host (on macOS the credentials live in Keychain; on Linux they live at `~/.claude/.credentials.json` after `claude /login`)
+- A Claude Code subscription (Pro / Max / Team / Enterprise) to log in with
 
-### 1. First-time auth setup
-
-Invoke the **`setup` skill** in Claude Code inside this project — it seeds `~/.claude/.credentials.json` from the host (Keychain on macOS) and hands the file to the container via a volume mount. The in-container CLI then auto-refreshes the OAuth tokens; there's no recurring script to run.
-
-If you prefer to do it manually (macOS):
-
-```bash
-security find-generic-password -s 'Claude Code-credentials' -w > ~/.claude/.credentials.json
-chmod 600 ~/.claude/.credentials.json
-```
-
-No env var goes into `.env` — auth is fully file-based.
-
-### 2. Bring everything up
+### 1. Bring everything up
 
 ```bash
 docker compose up -d --build
@@ -103,6 +90,20 @@ curl http://localhost:3000/health
 ```
 
 Langfuse dashboard: http://localhost:3333 (admin@local.dev / admin123)
+
+### 2. Log the container into Claude (one-time)
+
+The container holds its own OAuth session, independent of anything on the host. Bootstrap it **once**:
+
+```bash
+docker exec -it receipt-assistant claude /login
+# Follow the prompt: open the URL in a browser, authenticate,
+# paste the returned code back into the terminal.
+```
+
+Credentials persist in the `claude-code-config` named Docker volume and survive every `docker compose down` / `up` / `restart`. The in-container CLI self-refreshes access + refresh tokens on expiry and writes rotation back into the volume. No env var, no host Keychain sync, no recurring script.
+
+Eventually the refresh token expires server-side (weeks to months). When that happens the next call returns 401 — rerun the same `claude /login` inside the container. For full bootstrap, migration, and 401-recovery procedures, invoke the **`setup` skill** in Claude Code inside this project.
 
 ### 3. After changing source code
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,17 +57,25 @@ services:
       LANGFUSE_HOST: http://langfuse-web:3000
       LANGFUSE_PUBLIC_KEY: pk-receipt-local
       LANGFUSE_SECRET_KEY: sk-receipt-local
+      # Tell the `claude` CLI explicitly where its config + credentials live.
+      # Matches the Anthropic-official devcontainer convention and pairs with
+      # the `claude-code-config` named volume mounted below.
+      CLAUDE_CONFIG_DIR: /home/node/.claude
     volumes:
       - receipt-data:/data
-      # Claude Code OAuth credentials — mounted RW so the `claude` CLI inside
-      # the container can self-refresh access+refresh tokens on expiry. On
-      # macOS hosts this file is seeded from Keychain by the `setup` skill
-      # (see ~/Documents/10_Projects/2026_Dev_ReceiptAssistant/.claude/skills/setup).
-      # Do NOT swap to `:ro` — that disables self-refresh and brings back the
-      # 24h-expiry 401 bug.
-      - ${HOME}/.claude/.credentials.json:/home/node/.claude/.credentials.json:rw
+      # Claude Code OAuth credentials live in a **named Docker volume**,
+      # NOT a bind mount of the host's `~/.claude/`. The container holds its
+      # own independent OAuth session (seeded once via
+      # `docker exec -it receipt-assistant claude /login`) and self-refreshes
+      # forever without colliding with host or other containers.
+      # See the `setup` skill for bootstrap and recovery procedures.
+      - claude-code-config:/home/node/.claude
     restart: unless-stopped
 
 volumes:
   receipt-data:
   receipts-postgres-data:
+  # Holds the container's Claude Code credentials + config. Persists across
+  # `docker compose down` / `up` / `restart`. `docker compose down -v` WIPES
+  # it — that loses the OAuth session and requires another `claude /login`.
+  claude-code-config:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -e
 
-# Claude Code OAuth credentials arrive via a volume-mounted .credentials.json
-# (see docker-compose.yml). The CLI inside the container self-refreshes on
-# expiry and writes the rotated tokens back to the mounted file. No env-var
-# handoff or credentials synthesis here — keep this entrypoint thin.
+# Claude Code OAuth credentials live in the `claude-code-config` named Docker
+# volume mounted at /home/node/.claude (see docker-compose.yml). The container
+# holds its own OAuth session, bootstrapped once via
+# `docker exec -it receipt-assistant claude /login`. The in-container CLI
+# self-refreshes on expiry and writes rotated tokens back into the volume.
+# No env-var handoff or credentials synthesis — keep this entrypoint thin.
 
 exec "$@"

--- a/scripts/smoke-batch.md
+++ b/scripts/smoke-batch.md
@@ -5,7 +5,7 @@ Phase 1 of issue #32 ships the batch ingestion endpoint but no automated CLI har
 ## Prerequisites
 
 - `receipt-assistant` running on `localhost:3000` (the usual `docker compose up`).
-- `claude` CLI v2.x authenticated on host + in-container (see the `setup` skill if 401s appear).
+- `claude` CLI v2.x logged in **inside the container** via `docker exec -it receipt-assistant claude /login` (host auth is unrelated to the container's OAuth session). See the `setup` skill if 401s appear.
 - Two or three real receipt images on disk — e.g. `~/Desktop/RECEIPT/*.jpeg`.
 
 ## Step 1 — Submit a batch


### PR DESCRIPTION
## Summary

- Replace bind-mount of host `~/.claude/.credentials.json` with named Docker volume `claude-code-config` at `/home/node/.claude`
- Bootstrap via `docker exec -it receipt-assistant claude /login` (Anthropic-official devcontainer pattern)
- Container holds its own OAuth session, no host/container rotation collision
- Updates `docker-compose.yml`, `entrypoint.sh`, `.env.example`, `CLAUDE.md`, `README.md`, `scripts/smoke-batch.md`

Closes #45

## Test plan

- [x] `docker compose config` validates with new volume wiring
- [ ] `docker compose down && docker compose up -d --build` — stack comes up healthy
- [ ] `docker volume ls | grep claude-code-config` — volume created
- [ ] `docker exec -it receipt-assistant claude /login` — OAuth flow completes; `.credentials.json` written into volume
- [ ] `docker compose restart receipt-assistant` — credentials persist
- [ ] Upload a real receipt via `/v1/ingest/batch` — batch reaches `extracted`
- [x] Grep sweep: no residual `\${HOME}/.claude/.credentials.json:rw`, `security find-generic-password`, or `CLAUDE_CODE_OAUTH_TOKEN` outside historical timeline sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)