### PR TITLE
feat: expose deployed build metadata (#52)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@
 
 node_modules
 dist
-.git
 .gitignore
 .env
 .env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,16 @@ FROM node:22-bookworm AS builder
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
 # Install full deps first (cached layer as long as package*.json is unchanged)
 COPY package.json package-lock.json* ./
 RUN npm ci
 
 # Copy sources and build
+COPY .git ./.git
 COPY tsconfig.json ./
+COPY scripts/ ./scripts/
 COPY src/ ./src/
 COPY drizzle/ ./drizzle/
 RUN npm run build

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Personal receipt processing assistant powered by Claude Code CLI + FastMCP",
   "type": "module",
   "scripts": {
+    "prebuild": "node scripts/generate-build-info.mjs",
     "build": "tsc",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx scripts/migrate.ts",

--- a/scripts/generate-build-info.mjs
+++ b/scripts/generate-build-info.mjs
@@ -1,0 +1,33 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+
+function run(cmd) {
+  try {
+    return execSync(cmd, { cwd: root, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+  } catch {
+    return null;
+  }
+}
+
+const gitSha = process.env.GIT_SHA || run('git rev-parse HEAD') || 'unknown';
+const gitShortSha = process.env.GIT_SHORT_SHA || run('git rev-parse --short HEAD') || gitSha.slice(0, 7);
+const gitBranch = process.env.GIT_BRANCH || run('git rev-parse --abbrev-ref HEAD') || 'unknown';
+const builtAt = process.env.BUILD_TIME || new Date().toISOString();
+
+const outDir = path.join(root, 'src', 'generated');
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(
+  path.join(outDir, 'build-info.ts'),
+  `export const buildInfo = ${JSON.stringify({
+    service: 'receipt-assistant',
+    version: pkg.version,
+    gitSha,
+    gitShortSha,
+    gitBranch,
+    builtAt,
+  }, null, 2)} as const;\n`,
+);

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,7 @@ import {
 } from "./routes/ingest.js";
 import { reconcileRouter } from "./routes/reconcile.js";
 import { reportsRouter } from "./routes/reports.js";
+import { buildInfo } from "./generated/build-info.js";
 
 export function buildApp(): Express {
   const app = express();
@@ -49,7 +50,16 @@ export function buildApp(): Express {
   );
 
   app.get("/health", (_req: Request, res: Response) => {
-    res.json({ status: "ok", service: "receipt-assistant", version: "2.0.0-alpha" });
+    res.json({
+      status: "ok",
+      service: "receipt-assistant",
+      version: buildInfo.version,
+      build: buildInfo,
+    });
+  });
+
+  app.get("/version", (_req: Request, res: Response) => {
+    res.json(buildInfo);
   });
 
   // ── Per-request context ─────────────────────────────────────────────

--- a/src/generated/build-info.ts
+++ b/src/generated/build-info.ts
@@ -1,0 +1,8 @@
+export const buildInfo = {
+  "service": "receipt-assistant",
+  "version": "1.0.0",
+  "gitSha": "c26c1428710c6ab32286cfa6a1c8f3cb0b65bcb0",
+  "gitShortSha": "c26c142",
+  "gitBranch": "main",
+  "builtAt": "2026-04-27T22:07:53.685Z"
+} as const;

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -18,7 +18,7 @@ import {
   ErrorResponse,
   ValidationErrorResponse,
 } from "./schemas/common.js";
-import { HealthResponse } from "./schemas/health.js";
+import { BuildInfoResponse, HealthResponse } from "./schemas/health.js";
 import { ProblemDetails } from "./schemas/v1/common.js";
 import { registerAccountsOpenApi } from "./routes/accounts.js";
 import { registerTransactionsOpenApi } from "./routes/transactions.js";
@@ -33,6 +33,7 @@ export function buildRegistry(): OpenAPIRegistry {
 
   registry.register("ErrorResponse", ErrorResponse);
   registry.register("ValidationErrorResponse", ValidationErrorResponse);
+  registry.register("BuildInfoResponse", BuildInfoResponse);
   registry.register("HealthResponse", HealthResponse);
   registry.register("ProblemDetails", ProblemDetails);
 
@@ -51,6 +52,19 @@ export function buildRegistry(): OpenAPIRegistry {
       200: {
         description: "Service is up",
         content: { "application/json": { schema: HealthResponse } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/version",
+    summary: "Build metadata",
+    tags: ["meta"],
+    responses: {
+      200: {
+        description: "Deployed build metadata",
+        content: { "application/json": { schema: BuildInfoResponse } },
       },
     },
   });

--- a/src/schemas/health.ts
+++ b/src/schemas/health.ts
@@ -1,10 +1,22 @@
 import { z } from "zod";
 import "./common.js";
 
+export const BuildInfoResponse = z
+  .object({
+    service: z.string().openapi({ example: "receipt-assistant" }),
+    version: z.string().openapi({ example: "1.0.0" }),
+    gitSha: z.string().openapi({ example: "a02db01234567890abcdef1234567890abcdef12" }),
+    gitShortSha: z.string().openapi({ example: "a02db01" }),
+    gitBranch: z.string().openapi({ example: "main" }),
+    builtAt: z.string().datetime().openapi({ example: "2026-04-27T22:00:35.000Z" }),
+  })
+  .openapi("BuildInfoResponse");
+
 export const HealthResponse = z
   .object({
     status: z.literal("ok"),
     service: z.string().openapi({ example: "receipt-assistant" }),
     version: z.string().openapi({ example: "1.0.0" }),
+    build: BuildInfoResponse,
   })
   .openapi("HealthResponse");

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { registerDocumentsMcpTools } from "./mcp/documents.js";
 import { registerReconcileMcpTools } from "./mcp/reconcile.js";
 import { registerReportsMcpTools } from "./mcp/reports.js";
 import { start as startIngestWorker } from "./ingest/worker.js";
+import { buildInfo } from "./generated/build-info.js";
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
 const MCP_PORT = parseInt(process.env.MCP_PORT ?? "3001", 10);
@@ -62,9 +63,10 @@ async function main(): Promise<void> {
   const app = buildApp();
   app.listen(PORT, "0.0.0.0", () => {
     console.log(`🌐 HTTP API listening on http://0.0.0.0:${PORT}`);
+    console.log(`🏷️  Build ${buildInfo.version} (${buildInfo.gitShortSha}) built ${buildInfo.builtAt}`);
     console.log(`
 📋 Endpoints:
-   GET  /health · /openapi.json · /docs
+   GET  /health · /version · /openapi.json · /docs
    /v1/accounts        — chart of accounts + balance + register
    /v1/transactions    — double-entry ledger CRUD + postings + void
    /v1/postings        — read-only posting search


### PR DESCRIPTION
## Summary
- generate backend build metadata automatically at build time
- expose deployed build info via /version and /health
- log deployed build identity at startup for easier verification

Closes #52

## Test plan
- [x] npm run build
- [x] docker compose up -d --build
- [x] curl http://localhost:3000/version
- [x] curl http://localhost:3000/health

🤖 Generated with [Claude Code](https://claude.com/claude-code)