### PR TITLE
feat(eval): date-OCR evaluation harness (#27 AC#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/
 .env.*
 !.env.example
 /scripts/smoke-v1-ingest.report.json
+/scripts/eval-dates.report.json
+/scripts/eval-dates.report.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,12 @@ services:
       # via its Bash tool (for Phase 3 geocoding during extraction). Empty
       # is fine — the prompt instructs the agent to skip geocoding.
       GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY:-}
+      # Worker concurrency for `claude -p` extraction. Default 3 is fine
+      # for steady-state single-receipt uploads but starves batch evals
+      # (e.g. scripts/eval-dates.ts on a 23-fixture manifest). CPU floor is
+      # ~10% even at concurrency 3 — host has headroom. Bumped to 6 to
+      # halve eval wall-clock without straining Anthropic API rate limits.
+      MAX_CLAUDE_CONCURRENCY: ${MAX_CLAUDE_CONCURRENCY:-6}
     volumes:
       # Uploaded receipt images = user content (PII). Lives in the outer
       # project's iCloud-synced docs root, so the user's own receipt corpus

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx scripts/migrate.ts",
     "db:seed": "tsx scripts/seed.ts",
-    "openapi:generate": "tsx scripts/generate-openapi.ts"
+    "openapi:generate": "tsx scripts/generate-openapi.ts",
+    "eval:dates": "tsx scripts/eval-dates.ts"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.3.4",

--- a/scripts/eval-dates.fixtures.json
+++ b/scripts/eval-dates.fixtures.json
@@ -1,0 +1,186 @@
+[
+  {
+    "sha256": "8e4239477e236ffa798d742f51c45b7c3e46fc590810de647f735d4e0c288a04",
+    "original_filename": "2025-09-30_Receipt_Wilson_wristband_classic_navy_x2_26.28.jpeg",
+    "bucket": "hard_date",
+    "ground_truth": { "date": "2025-09-30", "merchant_tokens": ["wilson"], "total_minor": 2628 },
+    "expected_status": "done",
+    "notes": "The original #27 case. 09/30 read as 09/03. Deterministic across 3 Phase 2.5 rounds (2026-04-21 comment) — digit-order read error, prompt layer cannot reach."
+  },
+  {
+    "sha256": "e4756c65fb691e32c4b3235ed46b6b5571bffcf719eafd8adf4811cf89dfe475",
+    "original_filename": "2025-09-20_Receipt_WingHopFung_black_pearl_wine_40.99.jpeg",
+    "bucket": "hard_all",
+    "ground_truth": { "date": "2025-09-20", "merchant_tokens": ["wing", "hop", "fung"], "total_minor": 4099 },
+    "expected_status": "done",
+    "notes": "Pathological fixture — faded thermal paper. Across 3 rounds (2026-04-21) stressed date, total, AND merchant simultaneously. Non-deterministic. Gold-standard regression marker."
+  },
+  {
+    "sha256": "56267be6676c0af681b958b29346d8302f312170819ddd6da964e9427befe2b1",
+    "original_filename": "2025-12-01_Receipt_Marukai_groceries_97.72.jpeg",
+    "bucket": "hard_date",
+    "ground_truth": { "date": "2025-12-01", "merchant_tokens": ["marukai"], "total_minor": 9772 },
+    "expected_status": "done",
+    "notes": "Day digit misread (01 → 11)."
+  },
+  {
+    "sha256": "2bf4026fa87080003a5d212a1e2bf096cb2fb3acc1e8a87d91a01ededec71469",
+    "original_filename": "2025-12-07_Receipt_CircleK_fuel_unleaded_70.79.jpeg",
+    "bucket": "hard_date",
+    "ground_truth": { "date": "2025-12-07", "merchant_tokens": ["circle", "k"], "total_minor": 7079 },
+    "expected_status": "done",
+    "notes": "Day digit misread (07 → 27). Common pump-receipt thermal-print artifact."
+  },
+  {
+    "sha256": "9e02b5d0b97606a1b344d3b65f75bfd5ba05bf531001c7ff4dc146cd2925e9ae",
+    "original_filename": "2025-11-29_Receipt_Haidilao_hotpot_dinner_306.49.jpeg",
+    "bucket": "hard_date",
+    "ground_truth": { "date": "2025-11-29", "merchant_tokens": ["haidilao"], "total_minor": 30649 },
+    "expected_status": "done",
+    "notes": "Month digit misread (11 → 10). Rare — month misreads are usually a sign of bad print or printer drift."
+  },
+  {
+    "sha256": "6f152d024a9be528796f5cec8b0a890d7cc711e31fa202f7fd7fd0eba87a8dab",
+    "original_filename": "2025-09-29_Receipt_UrthCaffe_brunch_93.03.jpeg",
+    "bucket": "hard_total",
+    "ground_truth": { "date": "2025-09-29", "merchant_tokens": ["urth", "caffe"], "total_minor": 9303 },
+    "expected_status": "done",
+    "notes": "Subtotal-vs-final confusion. Reads $98.03 (pre-tip + suggested-tip column) instead of final $93.03."
+  },
+  {
+    "sha256": "43cd36eb799a7a969b11ffd8593e4d4f549ed6533038ac985cbeda0b205b3731",
+    "original_filename": "2026-02-22_Receipt_TraderJoes_groceries_29.36.jpeg",
+    "bucket": "hard_total",
+    "ground_truth": { "date": "2026-02-22", "merchant_tokens": ["trader", "joe"], "total_minor": 2936 },
+    "expected_status": "done",
+    "notes": "Single-digit total misread (29.36 → 39.36)."
+  },
+  {
+    "sha256": "23494391be93197175867bd7d35e6e2578cac42f0d32729978b208612c0194f8",
+    "original_filename": "2026-02-27_Receipt_Eataly_black_label_ham_13.00.jpeg",
+    "bucket": "hard_total",
+    "ground_truth": { "date": "2026-02-27", "merchant_tokens": ["eataly"], "total_minor": 1300 },
+    "expected_status": "done",
+    "notes": "Total read as half of correct value (13.00 → 6.50). Likely a unit-price vs line-total confusion."
+  },
+  {
+    "sha256": "8975c08945295d059a74e37ecea21c32b6641e208a62b9d28c7b16b6302588fb",
+    "original_filename": "2025-09-10_Receipt_WingOnMarket_charge_slip_64.85.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-09-10", "merchant_tokens": ["wing", "on", "market"], "total_minor": 6485 },
+    "expected_status": "done",
+    "notes": "Asian-grocery thermal, lots of Chinese characters — historically extracts cleanly."
+  },
+  {
+    "sha256": "127a4e07980756252e7a4ee64abf80c9ed1ec926bb54c2fe56b09b2a53c18ff3",
+    "original_filename": "2025-09-28_Receipt_DongTingXian_dine_in_135.22.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-09-28", "merchant_tokens": ["dong", "ting", "xian"], "total_minor": 13522 },
+    "expected_status": "done",
+    "notes": "Dine-in receipt with tip line — historically clean."
+  },
+  {
+    "sha256": "db9ed4575a388b2c1928d97d69f091ebb262f3611129bd243fbc57ac616262a8",
+    "original_filename": "2025-10-18_Receipt_99Ranch_san_gabriel_groceries_131.12.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-10-18", "merchant_tokens": ["99", "ranch"], "total_minor": 13112 },
+    "expected_status": "done",
+    "notes": "99 Ranch — payee extraction historically resolves to store number; substring match is enough."
+  },
+  {
+    "sha256": "1c017723268d25781cc4775db86ff66cbb452929f656cbe14a90590a9698bc9a",
+    "original_filename": "2025-10-18_Receipt_LeYuenBBQ_bbq_63.91.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-10-18", "merchant_tokens": ["le", "yuen", "bbq"], "total_minor": 6391 },
+    "expected_status": "done",
+    "notes": ""
+  },
+  {
+    "sha256": "b6a5fdd1615f0427f4577ad2f495a51df0dd23a2bec711f52cd9777df8919df2",
+    "original_filename": "2025-10-22_Receipt_Yoshinoya_beef_combo_bowls_21.03.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-10-22", "merchant_tokens": ["yoshinoya"], "total_minor": 2103 },
+    "expected_status": "done",
+    "notes": ""
+  },
+  {
+    "sha256": "2879a616fd25054e87e7e779d4efe2d6a158e55cb309399cb518f5dd5dbfdc82",
+    "original_filename": "2025-10-27_Receipt_TraderJoes_milk_cinnamon_pumpkin_10.58.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-10-27", "merchant_tokens": ["trader", "joe"], "total_minor": 1058 },
+    "expected_status": "done",
+    "notes": ""
+  },
+  {
+    "sha256": "38278bbaf8f85d97cc9d7b74824ebaab869aae73ce1041b1a54782d69cb96514",
+    "original_filename": "2025-11-02_Receipt_KellysCoffeeAndFudge_cafe_latte_5.75.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-11-02", "merchant_tokens": ["kelly", "coffee"], "total_minor": 575 },
+    "expected_status": "done",
+    "notes": "Small total — guards against truncation/zero-pad errors."
+  },
+  {
+    "sha256": "725c65febd2c3d1ccdcb6dff2f74917252dc5b81c4b2d4e125dc67ebbc059d51",
+    "original_filename": "2025-11-04_Receipt_Costco_groceries_47.17.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-11-04", "merchant_tokens": ["costco"], "total_minor": 4717 },
+    "expected_status": "done",
+    "notes": ""
+  },
+  {
+    "sha256": "1eb3e55795d0dd606fe61ff8131b1a75789e3c2aeb93c00513aacd830c157a67",
+    "original_filename": "2025-11-14_Receipt_SunriseNoodleHouse_cantonese_clay_pot_69.94.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-11-14", "merchant_tokens": ["sunrise", "noodle"], "total_minor": 6994 },
+    "expected_status": "done",
+    "notes": ""
+  },
+  {
+    "sha256": "361014b68e7b42d0a4bbebc9d939b0d3dd26299743545794d7937b8defc375a9",
+    "original_filename": "2025-11-22_Receipt_WingHopFung_groceries_15.39.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-11-22", "merchant_tokens": ["wing", "hop", "fung"], "total_minor": 1539 },
+    "expected_status": "done",
+    "notes": "Same merchant as the hard_all WingHopFung wine fixture, but a clean print — guards against false-positive prompt fixes that throw the baby out with the bathwater."
+  },
+  {
+    "sha256": "041098f3b03c9bb19ea4e1de5342e1922cc9f0bfc4a439e99b28e2500e71ba8c",
+    "original_filename": "2025-12-01_Receipt_Petco_grooming_bath_97.57.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-12-01", "merchant_tokens": ["petco"], "total_minor": 9757 },
+    "expected_status": "done",
+    "notes": "Same date as the hard_date Marukai 97.72 fixture — guards against date-fix regressions on receipts with similar timestamps."
+  },
+  {
+    "sha256": "e5f75d412c4cc3b4b669e5b29c3363395163838d45abaea571703890d4f9a14b",
+    "original_filename": "2025-12-08_Receipt_HMart_groceries_107.45.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2025-12-08", "merchant_tokens": ["h", "mart"], "total_minor": 10745 },
+    "expected_status": "done",
+    "notes": ""
+  },
+  {
+    "sha256": "6a0f8737fc3c97746600e56baa078d18b1a386d740591a16f493e6aa12abbe86",
+    "original_filename": "2026-02-12_Receipt_KFC_zinger_sandwich_15.34.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2026-02-12", "merchant_tokens": ["kfc"], "total_minor": 1534 },
+    "expected_status": "done",
+    "notes": ""
+  },
+  {
+    "sha256": "86c4005c35cbe4a1b779eddc2753aa12be4853091831cc0263d61ca9ff472061",
+    "original_filename": "2026-03-06_Receipt_Costco_gas_marina_del_rey_73.78.jpeg",
+    "bucket": "good",
+    "ground_truth": { "date": "2026-03-06", "merchant_tokens": ["costco", "gas"], "total_minor": 7378 },
+    "expected_status": "done",
+    "notes": "CLAUDE.md-flagged historically-hard fixture (gas pump receipts), but extracts cleanly under current pipeline — guards against regressions if prompt evolves."
+  },
+  {
+    "sha256": "3a81863b580828192134c22afed6989bac5b9bec0ae010fb6e892ac446a94450",
+    "original_filename": "2026-03-25_Receipt_EuclidCoffee_iced_latte_8.00.jpeg",
+    "bucket": "hard_total",
+    "ground_truth": { "date": "2026-03-25", "merchant_tokens": ["euclid", "coffee"], "total_minor": 800 },
+    "expected_status": "done",
+    "notes": "Handwritten tip on small cafe receipt; pipeline reads pre-tip $5.59 / $6.59 lines as total instead of the final $8.00. Non-deterministic across runs (2026-04-19 issue comment)."
+  }
+]

--- a/scripts/eval-dates.md
+++ b/scripts/eval-dates.md
@@ -1,0 +1,190 @@
+# `eval-dates` — Date-OCR evaluation harness
+
+`scripts/eval-dates.ts` round-trips a manifest of receipt fixtures through
+the live `/v1/ingest/batch` worker pipeline and scores the extracted
+`(date, total, payee)` per fixture against committed ground truth. It's
+the durable AC#3 deliverable for [receipt-assistant#27].
+
+[receipt-assistant#27]: https://github.com/TINKPA/receipt-assistant/issues/27
+
+## TL;DR
+
+```bash
+# from inside ~/Developer/receipt-assistant/
+docker compose up -d                # backend + postgres + claude container
+npm run eval:dates                  # ~5-10 min for the default 23 fixtures
+cat scripts/eval-dates.report.md    # human-readable table
+```
+
+Reports land at `scripts/eval-dates.report.{json,md}` (gitignored — the
+manifest is committed, the per-run report is not).
+
+## How it works
+
+1. Reads `scripts/eval-dates.fixtures.json`.
+2. For each fixture, locates the source JPG at
+   `${UPLOADS_DIR}/<sha256>.jpg` (default
+   `~/Documents/10_Projects/2026_Dev_ReceiptAssistant/data/uploads/uploads/`).
+3. Re-encodes via `sips -s formatOptions 75` into a tmpdir. The
+   re-encode is **load-bearing**: it bumps each file's SHA past
+   `documents.sha256` dedupe so the worker actually re-runs `claude -p`
+   on every fixture every run. Without this you'd score against cached
+   extractions from weeks ago and miss any current-pipeline regressions.
+4. POSTs all fixtures in a single multipart batch to `/v1/ingest/batch`.
+5. Polls `/v1/batches/<id>` every 3 s until every ingest reaches a
+   terminal state (`done` / `unsupported` / `error`). 10 min timeout.
+6. For each `done` ingest, `GET /v1/transactions/<tx_id>` to pull
+   `occurred_on`, `payee`, and `max(|postings.amount_minor|)` (the
+   expense-leg total).
+7. Scores per bucket (table below), emits JSON + Markdown reports.
+
+The harness uses no auth headers — every request hits the seed
+workspace via `contextMiddleware` (`src/http/context.ts`). No
+`--json-schema` is involved anywhere; the worker owns the
+`claude -p` invocation. **No direct DB access**: the harness only
+talks to the HTTP API.
+
+## CLI flags
+
+| Flag                | Default                                                                                  | What it does                          |
+|---------------------|------------------------------------------------------------------------------------------|---------------------------------------|
+| `--base=<url>`      | `http://localhost:3000`                                                                  | API base                              |
+| `--manifest=<path>` | `scripts/eval-dates.fixtures.json`                                                       | Alternate manifest (for prompt A/Bs)  |
+| `--uploads-dir=<p>` | `~/Documents/10_Projects/2026_Dev_ReceiptAssistant/data/uploads/uploads`                 | Where the SHA-named JPGs live         |
+| `--limit=<n>`       | all                                                                                      | Run a subset (debug)                  |
+| `--gate`            | off                                                                                      | Exit 1 if date_accuracy < 90% (AC#1)  |
+
+`UPLOADS_DIR=...` env var is also honored.
+
+## Buckets and pass criteria
+
+The manifest assigns each fixture to one of five buckets. The harness
+scores each fixture by the bucket-specific rule below; the aggregate
+`date_accuracy` reported at the top of the report is a uniform metric
+across every extracted fixture and is what AC#1 (≥ 90%) measures
+against.
+
+| Bucket          | Pass means                                                                       | Why this exists                                                                                                   |
+|-----------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `hard_date`     | `transactions.occurred_on == ground_truth.date`                                  | Known-failing date OCR (Wilson 30↔03, etc.). A prompt fix that unsticks any of these moves the needle.            |
+| `hard_total`    | `max(\|postings.amount_minor\|) == ground_truth.total_minor`                     | Subtotal-vs-final / handwritten-tip confusion fixtures.                                                            |
+| `hard_all`      | All three of date, total, payee match                                            | Pathological fixture (WingHopFung). Single image stress-tests three independent dimensions.                       |
+| `good_rejects`  | `ingest_status == "unsupported"`                                                 | Blurry photos where the worker correctly refuses to guess. Currently empty — add fixtures as they surface.        |
+| `good`          | Date + total + payee all match                                                   | Regression guard. A prompt that improves `hard_date` but breaks any of these is net-bad.                          |
+
+Within each bucket:
+- `date_match` — `occurred_on === ground_truth.date` (string compare,
+  YYYY-MM-DD).
+- `total_match` — `max(|amount_minor|) === ground_truth.total_minor`.
+  Null if the manifest entry has no total or the ingest didn't produce
+  a transaction.
+- `payee_match` — case-insensitive substring of **any** of the
+  manifest's `merchant_tokens` in the extracted payee. Tokens are
+  lowercase CamelCase splits of the filename merchant slug (e.g.
+  `WingHopFung` → `["wing", "hop", "fung"]`). The match passes if the
+  worker resolves the payee to *anything* recognizable — store
+  numbers, district names, and the canonical brand name all match.
+
+## Adding a fixture to the manifest
+
+1. Identify the receipt in the live DB:
+   ```bash
+   docker exec receipts-postgres psql -U postgres -d receipts -c "
+     SELECT i.filename, d.sha256, t.occurred_on, t.payee
+     FROM ingests i
+     JOIN documents d ON d.source_ingest_id = i.id
+     LEFT JOIN transactions t ON t.source_ingest_id = i.id
+     WHERE i.filename ILIKE '%PARTIAL%' AND i.status = 'done';
+   "
+   ```
+2. Confirm `${UPLOADS_DIR}/<sha>.jpg` exists on disk.
+3. Decide the bucket. Rules of thumb:
+   - DB `occurred_on` ≠ filename date → `hard_date`
+   - DB total ≠ filename total → `hard_total`
+   - Both wrong + payee also drifts → `hard_all`
+   - Status returns `unsupported` → `good_rejects` (rare — add when
+     a deliberately-blurry photo is part of the corpus)
+   - Otherwise → `good`
+4. Add an entry to `scripts/eval-dates.fixtures.json`:
+   ```jsonc
+   {
+     "sha256": "<from query>",
+     "original_filename": "<from query>",
+     "bucket": "<bucket>",
+     "ground_truth": {
+       "date": "YYYY-MM-DD",                       // from filename
+       "merchant_tokens": ["lower", "case", "tokens"],
+       "total_minor": 1234                          // null if filename has no total
+     },
+     "expected_status": "done",                     // or "unsupported"
+     "notes": "Why this fixture is in the manifest — one short sentence."
+   }
+   ```
+5. Re-run `npm run eval:dates` and verify the new entry shows in
+   the report.
+
+The manifest is the durable artifact. The JPGs themselves stay in
+`data/uploads/uploads/` (iCloud, gitignored per the
+three-data-locations invariant — these are real PII receipts).
+Anyone with access to that uploads dir can run the eval; the manifest
+defines what "correct" means.
+
+## Interpreting the report
+
+The Markdown report has three sections:
+
+- **Aggregate**: top-line `date_accuracy`. Compare against the 90% AC#1
+  threshold. Numerator = fixtures whose extracted date matches ground
+  truth. Denominator = fixtures with *any* extraction (so
+  `good_rejects` don't dilute the metric).
+- **By bucket**: pass counts per bucket. Use this to localize a
+  regression — e.g. if `hard_date` passes drop from 2/5 to 0/5 but
+  `good` passes drop from 14/14 to 12/14, the prompt change has a
+  *different* failure mode than just "couldn't fix the hard ones".
+- **Per-fixture**: every row shows extracted vs ground-truth date and
+  total side-by-side. `✅`/`❌` mark match/mismatch; `—` means
+  the dimension wasn't applicable (e.g. no total in filename, or no
+  extraction at all).
+
+### Known stragglers (do not panic)
+
+- **WingHopFung wine** (`hard_all`) — non-deterministic across runs
+  per the [2026-04-21 issue comment][nd-comment]. Faded thermal
+  paper; pixel-level OCR is beyond what prompt iteration can fix.
+  Expect this to fail on most runs.
+- **Wilson wristband** (`hard_date`) — 09/30 → 09/03 deterministic
+  across 3 rounds of Phase 2.5 self-check iteration. A digit-order
+  read error. Expect this to fail until a model upgrade or image
+  preprocessing lands.
+
+[nd-comment]: https://github.com/TINKPA/receipt-assistant/issues/27#issuecomment-4285867967
+
+### When `date_accuracy < 90%`
+
+That's the issue #27 starting condition. The harness gives you a
+deterministic, repeatable measurement; the next move depends on
+what's failing:
+
+- **All `hard_*` failing, `good` clean** → the prompt is at its
+  current ceiling; pivot to A/B trials with prompt variants (see
+  the original issue body) or to a model bump.
+- **`good` regressed** → a recent prompt or model change has
+  broader cost than the win it was after; revert and investigate.
+- **A new failure mode in a previously-`good` fixture** → promote
+  that fixture to a `hard_*` bucket and continue iterating.
+
+## Bash AC#1 wrapper (per the issue body)
+
+The issue body asks for `scripts/eval-dates.sh`. Since every existing
+script in this repo runs through `tsx`, the package.json `eval:dates`
+script is the canonical entry point and what gets used in practice.
+If a CI runner needs an exact `.sh` filename to invoke, this
+single-line wrapper is the bridge:
+
+```bash
+#!/usr/bin/env bash
+exec npm run eval:dates -- --gate "$@"
+```
+
+(Not committed by default — add `scripts/eval-dates.sh` only if a
+specific CI integration demands it.)

--- a/scripts/eval-dates.ts
+++ b/scripts/eval-dates.ts
@@ -1,0 +1,530 @@
+/**
+ * eval-dates.ts — Date-OCR evaluation harness for issue #27 AC#3.
+ *
+ * Round-trips a manifest of fixtures through the live `/v1/ingest/batch`
+ * worker pipeline (single-call agent flow, post-#32 ledger API) and
+ * scores extracted (date, total, payee) per fixture against committed
+ * ground truth in `scripts/eval-dates.fixtures.json`.
+ *
+ * Per fixture, the harness:
+ *   1. Re-encodes the source JPG (sips) so a fresh SHA bumps past
+ *      dedupe and forces the worker to actually run claude on it.
+ *   2. Uploads via multipart POST /v1/ingest/batch (all fixtures in
+ *      one batch).
+ *   3. Polls GET /v1/batches/<id> until every item reaches a terminal
+ *      status (done / unsupported / error). Aborts on 5-min timeout.
+ *   4. For each `done` item, GET /v1/transactions/<id> to pull
+ *      occurred_on / payee / postings[].amount_minor.
+ *   5. Scores per bucket (see eval-dates.md for pass criteria).
+ *   6. Emits scripts/eval-dates.report.{json,md}.
+ *
+ * No `--json-schema`, no DB writes, no auth headers (seed-workspace
+ * middleware). Single-file; only deps are tsx + Node built-ins.
+ *
+ * CLI:
+ *   --base <url>           API base, default http://localhost:3000
+ *   --manifest <path>      Fixture manifest, default scripts/eval-dates.fixtures.json
+ *   --uploads-dir <path>   SHA-named JPG root, default the iCloud project's data/uploads/uploads
+ *   --limit <n>            Cap fixture count, default all
+ *   --gate                 Exit 1 if aggregate date_accuracy < 0.9 (AC#1)
+ *
+ * Run: `npm run eval:dates` (or `npx tsx scripts/eval-dates.ts`).
+ */
+import { spawn } from "child_process";
+import { readFile, writeFile, mkdtemp, rm, stat } from "fs/promises";
+import { tmpdir } from "os";
+import * as path from "path";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+type Bucket = "hard_date" | "hard_total" | "hard_all" | "good_rejects" | "good";
+
+interface Fixture {
+  sha256: string;
+  original_filename: string;
+  bucket: Bucket;
+  ground_truth: {
+    date: string;
+    merchant_tokens: string[];
+    total_minor: number | null;
+  };
+  expected_status: "done" | "unsupported" | "error";
+  notes: string;
+}
+
+interface BatchItem {
+  ingest_id: string;
+  filename: string;
+  status: "queued" | "processing" | "done" | "unsupported" | "error";
+  produced: {
+    transaction_ids: string[];
+    document_ids: string[];
+    receipt_ids: string[];
+  } | null;
+  error: string | null;
+}
+
+interface Transaction {
+  id: string;
+  occurred_on: string;
+  payee: string | null;
+  postings: { amount_minor: number; currency: string }[];
+}
+
+interface FixtureResult {
+  fixture: Fixture;
+  ingest_id: string | null;
+  ingest_status: string;
+  ingest_error: string | null;
+  transaction_id: string | null;
+  extracted: {
+    occurred_on: string | null;
+    payee: string | null;
+    total_minor: number | null;
+  };
+  scoring: {
+    date_match: boolean | null;
+    total_match: boolean | null;
+    payee_match: boolean | null;
+    status_match: boolean;
+    bucket_pass: boolean;
+  };
+  duration_ms: number;
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────
+
+function parseArgs(argv: string[]) {
+  const args: Record<string, string | boolean> = {};
+  for (const a of argv) {
+    const m = /^--([^=]+)(?:=(.*))?$/.exec(a);
+    if (m) args[m[1]!] = m[2] ?? true;
+  }
+  const HOME = process.env.HOME!;
+  return {
+    base: (args.base as string) ?? "http://localhost:3000",
+    manifest: (args.manifest as string) ?? path.resolve(
+      path.dirname(new URL(import.meta.url).pathname),
+      "eval-dates.fixtures.json",
+    ),
+    uploadsDir: (args["uploads-dir"] as string)
+      ?? process.env.UPLOADS_DIR
+      ?? path.join(
+        HOME,
+        "Documents/10_Projects/2026_Dev_ReceiptAssistant/data/uploads/uploads",
+      ),
+    limit: args.limit ? Number(args.limit) : undefined,
+    gate: args.gate === true || args.gate === "true",
+  };
+}
+
+// ── Re-encode via sips (bumps SHA past dedupe) ─────────────────────────
+
+async function sipsReencode(srcPath: string, outPath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(
+      "sips",
+      ["-s", "format", "jpeg", "-s", "formatOptions", "75",
+       srcPath, "--out", outPath],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+    let stderr = "";
+    proc.stderr.on("data", (b) => { stderr += b.toString(); });
+    proc.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`sips exit ${code}: ${stderr}`));
+    });
+    proc.on("error", reject);
+  });
+}
+
+// ── HTTP helpers ───────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const r = await fetch(url, init);
+  if (!r.ok) {
+    const body = await r.text().catch(() => "");
+    throw new Error(`${init?.method ?? "GET"} ${url} → ${r.status}: ${body.slice(0, 500)}`);
+  }
+  return r.json() as Promise<T>;
+}
+
+interface CreateBatchResponse {
+  batchId: string;
+  status: string;
+  items: { ingestId: string; filename: string; mime_type: string | null }[];
+  poll: string;
+}
+
+async function postBatch(
+  base: string,
+  files: { filename: string; bytes: Uint8Array }[],
+): Promise<CreateBatchResponse> {
+  const form = new FormData();
+  for (const f of files) {
+    form.append("files", new Blob([f.bytes as BlobPart], { type: "image/jpeg" }), f.filename);
+  }
+  return fetchJson<CreateBatchResponse>(`${base}/v1/ingest/batch`, {
+    method: "POST",
+    body: form,
+  });
+}
+
+interface BatchRow {
+  id: string;
+  status: string;
+  items: BatchItem[];
+}
+
+async function getBatch(base: string, id: string): Promise<BatchRow> {
+  type ApiBatchItem = {
+    id: string;
+    filename: string;
+    status: BatchItem["status"];
+    produced: BatchItem["produced"];
+    error: string | null;
+  };
+  const raw = await fetchJson<{ id: string; status: string; items: ApiBatchItem[] }>(
+    `${base}/v1/batches/${id}`,
+  );
+  return {
+    id: raw.id,
+    status: raw.status,
+    items: raw.items.map((r) => ({
+      ingest_id: r.id,
+      filename: r.filename,
+      status: r.status,
+      produced: r.produced,
+      error: r.error,
+    })),
+  };
+}
+
+async function getTransaction(base: string, id: string): Promise<Transaction> {
+  const t = await fetchJson<{
+    id: string;
+    occurred_on: string;
+    payee: string | null;
+    postings: { amount_minor: number; currency: string }[];
+  }>(`${base}/v1/transactions/${id}`);
+  return t;
+}
+
+// ── Poll until terminal ────────────────────────────────────────────────
+
+const TERMINAL = new Set<BatchItem["status"]>(["done", "unsupported", "error"]);
+
+async function pollBatch(
+  base: string,
+  batchId: string,
+  fixtureCount: number,
+  timeoutMs: number,
+): Promise<BatchRow> {
+  const start = Date.now();
+  let last: BatchRow | null = null;
+  let lastDoneCount = -1;
+  while (Date.now() - start < timeoutMs) {
+    const row = await getBatch(base, batchId);
+    const done = row.items.filter((i) => TERMINAL.has(i.status)).length;
+    if (done !== lastDoneCount) {
+      const elapsed = Math.floor((Date.now() - start) / 1000);
+      console.error(`  [${elapsed}s] ${done}/${fixtureCount} terminal`);
+      lastDoneCount = done;
+    }
+    if (done === fixtureCount) return row;
+    last = row;
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+  throw new Error(
+    `Batch ${batchId} did not finish in ${timeoutMs}ms; last state: ${JSON.stringify(
+      last?.items.map((i) => ({ filename: i.filename, status: i.status })),
+    )}`,
+  );
+}
+
+// ── Scoring ────────────────────────────────────────────────────────────
+
+function score(
+  fx: Fixture,
+  ingest_status: string,
+  ext: { occurred_on: string | null; payee: string | null; total_minor: number | null },
+): FixtureResult["scoring"] {
+  const status_match = ingest_status === fx.expected_status;
+
+  const dateMatch =
+    ext.occurred_on == null ? null : ext.occurred_on === fx.ground_truth.date;
+
+  const totalMatch =
+    fx.ground_truth.total_minor == null || ext.total_minor == null
+      ? null
+      : ext.total_minor === fx.ground_truth.total_minor;
+
+  const payeeLower = (ext.payee ?? "").toLowerCase();
+  const payeeMatch =
+    ext.payee == null
+      ? null
+      : fx.ground_truth.merchant_tokens.some((t) => payeeLower.includes(t));
+
+  // Bucket-specific pass:
+  // - good_rejects: status must be `unsupported` (no extraction needed)
+  // - good: date+total+payee all match (or null total ⇒ skipped)
+  // - hard_date: date_match focal; total/payee informational
+  // - hard_total: total_match focal
+  // - hard_all: all three must match (the WingHopFung-style fixture
+  //            is the hardest gate, the one a prompt fix needs to clear).
+  let bucket_pass = false;
+  if (fx.bucket === "good_rejects") {
+    bucket_pass = ingest_status === "unsupported";
+  } else if (ingest_status !== "done") {
+    bucket_pass = false; // expected `done` but got error/unsupported
+  } else if (fx.bucket === "good") {
+    bucket_pass = !!(dateMatch && (totalMatch ?? true) && payeeMatch);
+  } else if (fx.bucket === "hard_date") {
+    bucket_pass = !!dateMatch;
+  } else if (fx.bucket === "hard_total") {
+    bucket_pass = !!totalMatch;
+  } else if (fx.bucket === "hard_all") {
+    bucket_pass = !!(dateMatch && totalMatch && payeeMatch);
+  }
+
+  return {
+    date_match: dateMatch,
+    total_match: totalMatch,
+    payee_match: payeeMatch,
+    status_match,
+    bucket_pass,
+  };
+}
+
+// ── Reporting ──────────────────────────────────────────────────────────
+
+interface Aggregate {
+  total_fixtures: number;
+  extracted_count: number;
+  date_match_count: number;
+  date_accuracy: number;
+  total_match_count: number;
+  total_accuracy: number;
+  payee_match_count: number;
+  payee_accuracy: number;
+  bucket_summary: Record<string, { pass: number; total: number }>;
+}
+
+function aggregate(results: FixtureResult[]): Aggregate {
+  const extracted = results.filter((r) => r.scoring.date_match !== null);
+  const dateOk = extracted.filter((r) => r.scoring.date_match === true).length;
+  const totalCandidates = extracted.filter((r) => r.scoring.total_match !== null);
+  const totalOk = totalCandidates.filter((r) => r.scoring.total_match === true).length;
+  const payeeCandidates = extracted.filter((r) => r.scoring.payee_match !== null);
+  const payeeOk = payeeCandidates.filter((r) => r.scoring.payee_match === true).length;
+
+  const bucketSummary: Record<string, { pass: number; total: number }> = {};
+  for (const r of results) {
+    const b = r.fixture.bucket;
+    bucketSummary[b] ??= { pass: 0, total: 0 };
+    bucketSummary[b].total += 1;
+    if (r.scoring.bucket_pass) bucketSummary[b].pass += 1;
+  }
+
+  return {
+    total_fixtures: results.length,
+    extracted_count: extracted.length,
+    date_match_count: dateOk,
+    date_accuracy: extracted.length === 0 ? 0 : dateOk / extracted.length,
+    total_match_count: totalOk,
+    total_accuracy: totalCandidates.length === 0 ? 0 : totalOk / totalCandidates.length,
+    payee_match_count: payeeOk,
+    payee_accuracy: payeeCandidates.length === 0 ? 0 : payeeOk / payeeCandidates.length,
+    bucket_summary: bucketSummary,
+  };
+}
+
+function renderMarkdown(
+  agg: Aggregate,
+  results: FixtureResult[],
+  meta: { batchId: string; durationMs: number; base: string },
+): string {
+  const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
+  const lines: string[] = [];
+
+  lines.push(`# Date-OCR eval baseline — ${new Date().toISOString().slice(0, 19)}Z`);
+  lines.push("");
+  lines.push(`Batch \`${meta.batchId}\` · ${(meta.durationMs / 1000).toFixed(1)}s · ${meta.base}`);
+  lines.push("");
+  lines.push("## Aggregate");
+  lines.push("");
+  lines.push("| Metric | Value | n |");
+  lines.push("|---|---|---|");
+  lines.push(`| **Date accuracy** | **${pct(agg.date_accuracy)}** | ${agg.date_match_count} / ${agg.extracted_count} |`);
+  lines.push(`| Total accuracy | ${pct(agg.total_accuracy)} | ${agg.total_match_count} / ${agg.extracted_count} |`);
+  lines.push(`| Payee accuracy | ${pct(agg.payee_accuracy)} | ${agg.payee_match_count} / ${agg.extracted_count} |`);
+  lines.push("");
+
+  lines.push("## By bucket");
+  lines.push("");
+  lines.push("| Bucket | Pass | Total |");
+  lines.push("|---|---|---|");
+  for (const [b, s] of Object.entries(agg.bucket_summary)) {
+    lines.push(`| \`${b}\` | ${s.pass} | ${s.total} |`);
+  }
+  lines.push("");
+
+  lines.push("## Per-fixture");
+  lines.push("");
+  lines.push("| Bucket | Filename | Status | Date (got → want) | Total (got → want) | Payee | Pass |");
+  lines.push("|---|---|---|---|---|---|---|");
+  for (const r of results) {
+    const gtDate = r.fixture.ground_truth.date;
+    const gtTotal = r.fixture.ground_truth.total_minor;
+    const dateCell = r.extracted.occurred_on
+      ? `${r.extracted.occurred_on === gtDate ? "✅" : "❌"} ${r.extracted.occurred_on}${r.extracted.occurred_on !== gtDate ? ` → ${gtDate}` : ""}`
+      : "—";
+    const totalCell =
+      r.extracted.total_minor == null || gtTotal == null
+        ? "—"
+        : `${r.extracted.total_minor === gtTotal ? "✅" : "❌"} ${(r.extracted.total_minor / 100).toFixed(2)}${r.extracted.total_minor !== gtTotal ? ` → ${(gtTotal / 100).toFixed(2)}` : ""}`;
+    const payeeCell = r.extracted.payee
+      ? `${r.scoring.payee_match ? "✅" : "❌"} ${r.extracted.payee}`
+      : "—";
+    const pass = r.scoring.bucket_pass ? "✅" : "❌";
+    lines.push(
+      `| \`${r.fixture.bucket}\` | ${r.fixture.original_filename} | ${r.ingest_status} | ${dateCell} | ${totalCell} | ${payeeCell} | ${pass} |`,
+    );
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  console.error(`# eval-dates`);
+  console.error(`  base:        ${args.base}`);
+  console.error(`  manifest:    ${args.manifest}`);
+  console.error(`  uploads-dir: ${args.uploadsDir}`);
+
+  const manifest = JSON.parse(await readFile(args.manifest, "utf8")) as Fixture[];
+  const fixtures = args.limit ? manifest.slice(0, args.limit) : manifest;
+  console.error(`  fixtures:    ${fixtures.length} (${manifest.length} in manifest)`);
+
+  // 1. Re-encode each source file into a temp dir.
+  const tmp = await mkdtemp(path.join(tmpdir(), "eval-dates-"));
+  console.error(`  tmp:         ${tmp}`);
+  const cleanup = async () => rm(tmp, { recursive: true, force: true }).catch(() => {});
+  process.on("SIGINT", () => { cleanup().finally(() => process.exit(130)); });
+
+  const start = Date.now();
+  console.error(`\n[1/4] sips re-encoding ${fixtures.length} fixtures...`);
+  const files: { fixture: Fixture; filename: string; bytes: Uint8Array }[] = [];
+  for (const fx of fixtures) {
+    const src = path.join(args.uploadsDir, `${fx.sha256}.jpg`);
+    try { await stat(src); } catch {
+      throw new Error(`Missing source JPG: ${src} (for fixture ${fx.original_filename})`);
+    }
+    const out = path.join(tmp, `${fx.sha256}.jpg`);
+    await sipsReencode(src, out);
+    files.push({
+      fixture: fx,
+      filename: fx.original_filename,
+      bytes: new Uint8Array(await readFile(out)),
+    });
+  }
+
+  // 2. Upload one batch.
+  console.error(`\n[2/4] POST /v1/ingest/batch (${files.length} files, ~${(files.reduce((s, f) => s + f.bytes.length, 0) / 1024 / 1024).toFixed(1)} MB)`);
+  const batch = await postBatch(args.base, files);
+  console.error(`  batchId:     ${batch.batchId}`);
+
+  // Pair each fixture with its returned ingest_id (by filename + upload order).
+  // The API returns items in upload order, so we just zip them.
+  if (batch.items.length !== files.length) {
+    throw new Error(`Batch items count ${batch.items.length} != files count ${files.length}`);
+  }
+  const ingestByFx = new Map<Fixture, string>();
+  files.forEach((f, i) => ingestByFx.set(f.fixture, batch.items[i]!.ingestId));
+
+  // 3. Poll until terminal.
+  console.error(`\n[3/4] Polling /v1/batches/${batch.batchId} until all terminal (timeout 30 min)`);
+  const batchRow = await pollBatch(args.base, batch.batchId, files.length, 30 * 60 * 1000);
+  await cleanup();
+
+  // 4. For each fixture, pull transaction details + score.
+  console.error(`\n[4/4] Fetching transactions and scoring`);
+  const itemByIngest = new Map(batchRow.items.map((i) => [i.ingest_id, i]));
+  const results: FixtureResult[] = [];
+  for (const fx of fixtures) {
+    const ingestId = ingestByFx.get(fx)!;
+    const item = itemByIngest.get(ingestId)!;
+    const t0 = Date.now();
+
+    let occurred_on: string | null = null;
+    let payee: string | null = null;
+    let total_minor: number | null = null;
+    let txId: string | null = null;
+    if (item.status === "done") {
+      txId = item.produced?.transaction_ids[0] ?? null;
+      if (txId) {
+        try {
+          const tx = await getTransaction(args.base, txId);
+          occurred_on = tx.occurred_on;
+          payee = tx.payee;
+          // Total = max absolute amount across postings (the expense leg).
+          // Double-entry guarantees one positive + one negative; absolute
+          // values agree.
+          const amts = tx.postings.map((p) => Math.abs(p.amount_minor));
+          total_minor = amts.length > 0 ? Math.max(...amts) : null;
+        } catch (e) {
+          console.error(`  warn: GET /v1/transactions/${txId} failed: ${(e as Error).message}`);
+        }
+      }
+    }
+
+    const scoring = score(fx, item.status, { occurred_on, payee, total_minor });
+    results.push({
+      fixture: fx,
+      ingest_id: ingestId,
+      ingest_status: item.status,
+      ingest_error: item.error,
+      transaction_id: txId,
+      extracted: { occurred_on, payee, total_minor },
+      scoring,
+      duration_ms: Date.now() - t0,
+    });
+  }
+
+  const durationMs = Date.now() - start;
+  const agg = aggregate(results);
+
+  // 5. Write reports.
+  const reportDir = path.dirname(args.manifest);
+  const jsonOut = {
+    generated_at: new Date().toISOString(),
+    batchId: batch.batchId,
+    base: args.base,
+    duration_ms: durationMs,
+    aggregate: agg,
+    fixtures: results,
+  };
+  await writeFile(path.join(reportDir, "eval-dates.report.json"), JSON.stringify(jsonOut, null, 2));
+  await writeFile(
+    path.join(reportDir, "eval-dates.report.md"),
+    renderMarkdown(agg, results, { batchId: batch.batchId, durationMs, base: args.base }),
+  );
+
+  // 6. Console summary + gate.
+  console.error(`\nDone in ${(durationMs / 1000).toFixed(1)}s.`);
+  console.error(`Date accuracy: ${(agg.date_accuracy * 100).toFixed(1)}% (${agg.date_match_count}/${agg.extracted_count})`);
+  console.error(`Reports: ${path.join(reportDir, "eval-dates.report.{json,md}")}`);
+
+  if (args.gate && agg.date_accuracy < 0.9) {
+    console.error(`\nGATE FAILED: date accuracy ${(agg.date_accuracy * 100).toFixed(1)}% < 90%`);
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Ships the durable AC#3 deliverable for #27 — a committed, repeatable harness that round-trips a 23-fixture manifest through `/v1/ingest/batch` and scores `(date, total, payee)` per bucket.

- `scripts/eval-dates.ts` — single-file TS harness. sips re-encodes each fixture to bump SHA past dedupe, POSTs one multipart batch, polls until terminal, GETs the produced transactions, scores per bucket.
- `scripts/eval-dates.fixtures.json` — 23-entry committed manifest (hard_date / hard_total / hard_all / good) covering every failure fixture documented in #27's history (Wilson, WingHopFung, UrthCaffe, Marukai, CircleK, Haidilao, plus TraderJoes/Eataly totals).
- `scripts/eval-dates.md` — operator doc: bucket pass criteria, how to add a fixture, known stragglers, interpretation guide.
- `package.json` — `npm run eval:dates` entry point.
- `docker-compose.yml` — bump `MAX_CLAUDE_CONCURRENCY` 3 → 6. Default 3 cost the 23-fixture eval ~25 min wall-clock at 8.77% CPU; the host has headroom. Halves baseline runtime.

## Baseline (this PR's first reproducible run)

```
Date accuracy   77.3%  (17/22)
Total accuracy  72.7%  (16/22)
Payee accuracy 100.0%  (22/22)

By bucket:  good 11/14 · hard_date 2/4 · hard_total 0/4 · hard_all 0/1
```

AC#1 (≥90% date accuracy) is **not yet met** — that part of #27 stays open. AC#3 (harness committed + `npm run eval:dates`) is met by this PR. Full per-fixture table will be posted to #27 separately.

## Why not extend `scripts/smoke-v1-ingest.ts`

The existing smoke script is from the pre-batch 4-step API era — its header still describes `POST /v1/documents` → host-side `claude -p` → `POST /v1/transactions` → `POST /v1/documents/:id/links`. The worker now owns `claude -p` and writes the DB directly. Hard-coded fixture path is also dev-machine-specific (`~/Desktop/RECEIPT/`). Cleaner to write fresh against the current API and let `smoke-v1-ingest` retire on its own.

## Test plan

- [x] `npm run eval:dates` round-trips 23 fixtures in ~11 min at `MAX_CLAUDE_CONCURRENCY=6`
- [x] `eval-dates.report.{json,md}` written, gitignored
- [x] Wilson `30↔03` reproduces (4th run in a row); WingHopFung non-determinism reproduces
- [x] Two new failure modes surfaced (Kelly's Coffee `11-02 → 11-21`, Costco gas Marina `03-06 → 03-08`) that weren't in the issue's prior failure catalog
- [x] `npm run eval:dates -- --gate` exits 1 when date_accuracy < 90% (verified — exits 1 at current 77.3%)

Fixes #27 AC#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)