### PR TITLE
feat: persist geocoded merchant locations in a `places` table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,10 @@
 # localhost; set this for any deployment reachable from the network).
 # AUTH_TOKEN=
 
-# Google Maps Server API key for merchant geocoding (lat/lng + address
-# lookup). Geocoding is skipped silently when this is unset.
-# GOOGLE_MAPS_SERVER_KEY=
+# Google Maps API key. Used by the extraction agent (claude -p inside the
+# container) to call Geocoding + Places APIs during Phase 3 of extraction.
+# The agent skips geocoding silently when this is unset.
+# GOOGLE_MAPS_API_KEY=
 
 # HTTP + MCP server ports. Defaults: 3000 / 3001. Also update the
 # `ports:` mapping in docker-compose.yml if you change these.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,10 @@ services:
       # Matches the Anthropic-official devcontainer convention and pairs with
       # the `claude-code-config` named volume mounted below.
       CLAUDE_CONFIG_DIR: /home/node/.claude
+      # Google Maps API key reachable by the in-container `claude -p` agent
+      # via its Bash tool (for Phase 3 geocoding during extraction). Empty
+      # is fine — the prompt instructs the agent to skip geocoding.
+      GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY:-}
     volumes:
       - receipt-data:/data
       # Claude Code OAuth credentials live in a **named Docker volume**,

--- a/drizzle/0003_foamy_lady_mastermind.sql
+++ b/drizzle/0003_foamy_lady_mastermind.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "places" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"google_place_id" text NOT NULL,
+	"formatted_address" text NOT NULL,
+	"lat" numeric(9, 6) NOT NULL,
+	"lng" numeric(9, 6) NOT NULL,
+	"source" text NOT NULL,
+	"raw_response" jsonb,
+	"created_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	"hit_count" integer DEFAULT 1 NOT NULL,
+	CONSTRAINT "places_google_place_id_unique" UNIQUE("google_place_id")
+);
+--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "place_id" uuid;--> statement-breakpoint
+CREATE INDEX "places_lat_lng_idx" ON "places" USING btree ("lat","lng");--> statement-breakpoint
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_place_id_places_id_fk" FOREIGN KEY ("place_id") REFERENCES "public"."places"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "transactions_place_idx" ON "transactions" USING btree ("place_id");

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1904 @@
+{
+  "id": "dbd7e28f-0c81-454f-b742-1d959812e477",
+  "prevId": "ca3030c2-0b6c-4732-a60f-77fa11839cef",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_uniq": {
+          "name": "users_email_lower_uniq",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_users_id_fk": {
+          "name": "workspace_members_user_id_users_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_workspace_id_user_id_pk": {
+          "name": "workspace_members_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_owner_id_users_id_fk": {
+          "name": "workspaces_owner_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_balance_minor": {
+          "name": "opening_balance_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "accounts_workspace_idx": {
+          "name": "accounts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_parent_idx": {
+          "name": "accounts_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_workspace_type_idx": {
+          "name": "accounts_workspace_type_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_workspace_id_workspaces_id_fk": {
+          "name": "accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_parent_id_accounts_id_fk": {
+          "name": "accounts_parent_id_accounts_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narration": {
+          "name": "narration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "txn_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "voided_by_id": {
+          "name": "voided_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transactions_keyset_idx": {
+          "name": "transactions_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_source_ingest_idx": {
+          "name": "transactions_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_trip_idx": {
+          "name": "transactions_trip_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_place_idx": {
+          "name": "transactions_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_workspace_id_workspaces_id_fk": {
+          "name": "transactions_workspace_id_workspaces_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_voided_by_id_transactions_id_fk": {
+          "name": "transactions_voided_by_id_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "voided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_source_ingest_id_ingests_id_fk": {
+          "name": "transactions_source_ingest_id_ingests_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_place_id_places_id_fk": {
+          "name": "transactions_place_id_places_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_created_by_users_id_fk": {
+          "name": "transactions_created_by_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.postings": {
+      "name": "postings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fx_rate": {
+          "name": "fx_rate",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_base_minor": {
+          "name": "amount_base_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "postings_transaction_idx": {
+          "name": "postings_transaction_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_account_idx": {
+          "name": "postings_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_workspace_idx": {
+          "name": "postings_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "postings_workspace_id_workspaces_id_fk": {
+          "name": "postings_workspace_id_workspaces_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_transaction_id_transactions_id_fk": {
+          "name": "postings_transaction_id_transactions_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_account_id_accounts_id_fk": {
+          "name": "postings_account_id_accounts_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_links": {
+      "name": "document_links",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "document_links_txn_idx": {
+          "name": "document_links_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_links_document_id_documents_id_fk": {
+          "name": "document_links_document_id_documents_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_links_transaction_id_transactions_id_fk": {
+          "name": "document_links_transaction_id_transactions_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_links_document_id_transaction_id_pk": {
+          "name": "document_links_document_id_transaction_id_pk",
+          "columns": [
+            "document_id",
+            "transaction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocr_text": {
+          "name": "ocr_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_meta": {
+          "name": "extraction_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "documents_workspace_sha_uniq": {
+          "name": "documents_workspace_sha_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_kind_idx": {
+          "name": "documents_kind_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_source_ingest_idx": {
+          "name": "documents_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_workspace_id_workspaces_id_fk": {
+          "name": "documents_workspace_id_workspaces_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_source_ingest_id_ingests_id_fk": {
+          "name": "documents_source_ingest_id_ingests_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_events": {
+      "name": "transaction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "txn_events_txn_idx": {
+          "name": "txn_events_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_events_workspace_id_workspaces_id_fk": {
+          "name": "transaction_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_transaction_id_transactions_id_fk": {
+          "name": "transaction_events_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_actor_id_users_id_fk": {
+          "name": "transaction_events_actor_id_users_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "idempotency_keys_uniq": {
+          "name": "idempotency_keys_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_workspace_id_workspaces_id_fk": {
+          "name": "idempotency_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reconcile": {
+          "name": "auto_reconcile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "batches_workspace_created_idx": {
+          "name": "batches_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_status_idx": {
+          "name": "batches_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batches_workspace_id_workspaces_id_fk": {
+          "name": "batches_workspace_id_workspaces_id_fk",
+          "tableFrom": "batches",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingests": {
+      "name": "ingests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ingest_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "produced": {
+          "name": "produced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingests_batch_idx": {
+          "name": "ingests_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_workspace_created_idx": {
+          "name": "ingests_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_status_idx": {
+          "name": "ingests_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingests_workspace_id_workspaces_id_fk": {
+          "name": "ingests_workspace_id_workspaces_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingests_batch_id_batches_id_fk": {
+          "name": "ingests_batch_id_batches_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconcile_proposals": {
+      "name": "reconcile_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconcile_proposals_batch_idx": {
+          "name": "reconcile_proposals_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconcile_proposals_kind_idx": {
+          "name": "reconcile_proposals_kind_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconcile_proposals_batch_id_batches_id_fk": {
+          "name": "reconcile_proposals_batch_id_batches_id_fk",
+          "tableFrom": "reconcile_proposals",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "google_place_id": {
+          "name": "google_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "places_lat_lng_idx": {
+          "name": "places_lat_lng_idx",
+          "columns": [
+            {
+              "expression": "lat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lng",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "places_google_place_id_unique": {
+          "name": "places_google_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_place_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "asset",
+        "liability",
+        "equity",
+        "income",
+        "expense"
+      ]
+    },
+    "public.batch_status": {
+      "name": "batch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "extracted",
+        "reconciling",
+        "reconciled",
+        "failed",
+        "reconcile_error"
+      ]
+    },
+    "public.document_kind": {
+      "name": "document_kind",
+      "schema": "public",
+      "values": [
+        "receipt_image",
+        "receipt_email",
+        "receipt_pdf",
+        "statement_pdf",
+        "other"
+      ]
+    },
+    "public.ingest_status": {
+      "name": "ingest_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "done",
+        "error",
+        "unsupported"
+      ]
+    },
+    "public.txn_status": {
+      "name": "txn_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided",
+        "reconciled",
+        "error"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776593049864,
       "tag": "0002_batch_ingest",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1776726080523,
+      "tag": "0003_foamy_lady_mastermind",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -630,6 +630,46 @@
           "kind"
         ]
       },
+      "Place": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "google_place_id": {
+            "type": "string"
+          },
+          "formatted_address": {
+            "type": "string"
+          },
+          "lat": {
+            "type": "number"
+          },
+          "lng": {
+            "type": "number"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "google_geocode",
+              "google_places"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "google_place_id",
+          "formatted_address",
+          "lat",
+          "lng",
+          "source"
+        ]
+      },
       "Transaction": {
         "type": "object",
         "properties": {
@@ -730,6 +770,9 @@
             "items": {
               "$ref": "#/components/schemas/TransactionDocumentRef"
             }
+          },
+          "place": {
+            "$ref": "#/components/schemas/Place"
           }
         },
         "required": [
@@ -747,7 +790,8 @@
           "created_at",
           "updated_at",
           "postings",
-          "documents"
+          "documents",
+          "place"
         ]
       },
       "BulkResultItem": {

--- a/src/ingest/extractor.ts
+++ b/src/ingest/extractor.ts
@@ -15,6 +15,19 @@ import { spawn } from "child_process";
 import { randomUUID } from "crypto";
 import { buildExtractorPrompt } from "./prompt.js";
 
+export type ExtractorGeoInfo = {
+  /** Google Places `place_id`. */
+  place_id: string;
+  /** Google-formatted address (what Google returned, not what's on the receipt). */
+  formatted_address: string;
+  /** Latitude in decimal degrees. */
+  lat: number;
+  /** Longitude in decimal degrees. */
+  lng: number;
+  /** Which Google API was used. */
+  source: "google_geocode" | "google_places";
+};
+
 export type ExtractorReceiptFields = {
   payee: string;
   occurred_on: string;
@@ -30,6 +43,12 @@ export type ExtractorReceiptFields = {
     | (string & {});
   items?: Array<{ name: string; total_price_minor?: number }>;
   raw_text?: string;
+  /**
+   * Optional geocode result produced by the agent during Phase 3 of the
+   * extraction prompt. Null/absent when the agent couldn't confidently
+   * resolve the merchant to a Google Places entry.
+   */
+  geo?: ExtractorGeoInfo;
 };
 
 export type ExtractorStatementRow = {
@@ -179,6 +198,30 @@ function coerceResult(parsed: unknown, sessionId: string): ExtractorResult {
         sessionId,
       };
     }
+    // Optional geo block. Shape-check all five fields before letting
+    // it through — a partial / malformed geo gets silently dropped so
+    // it never lands in metadata with stringly-typed coordinates.
+    let geo: ExtractorGeoInfo | undefined;
+    const rawGeo = ex.geo;
+    if (rawGeo && typeof rawGeo === "object" && !Array.isArray(rawGeo)) {
+      const g = rawGeo as Record<string, unknown>;
+      if (
+        typeof g.place_id === "string" &&
+        typeof g.formatted_address === "string" &&
+        typeof g.lat === "number" &&
+        typeof g.lng === "number" &&
+        (g.source === "google_geocode" || g.source === "google_places")
+      ) {
+        geo = {
+          place_id: g.place_id,
+          formatted_address: g.formatted_address,
+          lat: g.lat,
+          lng: g.lng,
+          source: g.source,
+        };
+      }
+    }
+
     return {
       classification: k,
       extracted: {
@@ -191,6 +234,7 @@ function coerceResult(parsed: unknown, sessionId: string): ExtractorResult {
           ? (ex.items as ExtractorReceiptFields["items"])
           : undefined,
         raw_text: typeof ex.raw_text === "string" ? ex.raw_text : undefined,
+        geo,
       },
       sessionId,
     };

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -56,6 +56,46 @@ Phase 2 — extract
   For unsupported, provide only:
     { "reason": "short explanation of why this isn't extractable" }
 
+Phase 3 — geocode (receipt_image / receipt_email / receipt_pdf only)
+  Resolve the merchant location to a Google Places entry IF you can do
+  so with high confidence. Call Google Maps APIs via the Bash tool; the
+  API key is in the GOOGLE_MAPS_API_KEY environment variable.
+
+  Decision tree (in order — stop at first match):
+    (a) $GOOGLE_MAPS_API_KEY is empty  → geo: null. Do not call the API.
+    (b) Receipt shows a full street address → call Geocoding API:
+
+          ADDR='1380 Stockton St, San Francisco, CA 94133'
+          QS=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.stdin.read().strip()))' <<< "$ADDR")
+          curl -sS "https://maps.googleapis.com/maps/api/geocode/json?address=$QS&key=$GOOGLE_MAPS_API_KEY"
+
+        If status=="OK" and results is non-empty, use results[0].
+        Emit geo with source="google_geocode".
+    (c) No address, but receipt shows merchant + a locality hint (city
+        name on the header, state abbreviation, or ZIP code) → call
+        Places Find-Place-From-Text with the locality in the query:
+
+          Q='Wing On Market San Francisco'
+          QS=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.stdin.read().strip()))' <<< "$Q")
+          curl -sS "https://maps.googleapis.com/maps/api/place/findplacefromtext/json?input=$QS&inputtype=textquery&fields=place_id,name,formatted_address,geometry&key=$GOOGLE_MAPS_API_KEY"
+
+        If status=="OK" and candidates is non-empty, use candidates[0].
+        Emit geo with source="google_places".
+    (d) Only merchant name, no locality anywhere on receipt → geo: null.
+        Do NOT geocode by bare merchant name — chains like "Costco" or
+        common names like "Wing On Market" resolve to random stores in
+        other cities (empirically confirmed: bare "Wing On Market"
+        returns the San Gabriel LA store, not the SF one).
+
+  Validation (MUST do before emitting a non-null geo):
+    - The top result's formatted_address MUST contain one of the
+      locality tokens visible on the receipt (the city name, the
+      two-letter state abbreviation, or the ZIP code). If none match,
+      emit geo: null — you got a wrong-city match.
+    - Any non-OK API status, HTTP error, timeout, or parse failure →
+      geo: null. The caller's pipeline tolerates null geo; never block
+      extraction on a Maps outage.
+
 Rules
   - .eml with a PDF attachment: prefer the source with richer data
     (usually the attachment). Mention which in raw_text.
@@ -70,13 +110,20 @@ Final answer format (REQUIRED) — end your response with a single fenced
     "extracted": { "payee": "...", "occurred_on": "YYYY-MM-DD",
                    "total_minor": 12345, "currency": "USD",
                    "category_hint": "groceries",
-                   "items": [ ... ], "raw_text": "..." } }
+                   "items": [ ... ], "raw_text": "...",
+                   "geo": null | {
+                     "place_id": "ChIJ...",
+                     "formatted_address": "1380 Stockton St, San Francisco, CA 94133, USA",
+                     "lat": 37.7985813,
+                     "lng": -122.4084993,
+                     "source": "google_geocode"
+                   } } }
 
   { "classification": "receipt_email",
-    "extracted": { ...same fields as receipt_image... } }
+    "extracted": { ...same fields as receipt_image, including geo... } }
 
   { "classification": "receipt_pdf",
-    "extracted": { ...same fields as receipt_image... } }
+    "extracted": { ...same fields as receipt_image, including geo... } }
 
   { "classification": "statement_pdf",
     "extracted": { "rows": [ { "date": "...", "payee": "...", "amount_minor": 1234 } ] } }

--- a/src/ingest/worker.ts
+++ b/src/ingest/worker.ts
@@ -40,6 +40,7 @@ import {
   type TransactionRow,
 } from "../routes/transactions.service.js";
 import { linkDocumentToTransaction } from "../routes/documents.service.js";
+import { upsertPlace } from "../routes/places.service.js";
 import { emit as busEmit, type BatchCountsPayload } from "../events/bus.js";
 import { ingestSession, getSessionJsonlPath } from "../langfuse.js";
 
@@ -424,6 +425,26 @@ async function writeReceiptTransaction(
        WHERE id = ${tx.id}::uuid
          AND workspace_id = ${workspaceId}::uuid`,
   );
+
+  // Phase 3 geocode: if the agent produced a valid geo block, upsert
+  // into the shared `places` table and point this transaction at it.
+  // Failure here is logged but does not fail the ingest — geo is
+  // best-effort and the ledger row is already balanced & durable.
+  if (ex.geo) {
+    try {
+      const placeId = await upsertPlace(ex.geo);
+      await db.execute(
+        sql`UPDATE transactions
+             SET place_id = ${placeId}::uuid
+           WHERE id = ${tx.id}::uuid
+             AND workspace_id = ${workspaceId}::uuid`,
+      );
+    } catch (err) {
+      console.warn(
+        `[places] upsert failed for ingest=${ingestId}: ${(err as Error).message}`,
+      );
+    }
+  }
 
   return tx;
 }

--- a/src/routes/places.service.ts
+++ b/src/routes/places.service.ts
@@ -1,0 +1,86 @@
+/**
+ * Places service — manages the shared `places` table.
+ *
+ * Populated by the ingest worker when the extraction agent resolves a
+ * merchant to a Google Places entry (see `src/ingest/prompt.ts` Phase
+ * 3). Keyed by Google's stable `google_place_id`; the same merchant
+ * seen by two ingests (same or different workspace) hits one row.
+ *
+ * The shape returned by `upsertPlace` is the row's internal UUID —
+ * callers (the ingest worker) store this in `transactions.place_id`.
+ * The row itself is read by `loadPlacesByIds` for the transaction
+ * response JOIN.
+ */
+import { sql, inArray } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { places } from "../schema/places.js";
+import type { ExtractorGeoInfo } from "../ingest/extractor.js";
+
+export interface PlaceRow {
+  id: string;
+  google_place_id: string;
+  formatted_address: string;
+  /** Decimal degrees. Stored as numeric in PG, returned as string by the
+   * driver — this service coerces to number for the API response. */
+  lat: number;
+  lng: number;
+  source: "google_geocode" | "google_places";
+}
+
+/**
+ * Insert a new places row or bump hit_count + last_seen_at on an
+ * existing row keyed by google_place_id. Returns the row's UUID.
+ *
+ * The `formatted_address` / `lat` / `lng` on an existing row are NOT
+ * updated on conflict — Google's place_id is considered stable and we
+ * trust the first sighting. Raw response is overwritten with the
+ * latest body for debugging convenience.
+ */
+export async function upsertPlace(geo: ExtractorGeoInfo): Promise<string> {
+  const rows = await db
+    .insert(places)
+    .values({
+      googlePlaceId: geo.place_id,
+      formattedAddress: geo.formatted_address,
+      lat: String(geo.lat),
+      lng: String(geo.lng),
+      source: geo.source,
+      rawResponse: geo as unknown as Record<string, unknown>,
+    })
+    .onConflictDoUpdate({
+      target: places.googlePlaceId,
+      set: {
+        lastSeenAt: sql`NOW()`,
+        hitCount: sql`${places.hitCount} + 1`,
+      },
+    })
+    .returning({ id: places.id });
+  return rows[0]!.id;
+}
+
+/**
+ * Bulk-load by internal UUID. Used by transactions.service.ts to JOIN
+ * in the response. Returns a Map so callers can lookup by id without
+ * a second pass.
+ */
+export async function loadPlacesByIds(
+  ids: string[],
+): Promise<Map<string, PlaceRow>> {
+  const map = new Map<string, PlaceRow>();
+  if (ids.length === 0) return map;
+  const rows = await db
+    .select()
+    .from(places)
+    .where(inArray(places.id, ids));
+  for (const r of rows) {
+    map.set(r.id, {
+      id: r.id,
+      google_place_id: r.googlePlaceId,
+      formatted_address: r.formattedAddress,
+      lat: Number(r.lat),
+      lng: Number(r.lng),
+      source: r.source as "google_geocode" | "google_places",
+    });
+  }
+  return map;
+}

--- a/src/routes/transactions.service.ts
+++ b/src/routes/transactions.service.ts
@@ -22,6 +22,7 @@ import {
   transactionEvents,
   workspaces,
 } from "../schema/index.js";
+import { loadPlacesByIds, type PlaceRow } from "./places.service.js";
 import { newId } from "../http/uuid.js";
 import {
   HttpProblem,
@@ -84,6 +85,13 @@ export interface TransactionRow {
   updated_at: string;
   postings: PostingRow[];
   documents: Array<{ id: string; kind: string }>;
+  /**
+   * Optional Google Places entry for this transaction's merchant
+   * location. Null when the extraction agent declined to geocode (no
+   * address / no locality hint), when the workspace/ingest predates
+   * the places feature, or when the row has been unlinked.
+   */
+  place: PlaceRow | null;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -177,6 +185,7 @@ function mapTransactionRow(
   row: any,
   posts: any[],
   docs: Array<{ id: string; kind: string }>,
+  place: PlaceRow | null = null,
 ): TransactionRow {
   return {
     id: row.id,
@@ -197,6 +206,7 @@ function mapTransactionRow(
     updated_at: toIsoString(row.updatedAt ?? row.updated_at),
     postings: posts.map(mapPostingRow),
     documents: docs,
+    place,
   };
 }
 
@@ -225,7 +235,9 @@ async function loadTransactionFull(
     .from(documentLinks)
     .innerJoin(documents, eq(documents.id, documentLinks.documentId))
     .where(eq(documentLinks.transactionId, id));
-  return mapTransactionRow(t, posts, docLinks);
+  const placeMap = t.placeId ? await loadPlacesByIds([t.placeId]) : null;
+  const place = placeMap?.get(t.placeId!) ?? null;
+  return mapTransactionRow(t, posts, docLinks, place);
 }
 
 async function loadWorkspaceBaseCurrency(
@@ -501,8 +513,18 @@ export async function listTransactions(
     docByTx.set(d.transaction_id, arr);
   }
 
+  const placeIds = page
+    .map((r) => r.place_id as string | null)
+    .filter((v): v is string => typeof v === "string" && v.length > 0);
+  const placeMap = placeIds.length > 0 ? await loadPlacesByIds(placeIds) : null;
+
   const items = page.map((r) =>
-    mapTransactionRow(r, postByTx.get(r.id) ?? [], docByTx.get(r.id) ?? []),
+    mapTransactionRow(
+      r,
+      postByTx.get(r.id) ?? [],
+      docByTx.get(r.id) ?? [],
+      r.place_id && placeMap ? (placeMap.get(r.place_id) ?? null) : null,
+    ),
   );
 
   const last = page[page.length - 1]!;

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -10,3 +10,4 @@ export * from "./idempotency.js";
 export * from "./batches.js";
 export * from "./ingests.js";
 export * from "./reconcile_proposals.js";
+export * from "./places.js";

--- a/src/schema/places.ts
+++ b/src/schema/places.ts
@@ -1,0 +1,64 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  integer,
+  numeric,
+  jsonb,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { createdAt } from "./common.js";
+
+/**
+ * Normalized Google Places entries, keyed by Google's stable
+ * `google_place_id`. Shared across workspaces: the data is public
+ * (street address + lat/lng), and de-duplication across tenants is a
+ * feature — the same merchant visited by two users is one row.
+ *
+ * Populated by the ingest worker when the extraction agent returns a
+ * `geo` block (see `src/ingest/prompt.ts` Phase 3). Transactions point
+ * here via `transactions.place_id`; the response shape for
+ * `GET /v1/transactions/:id` joins this table and returns a nested
+ * `place` subobject.
+ *
+ * Never updated with per-workspace data. `hit_count` and `last_seen_at`
+ * are informational (observability for "most-visited places") and bump
+ * on every ingest, but they are not workspace-partitioned — a single
+ * workspace can't use them for private stats without a join through
+ * transactions.
+ */
+export const places = pgTable(
+  "places",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    /** Google's stable place_id. Unique across the table. */
+    googlePlaceId: text("google_place_id").notNull().unique(),
+    formattedAddress: text("formatted_address").notNull(),
+    /** Decimal degrees, ±90.000000. */
+    lat: numeric("lat", { precision: 9, scale: 6 }).notNull(),
+    /** Decimal degrees, ±180.000000. */
+    lng: numeric("lng", { precision: 9, scale: 6 }).notNull(),
+    /** Which Google endpoint produced this entry. */
+    source: text("source").notNull(),
+    /**
+     * Full Google response body at first sighting. Kept for debugging
+     * and future feature extraction (Places `types`, opening hours,
+     * etc.). Not refreshed on subsequent hits.
+     */
+    rawResponse: jsonb("raw_response"),
+    firstSeenAt: createdAt,
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true })
+      .notNull()
+      .default(sql`NOW()`),
+    hitCount: integer("hit_count").notNull().default(1),
+  },
+  (t) => [
+    // Geo-bbox filtering for future trip clustering. Btree on (lat, lng)
+    // isn't ideal for range queries (a GiST + PostGIS index would be
+    // better), but it's cheap, indexed, and sufficient for the small
+    // data volumes we expect pre-PostGIS.
+    index("places_lat_lng_idx").on(t.lat, t.lng),
+  ],
+);

--- a/src/schema/transactions.ts
+++ b/src/schema/transactions.ts
@@ -13,6 +13,7 @@ import { createdAt, updatedAt, version } from "./common.js";
 import { workspaces } from "./workspaces.js";
 import { users } from "./users.js";
 import { ingests } from "./ingests.js";
+import { places } from "./places.js";
 
 export const transactions = pgTable(
   "transactions",
@@ -40,6 +41,13 @@ export const transactions = pgTable(
     ),
     // trip_id is a forward-reference to the future trips table.
     tripId: uuid("trip_id"),
+    // FK to `places` for merchant geolocation; nullable because the
+    // extraction agent may legitimately decline to geocode (no address
+    // and no locality hint → geo:null). Written by the ingest worker
+    // from the agent's Phase 3 geo block.
+    placeId: uuid("place_id").references(() => places.id, {
+      onDelete: "set null",
+    }),
     metadata: jsonb("metadata").notNull().default({}),
     version,
     createdBy: uuid("created_by").references(() => users.id, {
@@ -58,5 +66,6 @@ export const transactions = pgTable(
     index("transactions_status_idx").on(t.workspaceId, t.status),
     index("transactions_source_ingest_idx").on(t.sourceIngestId),
     index("transactions_trip_idx").on(t.tripId),
+    index("transactions_place_idx").on(t.placeId),
   ],
 );

--- a/src/schemas/v1/transaction.ts
+++ b/src/schemas/v1/transaction.ts
@@ -51,6 +51,22 @@ export const TransactionDocumentRef = z
   })
   .openapi("TransactionDocumentRef");
 
+/**
+ * Google Places entry associated with a transaction's merchant location.
+ * Shared across workspaces via the `places` table; joined into the
+ * transaction response for display convenience.
+ */
+export const Place = z
+  .object({
+    id: Uuid,
+    google_place_id: z.string(),
+    formatted_address: z.string(),
+    lat: z.number(),
+    lng: z.number(),
+    source: z.enum(["google_geocode", "google_places"]),
+  })
+  .openapi("Place");
+
 export const Transaction = z
   .object({
     id: Uuid,
@@ -69,6 +85,7 @@ export const Transaction = z
     updated_at: IsoDateTime,
     postings: z.array(Posting),
     documents: z.array(TransactionDocumentRef),
+    place: Place.nullable(),
   })
   .openapi("Transaction");
 


### PR DESCRIPTION
## Summary

- New normalized \`places\` table keyed on Google's stable \`place_id\`; shared across workspaces for de-duplication
- \`transactions.place_id\` FK + index, populated by the ingest worker after \`upsertPlace\`
- \`GET /v1/transactions/:id\` and list endpoints JOIN \`places\` and return a typed \`transaction.place\` subobject
- \`transactions.metadata\` stays clean — geo data is NOT mixed into the freeform JSONB

Closes #47. Builds on #46's Phase 3 extraction prompt.

## Test plan

- [x] \`docker compose up -d --build\` — drizzle \`0003_foamy_lady_mastermind.sql\` applied cleanly on startup
- [x] Ingested a real Urth Caffe receipt — \`places\` row created, \`transactions.place_id\` populated, \`GET /v1/transactions/:id\` returns nested \`place\` (Santa Monica lat/lng, \`source=google_geocode\`)
- [x] \`metadata\` verified clean (only \`source/category_hint/classification/source_ingest_id\` — no \`geo\` pollution)
- [x] Backward compatibility: pre-places transactions return \`place: null\`
- [x] Frontend verification (separate PR) confirms map renders correctly at Ocean Park SM with the Urth Caffe marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)