### PR TITLE
refactor: split bind-mounts into 3 locations by data category (Era 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 /data/
 *.db
+.DS_Store
 
 # Local secrets — use .env.example as the template
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,52 +186,51 @@ that trap.)
 - **CI-ready**: verification scripts can hit the API directly
 - **No context switching**: stay in terminal, no browser navigation
 
-## Persistent data — host bind mounts at `~/Developer/2026_Dev_ReceiptAssistant/data/`
+## Persistent data — three locations by category
 
-All app-critical state lives on the **host filesystem**, *outside this git repo*, bind-mounted into containers. Docker named volumes are no longer used for anything that matters; the host path is also outside both this public repo and iCloud-synced `~/Documents/`.
+App state is split across three host locations by data type. Each location is chosen to defeat a specific failure mode; do not collapse them back into one.
 
-| Container path | Host bind | Purpose |
-|---|---|---|
-| `/var/lib/postgresql/data` | `~/Developer/2026_Dev_ReceiptAssistant/data/postgres/` | The ledger (postgres 17) |
-| `/data` | `~/Developer/2026_Dev_ReceiptAssistant/data/uploads/` | Uploaded receipt images |
-| `/home/node/.claude` | `~/Developer/2026_Dev_ReceiptAssistant/data/claude/` | Container's Claude Code OAuth + config |
+| Container path | Host bind | Category | Why this location |
+|---|---|---|---|
+| `/data` | `~/Documents/10_Projects/2026_Dev_ReceiptAssistant/data/uploads/` | User content (receipt images, PII) | Outer project lives in iCloud, so the user's own receipt corpus syncs across their Macs. Pin via Finder → "Keep Downloaded" if Optimize Mac Storage is on. |
+| `/var/lib/postgresql/data` | `~/Developer/receipt-assistant-data/postgres/` | Runtime state (DB binary) | Sibling dir outside any git repo and outside iCloud. Postgres binary contains extracted PII; this repo is public on GitHub. iCloud + Postgres fsync is hostile. Sibling is the right side of both lines. |
+| `/home/node/.claude` | `~/Developer/receipt-assistant-data/claude/` | Runtime state (OAuth credentials) | Same reason: `.credentials.json` is sensitive; keep it far from `git add -f` and never on iCloud. |
 
-The bind paths are written into `docker-compose.yml` as `${HOME}/Developer/2026_Dev_ReceiptAssistant/data/...` so they work for any local user. The notebook directory `~/Developer/2026_Dev_ReceiptAssistant/` is also reachable via a symlink at `~/Documents/10_Projects/2026_Dev_ReceiptAssistant/` for the Digital Life System layout. Originals of all uploaded receipts also live in `~/Desktop/RECEIPT/`, which remains the human-curated source of truth.
+`docker-compose.yml` uses absolute `${HOME}/...` paths so they resolve identically for any local user. Originals of all uploaded receipts also live in `~/Desktop/RECEIPT/`, which remains the human-curated source of truth.
 
-### Why this layout
+### Why three locations (the four failure modes)
 
-Three layered failure modes drove the design:
+1. **OrbStack / Docker named volumes are not durable.** Lost the entire ledger on 2026-05-09 to a stack-wide volume wipe (every named volume in this project recreated at the same instant — signature of `docker compose down -v` or OrbStack reset). Recovery from Time Machine was impossible: OrbStack sets `com.apple.metadata:com_apple_backup_excludeItem` on its 8 TB sparse `data.img.raw`, so TM has never backed it up. Only the raw images in `~/Desktop/RECEIPT/` survived. → Move durable data out of Docker-managed storage entirely.
 
-1. **OrbStack / Docker named volumes are not durable.** Lost the entire ledger on 2026-05-09 to a stack-wide volume wipe (every named volume in this project recreated at the same instant — signature of `docker compose down -v` or OrbStack reset). Recovery from Time Machine was impossible: OrbStack sets `com.apple.metadata:com_apple_backup_excludeItem` on its 8 TB sparse `data.img.raw`, so TM has never backed it up. Only the raw images in `~/Desktop/RECEIPT/` survived. → Move data out of Docker-managed storage entirely.
+2. **This repo is public on GitHub.** A `data/` directory inside the repo with real receipt content or OAuth credentials would be one `.gitignore` mishap or `git add -f` away from leaking PII / secrets. → Postgres data and OAuth credentials live in a **sibling** dir (`~/Developer/receipt-assistant-data/`), not in any git tree at all. The `data/` directory in this repo is reserved for code-asset datasets (test fixtures, golden eval sets) — gitignored via `/data/` but conceptually it's where intentional dataset additions go.
 
-2. **This repo is public on GitHub.** A `data/` directory inside the repo would be one `.gitignore` mishap or `git add -f` away from publishing PII receipts to the world. → Move data out of the repo tree entirely. The bind path is *outside* this repo, so no git operation here can ever touch it.
+3. **`~/Documents/` is iCloud-synced.** Postgres data files plus iCloud's continuous block-level reupload + revisioning is a hostile combination (constant churn, fsync semantics, possible truncation races). → Postgres lives outside iCloud. **User receipt images, however, intentionally live in iCloud** because the user wants their personal receipt corpus to sync across Macs; this is fine for static image files but requires "Keep Downloaded" pinning if Optimize Storage might evict them under the bind-mount.
 
-3. **`~/Documents/` is iCloud-synced** on this user's Mac. Postgres data files plus iCloud's continuous block-level reupload + revisioning is a hostile combination (constant churn, fsync semantics, possible truncation races). → Pick a non-iCloud path. `~/Developer/` is the right side of that line.
-
-The project notebook itself lives at `~/Developer/2026_Dev_ReceiptAssistant/` (moved off iCloud 2026-05-10) with a back-symlink at `~/Documents/10_Projects/2026_Dev_ReceiptAssistant`. The `data/` subdirectory inside the notebook holds the runtime data.
+4. **The outer project notebook lives in iCloud** (`~/Documents/10_Projects/2026_Dev_ReceiptAssistant/`, with `~/Developer/2026_Dev_ReceiptAssistant/` as a symlink back) because top-level docs (PLAN, CLAUDE.md, lab notes) are the kind of writing that should sync. The three code repos under `code/` are symlinks to `~/Developer/<repo>/` so the codebase itself stays off iCloud.
 
 Bind mounts move the failure boundary: a container or volume reset no longer touches the host filesystem. The data only goes away if *you* `rm -rf` the bind path explicitly.
 
-### Claude Code OAuth — same volume rules as before, on disk now
+### Claude Code OAuth — bind mount at sibling dir
 
-Auth is still **not** an env var, and still **not** a bind mount of the host's `~/.claude/.credentials.json`. The container holds its own independent OAuth session at `~/Developer/2026_Dev_ReceiptAssistant/data/claude/`, seeded once via `docker exec -it receipt-assistant claude /login`. The in-container CLI refreshes both `accessToken` and `refreshToken` on expiry and writes rotation back into that path on the host. No collision with the host's native `claude` CLI because nothing is shared.
+Auth is still **not** an env var, and still **not** a bind mount of the host's `~/.claude/.credentials.json`. The container holds its own independent OAuth session at `~/Developer/receipt-assistant-data/claude/`, seeded once via `docker exec -it receipt-assistant claude /login`. The in-container CLI refreshes both `accessToken` and `refreshToken` on expiry and writes rotation back into that path on the host. No collision with the host's native `claude` CLI because nothing is shared.
 
 **Operate this via the `setup` skill** — first-time bootstrap, 401 diagnosis, recovery procedures all live there.
 
-### Four-era timeline of OAuth approaches
+### Five-era timeline of OAuth approaches
 
 - **Era 1 (pre-2026-04-19) — `CLAUDE_CODE_OAUTH_TOKEN` env var + entrypoint-synthesized credentials file.** Broke because the env var overrides the file and disables self-refresh; the synthesized file had `refreshToken: ""`. Result: 24h 401 cycle.
 - **Era 2 (2026-04-19 → 2026-04-20) — host `~/.claude/.credentials.json` bind-mounted RW.** Broke because host and container shared a single OAuth session: host's `claude` CLI rotates the refresh token on every interactive use, invalidating the container's next call. Result: 401 every few hours.
 - **Era 3 (2026-04-20 → 2026-05-09) — Docker-managed named volume `claude-code-config`.** Worked operationally but vulnerable to volume wipes (and was wiped along with everything else on 2026-05-09).
-- **Era 4 (2026-05-09 onward) — host bind mount at `~/Developer/2026_Dev_ReceiptAssistant/data/claude/`.** Same OAuth isolation as Era 3, but now resilient to volume resets and physically located outside the public git repo. The directory only goes away if you delete it explicitly.
+- **Era 4 (2026-05-09 → 2026-05-11) — host bind mount at `~/Developer/2026_Dev_ReceiptAssistant/data/claude/`.** Volume-reset-resilient but mixed runtime state into the outer project notebook, which complicated the 2026-05-11 outer-project iCloud migration.
+- **Era 5 (2026-05-11 onward) — host bind mount at `~/Developer/receipt-assistant-data/claude/`.** Sibling dir, deliberately outside this repo and outside iCloud. Same OAuth isolation, with the runtime-state-leaks-into-docs-notebook problem solved by physical separation.
 
 ### Hard rules
 
 - **Never re-introduce `CLAUDE_CODE_OAUTH_TOKEN`** to `.env` or `docker-compose.yml`. Env var overrides the on-disk credentials file and disables self-refresh → Era 1's 24h 401 cycle.
-- **Never bind-mount the host's `~/.claude/` or `~/.claude/.credentials.json`** into the container. The host/container collision is Era 2's bug. Always use the project's `data/claude/`, which the host's native CLI never touches.
-- **Never `rm -rf` the bind-mount path** (`~/Developer/2026_Dev_ReceiptAssistant/data/`) without realizing you're nuking the ledger, the uploads, and the OAuth session in one command. `docker compose down -v` is now harmless — bind mounts are not Docker-managed — but the host directory is unforgiving.
-- **Never periodically sync host Keychain → the bind-mounted `data/claude/`.** Re-introduces rotation collisions; in-container auto-refresh is the intended mechanism.
-- **Never move `data/` back into this repo or under `~/Documents/`.** Repo placement risks a public-repo PII leak; `~/Documents/` is iCloud-synced and incompatible with Postgres write semantics.
+- **Never bind-mount the host's `~/.claude/` or `~/.claude/.credentials.json`** into the container. The host/container collision is Era 2's bug. Use the dedicated `~/Developer/receipt-assistant-data/claude/`, which the host's native CLI never touches.
+- **Never `rm -rf ~/Developer/receipt-assistant-data/`** — that's the postgres ledger + the OAuth session in one stroke. `docker compose down -v` is harmless (bind mounts are not Docker-managed) but the host directory is unforgiving.
+- **Never periodically sync host Keychain → `receipt-assistant-data/claude/`.** Re-introduces rotation collisions; in-container auto-refresh is the intended mechanism.
+- **Never move runtime data (postgres, claude) into this repo or into the outer iCloud notebook.** Repo placement risks a public-repo PII / credential leak; iCloud placement is incompatible with Postgres write semantics and risks credential exfil via sync. Only `data/uploads/` (user images) belongs in iCloud — postgres + claude stay in the sibling dir.
 - **Recovery on 401:** `docker exec -it receipt-assistant claude /login`, follow the OAuth code flow.
 
 ## GitHub Issues

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ docker exec -it receipt-assistant claude /login
 # paste the returned code back into the terminal.
 ```
 
-Credentials persist in the `claude-code-config` named Docker volume and survive every `docker compose down` / `up` / `restart`. The in-container CLI self-refreshes access + refresh tokens on expiry and writes rotation back into the volume. No env var, no host Keychain sync, no recurring script.
+Credentials persist on the host at `~/Developer/receipt-assistant-data/claude/` (bind-mounted into the container at `/home/node/.claude`) and survive every `docker compose down` / `up` / `restart` — and OrbStack resets, unlike Docker named volumes. The in-container CLI self-refreshes access + refresh tokens on expiry and writes rotation back into the bind path. No env var, no host Keychain sync, no recurring script.
 
 Eventually the refresh token expires server-side (weeks to months). When that happens the next call returns 401 — rerun the same `claude /login` inside the container. For full bootstrap, migration, and 401-recovery procedures, invoke the **`setup` skill** in Claude Code inside this project.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,12 +29,16 @@ services:
       TZ: UTC
       PGTZ: UTC
     volumes:
-      # App DB binary state. Bind-mount lives inside this repo at ./data/postgres
-      # (gitignored via /data/ in .gitignore) — it's pure runtime state, not
-      # user content. Keeping it next to the compose file means relative path,
-      # cross-machine portability, and no cross-repo path coupling.
-      # Survives OrbStack/Docker resets because it's host-side.
-      - ./data/postgres:/var/lib/postgresql/data
+      # App DB binary state. Bind-mount to a SIBLING dir outside any git repo
+      # and outside iCloud — `~/Developer/receipt-assistant-data/postgres/`.
+      # Why not inside this repo's data/? Because this repo is public on
+      # GitHub and the DB binary contains extracted receipt PII (merchants,
+      # amounts, line items). A `.gitignore` mishap or `git add -f` could
+      # leak it. Why not in the outer iCloud-synced project? Because
+      # iCloud's continuous block-level reupload is hostile to Postgres
+      # fsync semantics. Sibling dir is the right side of both lines.
+      # Survives OrbStack/Docker resets (host-side).
+      - ${HOME}/Developer/receipt-assistant-data/postgres:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d receipts"]
       interval: 3s
@@ -78,12 +82,14 @@ services:
       # will return errors at read time; pin the dir via Finder → "Keep
       # Downloaded" to prevent that.
       - ${HOME}/Documents/10_Projects/2026_Dev_ReceiptAssistant/data/uploads:/data
-      # Claude Code OAuth credentials + session state. Bind-mount inside
-      # this repo at ./data/claude (gitignored). NOT a bind of host's
-      # ~/.claude/ — that caused rotation collisions in Era 2. Container
-      # holds its own independent OAuth session, seeded once via
-      # `docker exec -it receipt-assistant claude /login`; the CLI
-      # self-refreshes and writes back here. Survives compose down/up and
-      # OrbStack resets. See `setup` skill.
-      - ./data/claude:/home/node/.claude
+      # Claude Code OAuth credentials + session state. Bind-mount to a
+      # SIBLING dir outside any git repo and outside iCloud —
+      # `~/Developer/receipt-assistant-data/claude/`. NOT inside this
+      # public repo (`.credentials.json` is sensitive — keep it far from
+      # `git add -f`). NOT a bind of host's `~/.claude/` — that caused
+      # rotation collisions in Era 2. Container holds its own independent
+      # OAuth session, seeded once via `docker exec -it receipt-assistant
+      # claude /login`; the CLI self-refreshes and writes back here.
+      # Survives compose down/up and OrbStack resets. See `setup` skill.
+      - ${HOME}/Developer/receipt-assistant-data/claude:/home/node/.claude
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,15 +29,12 @@ services:
       TZ: UTC
       PGTZ: UTC
     volumes:
-      # Bind-mount to a host path OUTSIDE this repo so that:
-      #   1. OrbStack/Docker resets can never wipe the ledger
-      #   2. The data is physically separate from a public git repo —
-      #      no .gitignore failure mode can leak it
-      #   3. The path stays the same across multiple repos (frontend
-      #      and macOS clients can share the same uploads dir if needed)
-      # Lives inside the project notebook ~/Developer/2026_Dev_ReceiptAssistant/
-      # which is itself off iCloud-synced ~/Documents/.
-      - ${HOME}/Developer/2026_Dev_ReceiptAssistant/data/postgres:/var/lib/postgresql/data
+      # App DB binary state. Bind-mount lives inside this repo at ./data/postgres
+      # (gitignored via /data/ in .gitignore) — it's pure runtime state, not
+      # user content. Keeping it next to the compose file means relative path,
+      # cross-machine portability, and no cross-repo path coupling.
+      # Survives OrbStack/Docker resets because it's host-side.
+      - ./data/postgres:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d receipts"]
       interval: 3s
@@ -66,24 +63,27 @@ services:
       LANGFUSE_SECRET_KEY: sk-receipt-local
       # Tell the `claude` CLI explicitly where its config + credentials live.
       # Matches the Anthropic-official devcontainer convention and pairs with
-      # the `claude-code-config` named volume mounted below.
+      # the ./data/claude bind-mount below.
       CLAUDE_CONFIG_DIR: /home/node/.claude
       # Google Maps API key reachable by the in-container `claude -p` agent
       # via its Bash tool (for Phase 3 geocoding during extraction). Empty
       # is fine — the prompt instructs the agent to skip geocoding.
       GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY:-}
     volumes:
-      # Uploaded receipt images. Bind-mounted to host so they survive
-      # OrbStack / Docker resets (originals also kept in ~/Desktop/RECEIPT/
-      # but ingest pipeline writes its own copy here). Path lives outside
-      # this public git repo to keep PII receipt content out of the
-      # version-control blast radius.
-      - ${HOME}/Developer/2026_Dev_ReceiptAssistant/data/uploads:/data
-      # Claude Code OAuth credentials. Bind-mounted onto the host (NOT a
-      # bind of host's ~/.claude/ — that caused rotation collisions in
-      # Era 2). Container has its own OAuth session, seeded once via
-      # `docker exec -it receipt-assistant claude /login`. The CLI
-      # self-refreshes and writes back into the host bind path on disk.
-      # Survives compose down/up and OrbStack resets. See `setup` skill.
-      - ${HOME}/Developer/2026_Dev_ReceiptAssistant/data/claude:/home/node/.claude
+      # Uploaded receipt images = user content (PII). Lives in the outer
+      # project's iCloud-synced docs root, so the user's own receipt corpus
+      # syncs across their Macs naturally. NOT in any git repo — outer
+      # project's .gitignore covers /data/, and these are never in this repo
+      # anyway. If iCloud "Optimize Mac Storage" evicts files, the bind-mount
+      # will return errors at read time; pin the dir via Finder → "Keep
+      # Downloaded" to prevent that.
+      - ${HOME}/Documents/10_Projects/2026_Dev_ReceiptAssistant/data/uploads:/data
+      # Claude Code OAuth credentials + session state. Bind-mount inside
+      # this repo at ./data/claude (gitignored). NOT a bind of host's
+      # ~/.claude/ — that caused rotation collisions in Era 2. Container
+      # holds its own independent OAuth session, seeded once via
+      # `docker exec -it receipt-assistant claude /login`; the CLI
+      # self-refreshes and writes back here. Survives compose down/up and
+      # OrbStack resets. See `setup` skill.
+      - ./data/claude:/home/node/.claude
     restart: unless-stopped

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 set -e
 
-# Claude Code OAuth credentials live in the `claude-code-config` named Docker
-# volume mounted at /home/node/.claude (see docker-compose.yml). The container
-# holds its own OAuth session, bootstrapped once via
+# Claude Code OAuth credentials live in a host bind-mount at
+# ~/Developer/receipt-assistant-data/claude/, mounted into the container at
+# /home/node/.claude (see docker-compose.yml). The container holds its own
+# OAuth session, bootstrapped once via
 # `docker exec -it receipt-assistant claude /login`. The in-container CLI
-# self-refreshes on expiry and writes rotated tokens back into the volume.
+# self-refreshes on expiry and writes rotated tokens back into the bind path.
 # No env-var handoff or credentials synthesis — keep this entrypoint thin.
 
 exec "$@"


### PR DESCRIPTION
## Summary
- `data/uploads/` → `~/Documents/10_Projects/2026_Dev_ReceiptAssistant/data/uploads/` (iCloud, user-content PII images sync across Macs)
- `data/postgres/` + `data/claude/` → `~/Developer/receipt-assistant-data/` (sibling dir, off-repo + off-iCloud — runtime state: DB binary + OAuth credentials)
- `docker-compose.yml` updated to use the three new bind-mount paths; old `${HOME}/Developer/2026_Dev_ReceiptAssistant/data/...` Era-4 paths replaced.
- `docker/entrypoint.sh` comment caught a stale Era-3 named-volume reference (already 4 days behind reality before this PR); fixed.
- `README.md` quick-start credential-persistence wording updated from "claude-code-config named Docker volume" → bind-mount path.
- `CLAUDE.md` "Persistent data" section rewritten — 3-location table, "Why three locations" with 4 failure modes, "Five-era timeline" extended with Era 5, hard-rules list updated.
- `.gitignore`: add `.DS_Store`.

Closes #62

## Test plan
- [x] `docker compose up -d receipts-postgres receipt-assistant` → both healthy (`receipts-postgres Up (healthy)`, `receipt-assistant Up (healthy)`)
- [x] `docker inspect` shows three bind-mount sources resolving correctly:
  - `/Users/.../Documents/10_Projects/2026_Dev_ReceiptAssistant/data/uploads`
  - `/Users/.../Developer/receipt-assistant-data/postgres`
  - `/Users/.../Developer/receipt-assistant-data/claude`
- [x] `psql -c "SELECT COUNT(*) FROM transactions"` returns existing data (91 rows survived the move)
- [x] `/health` endpoint returns ok with current build sha
- [x] Container's `/home/node/.claude/.credentials.json` present after move (OAuth session preserved, no re-login needed)
- [x] Cross-repo stale-reference sweep across 4 markdown roots returns only intentional/historical hits

## Why three commits in this PR
- `e20146c` initial move (postgres + claude into this repo's `data/`) — caught violating `CLAUDE.md:207` ("data directory inside the repo would be one .gitignore mishap from publishing PII"). Preserved as audit-trail.
- `62d5c7b` correction: move to sibling dir `~/Developer/receipt-assistant-data/` instead. This is the actual Era-5 destination.
- `fed2a36` stale Era-3 comment in `entrypoint.sh` caught by sweep, fixed.

Squash-merge collapses these into a single commit — clean public history, audit trail preserved in this PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)