### PR TITLE
feat: warn at startup when GOOGLE_MAPS_API_KEY is unset

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,13 @@ async function main(): Promise<void> {
     );
   }
 
+  if (!process.env.GOOGLE_MAPS_API_KEY) {
+    console.warn(
+      "⚠️  GOOGLE_MAPS_API_KEY not set — receipt geocoding will be skipped. " +
+        "Set the env var in .env to enable Google Maps Geocoding + Places API calls during Phase 3 of extraction.",
+    );
+  }
+
   // Ingest worker: recovers any stale batches from a prior crash and
   // then sits idle until /v1/ingest/batch enqueues files. Same process
   // as HTTP so the DB pool + v1 services are shared.


### PR DESCRIPTION
## Summary

Add a single warning log at server startup when `GOOGLE_MAPS_API_KEY` is missing. Geocoding remains a silent best-effort skip during extraction (per the agent prompt), but operators now know up-front that the feature is disabled.

## Why

Currently a user can configure their `.env` with the wrong variable name (e.g. `GOOGLE_MAPS_SERVER_KEY` instead of `GOOGLE_MAPS_API_KEY`) and never realize geocoding is silently disabled. The only diagnostic is the per-receipt agent log:

> Geocoding denied (API key issue). Per instructions, skip geocoding (best-effort, never blocks). Phase 3.5 Check C also skipped (no geocode result).

That message appears once per upload, after the fact, deep in extraction logs. A startup warning surfaces the misconfiguration immediately, before any uploads.

## Changes

- `src/server.ts`: in `main()`, after the seed step, check `process.env.GOOGLE_MAPS_API_KEY`. If unset/empty, emit one warning matching the existing emoji-prefixed log style.
- No behavioral change to the extraction agent or API contract.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Boot with `GOOGLE_MAPS_API_KEY` unset → warning appears once between seed + MCP-listening logs; receipts still extract (no place data).
- [ ] Boot with key set → no warning; geocoding works as before.

## Related

- Frontend UX issue (silently absent Location section): TINKPA/receipt-assistant-frontend#15