### PR TITLE
fix(places): accept Google place_id on GET /v1/places/{id}

### DIFF
--- a/src/routes/places.service.ts
+++ b/src/routes/places.service.ts
@@ -121,10 +121,24 @@ export async function loadPlacesByIds(
 
 /**
  * Single-place fetch including photo refs. Used by GET /v1/places/:id.
+ *
+ * Identifier accepts EITHER the row's UUID `id` OR Google's stable
+ * `google_place_id` (`ChIJ…`-shaped). The latter is what
+ * `merchants.place_id` stores (the field name is misleading — it
+ * holds Google's id, not our FK; schema comment in
+ * `src/schema/merchants.ts:52`). Recognizing both keeps callers from
+ * having to maintain a separate lookup path for that distinction.
  */
 export async function loadPlaceById(id: string): Promise<PlaceRow | null> {
-  const rows = await db.select().from(places).where(eq(places.id, id));
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+  const rows = await db
+    .select()
+    .from(places)
+    .where(isUuid ? eq(places.id, id) : eq(places.googlePlaceId, id));
   if (rows.length === 0) return null;
+  // Photos are keyed by the row's UUID — even if the caller passed a
+  // Google place_id we must resolve to UUID for the photos join.
+  const placeUuid = rows[0]!.id;
   const photoRows = await db
     .select({
       rank: placePhotos.rank,
@@ -134,7 +148,7 @@ export async function loadPlaceById(id: string): Promise<PlaceRow | null> {
       ocr_extracted: placePhotos.ocrExtracted,
     })
     .from(placePhotos)
-    .where(eq(placePhotos.placeId, id))
+    .where(eq(placePhotos.placeId, placeUuid))
     .orderBy(placePhotos.rank);
   return {
     ...rowToApi(rows[0]!),


### PR DESCRIPTION
Quick fix uncovered during E2E verification of #74.

`merchants.place_id` stores the Google place_id string (`ChIJ...`), not the `places.id` UUID — the schema comment in `src/schema/merchants.ts:52` says so explicitly. MerchantDetail in the frontend passes that value straight to `fetchPlace(id)`, which 404'd because the endpoint only matched on UUID. The Chinese subtitle on the merchant page silently never rendered.

Fix: `loadPlaceById` now recognizes UUID shape vs Google's `ChIJ…`-style id and dispatches to the right column. Photos sub-query also fixed (was using the input id verbatim, would have hit zero rows for Google-id calls).

Verified live post-deploy:

```
GET /v1/places/ChIJq8Fw98XbwoARxc-NHNTjt4Q → 200
  display_name_en = "Jiu Ji Dessert (九记八方甜品）"
  display_name_zh = "九记八方"
  display_name_zh_source = "photo_ocr"
GET /v1/places/ChIJRSYPHl3FwoAR3v32Kbp6y5w → 200 (Wing Hop Fung) ✓
```

MerchantDetail now correctly shows:

  Jiu Ji Dessert
    九记八方   ✎ STOREFRONT

  Wing Hop Fung
    Wing Hop Fung(永合豐)Monterey Park Store   ✎ GOOGLE

🤖 Generated with [Claude Code](https://claude.com/claude-code)