### PR TITLE
refactor(prompt): require canonical merchant.category in Phase 2.5

### DIFF
--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -306,16 +306,10 @@ seven canonical accounts:
   Food & Drinks · Transportation · Shopping · Travel ·
   Entertainment · Health · Services
 
-If for some reason you didn't fill \`merchant.category\` in Phase 2.5,
-derive it from \`category_hint\` using this mapping:
-
-  groceries / dining / cafe   → Food & Drinks
-  transport                   → Transportation
-  retail                      → Shopping
-  other / unsure              → Services   (catch-all — Services is the
-                                            new home for anything that
-                                            doesn't fit the other six;
-                                            never invent a new account)
+\`merchant.category\` is REQUIRED — Phase 2.5 is not optional and you
+must not skip it. If a merchant genuinely doesn't fit the other six
+buckets, use Services as the catch-all. Never invent a new account
+and never leave the category blank.
 
 Mirror side is Credit Card (default).
 


### PR DESCRIPTION
## Summary

Phase 2.5 introduced \`metadata.merchant.category\` as the canonical 7-class taxonomy (\`Food & Drinks\` / \`Shopping\` / \`Transportation\` / \`Travel\` / \`Entertainment\` / \`Health\` / \`Services\`), but the Phase 4 SQL template treated it as optional and shipped a "if you didn't fill it, derive from category_hint" fallback. The result is a 3-layer drift problem:

1. **DB**: of 121 transactions in the local workspace, only 13 (10.7%) have \`metadata.merchant.category\`. The remaining 108 rows fall back to \`category_hint\`. PR #64's "backfill populates this on every existing row" turned out to be aspirational.
2. **Frontend**: \`mapTransaction\` and \`classifyBackendCategory\` each carry their own legacy fallback path, and they have already drifted once (\`mapTransaction\` missed the canonical direct-match, rendering Food & Drinks rows as gray Uncategorized — fixed in receipt-assistant-frontend@68c3315).
3. **Prompt**: this file's "if you forgot…" clause keeps the fallback alive forever and makes future model-side regressions silent.

This PR removes the optional escape hatch. Phase 2.5 is now mandatory; Services is the documented catch-all.

## Scope

- \`src/ingest/prompt.ts\` Phase 4 only. The Phase 2.5 spec already lists all 7 canonical names with a mapping crib — no model behavior change other than removing the permission to skip it.
- \`category_hint\` continues to be emitted (it's a finer-grained signal; analytics may want \`cafe\` vs \`groceries\` later).

## Sequence (3-PR cleanup)

This is **PR 1 / 3**. After this merges:

- **PR 2** — Drizzle \`0008_backfill_canonical_merchant_category.sql\` backfills the 108 legacy rows from posting account names (104 rows recover cleanly from the canonical expense account; 4 VOID/refund edge cases derive from \`category_hint\`).
- **PR 3** — receipt-assistant-frontend removes \`CATEGORY_MAP\` / \`LEGACY_CATEGORY_MAP\` / \`normalizeCategoryKey\` / \`migrateLegacyCategory\` and the \`categoryFromTxn\` fallback chain.

Order matters: prompt → backfill → frontend cleanup. Reversing it would briefly render legacy rows gray.

## Acceptance criteria

- [ ] New ingestions in Langfuse traces show \`metadata.merchant.category\` populated on every \`receipt_image\` / \`receipt_email\` / \`receipt_pdf\` row.
- [ ] No new transaction lands with \`metadata.merchant.category IS NULL\`.
- [ ] Hard-set fixtures (Costco gas, handwritten tip, AYCE) re-extract without category regressions.

## Impact

Unblocks #64 backfill follow-up + the frontend legacy cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)