### PR TITLE
feat(ingest): stamp metadata.extraction provenance (#80 Phase 1, fixes #88)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,38 @@ These apply to the agent that reads a receipt image and writes a `transaction` +
 7. **Language**: Receipts may be in English, Chinese, or other languages. Handle all.
 8. **OCR text**: Persist the full receipt transcription on the `documents.ocr_text` column for future reference.
 
+## Extraction provenance — `metadata.extraction` (Phase 1 of #80)
+
+Every transaction the ingest agent writes stamps a `metadata.extraction` block recording the prompt/model under which it ran. Schema:
+
+```jsonc
+{
+  "extraction": {
+    "prompt_version": "2.5",                    // see src/ingest/prompt.ts → PROMPT_VERSION
+    "prompt_git_sha": "<build-info gitSha>",
+    "model":          "<CLAUDE_MODEL env or 'sonnet'>",
+    "ran_at":         "<wall-clock at COMMIT>"
+  }
+}
+```
+
+This is the gate for [#91](https://github.com/TINKPA/receipt-assistant/issues/91) (`POST /v1/documents/:id/re-extract`) and Phase 2 [#89](https://github.com/TINKPA/receipt-assistant/issues/89) — rows whose `prompt_version` ≠ the current source-tree `PROMPT_VERSION` are eligible to be re-derived.
+
+### When to bump `PROMPT_VERSION`
+
+Bump in the **same PR** as the prompt change. Guideline:
+
+| Change | Bump? |
+|---|---|
+| New self-check block, new required field, fundamentally different reasoning flow | **Yes** (minor or major) |
+| Wording polish, typo fix, whitespace, log-only edit | **No** |
+| New tool exposure (e.g. agent gains a new Bash command pattern) | **Yes** |
+| Reordering existing instructions without semantic change | **No** |
+
+The version is a flat string (`"2.5"` today; `"2.5.1"` for a small additive iteration, `"3.0"` for a clean break). Auto-bumping on every commit defeats the purpose — it floods the version field with noise and makes the re-extract eligibility filter useless.
+
+Legacy rows ingested before Phase 1 shipped have `metadata.extraction = NULL`. Phase 2/Phase 4 treats NULL as "unknown version, eligible to be re-extracted."
+
 ## Known Pitfalls
 
 1. **`--json-schema` degrades OCR accuracy vs plain-text output**:

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -7,6 +7,17 @@
  * See `receipt-assistant#49` for the architectural move from Phase 1
  * (Node-side coerce + service-layer writes) to Phase 2.
  */
+import { buildInfo } from "../generated/build-info.js";
+
+/**
+ * Manual prompt-version stamp written into `transactions.metadata.extraction`
+ * for every ingest. Bump on meaningful prompt changes only — typo fixes
+ * and whitespace edits do not warrant a new version. The string becomes
+ * the gate for `POST /v1/documents/:id/re-extract` (#91): rows whose
+ * `extraction.prompt_version` ≠ `PROMPT_VERSION` are eligible to be
+ * re-derived. See #80 / #88 for the 3-layer data model rationale.
+ */
+export const PROMPT_VERSION = "2.5";
 
 export interface ExtractorPromptContext {
   /** Absolute path inside the container where the file was staged. */
@@ -384,6 +395,24 @@ An ingest without this key is considered incomplete. Emit it even
 when no corrections were needed (correction_applied=false,
 note="clean extraction").
 
+### REQUIRED metadata.extraction shape (provenance stamp — #88 / #80)
+
+The transaction SQL template below already includes the
+\`extraction\` key under metadata. **Do not change its values** — they
+are templated from Node-side build artifacts so they describe the
+prompt/model under which extraction actually ran:
+
+  "extraction": {
+    "prompt_version": "${PROMPT_VERSION}",     // bumped manually on meaningful prompt edits
+    "prompt_git_sha": "${buildInfo.gitSha}",    // build-time git rev
+    "model":          "${process.env.CLAUDE_MODEL ?? "sonnet"}",
+    "ran_at":         NOW()                                                    // wall-clock at COMMIT
+  }
+
+Future re-extract endpoints (#91) gate eligibility on
+\`prompt_version != latest\`. Leaving these wrong would mark this
+transaction as already-up-to-date and skip it.
+
 ── Phase 4 — Write to the ledger ──────────────────────────────────────
 
 v1 schema primer (workspace_id is required on every row):
@@ -464,6 +493,12 @@ them first):
             'canonical_name', '<CANONICAL_NAME>',
             'brand_id',       '<brand-id>',
             'category',       '<7-class CATEGORY>'
+          ),
+          'extraction', jsonb_build_object(
+            'prompt_version', '${PROMPT_VERSION}',
+            'prompt_git_sha', '${buildInfo.gitSha}',
+            'model',          '${process.env.CLAUDE_MODEL ?? "sonnet"}',
+            'ran_at',         NOW()
           )
           -- add tax/tip/items/raw_text here if useful, as extra JSONB keys
         ),


### PR DESCRIPTION
## Summary

Phase 1 of the 3-layer data model rollout (#80) — stamp every new transaction with `metadata.extraction.{prompt_version, prompt_git_sha, model, ran_at}` so future re-derive (#89) and re-extract (#91) endpoints can identify stale rows.

Zero-risk additive change: no migration, no behavior change for existing rows (they keep `metadata.extraction = NULL` and are treated as "unknown version, eligible to be re-extracted" by Phase 4).

## Changes

- `src/ingest/prompt.ts`:
  - `export const PROMPT_VERSION = "2.5"`
  - `import { buildInfo } from "../generated/build-info.js"`
  - Template `extraction` block into the receipt-image transaction SQL's `jsonb_build_object` — values are Node-side build artifacts the agent is instructed not to alter.
  - New "REQUIRED metadata.extraction shape" doc section so the agent knows the block is mandatory and templated.
- `CLAUDE.md`: new "Extraction provenance" subsection with the schema + when-to-bump guidance.

## Verification

```
$ docker compose build receipt-assistant && docker compose up -d receipt-assistant
$ npm run eval:dates -- --limit=2
$ docker exec receipts-postgres psql -U postgres -d receipts -c \
    "SELECT i.filename, t.metadata->'extraction' FROM ingests i \
     JOIN transactions t ON t.source_ingest_id = i.id \
     WHERE i.created_at > now() - interval '5 minutes';"
```

Returns rows with `{"model": "sonnet", "ran_at": "2026-05-15T07:51:57+00:00", "prompt_git_sha": "7349be7...", "prompt_version": "2.5"}` on every new transaction. Confirmed against both the Wilson and WingHopFung fixtures.

## Test plan

- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Backend container rebuilds and starts (image `receipt-assistant:local` updated)
- [x] New transactions stamped (verified via SQL query)
- [x] No regression on existing eval-dates baseline — date/total/payee scoring unaffected

## Out of scope (future phases)

- Re-derive endpoint (#89) — reads `prompt_version` to decide eligibility
- `place_snapshots` table (#90)
- Re-extract endpoint (#91) — gates on `prompt_version != latest`
- UI surface (frontend #49)

Fixes #88. Tracking: #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)