### PR TITLE
Re-derive endpoints for places + derivation_events audit (#80 Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Every transaction the ingest agent writes stamps a `metadata.extraction` block r
 }
 ```
 
-This is the gate for [#91](https://github.com/TINKPA/receipt-assistant/issues/91) (`POST /v1/documents/:id/re-extract`) and Phase 2 [#89](https://github.com/TINKPA/receipt-assistant/issues/89) — rows whose `prompt_version` ≠ the current source-tree `PROMPT_VERSION` are eligible to be re-derived.
+This is the gate for [#91](https://github.com/TINKPA/receipt-assistant/issues/91) (`POST /v1/documents/:id/re-extract`) — rows whose `prompt_version` ≠ the current source-tree `PROMPT_VERSION` are eligible to be re-extracted. Phase 2 of the same epic ([#89](https://github.com/TINKPA/receipt-assistant/issues/89)) shipped re-derive for `places`; see the next section.
 
 ### When to bump `PROMPT_VERSION`
 
@@ -80,6 +80,51 @@ Bump in the **same PR** as the prompt change. Guideline:
 The version is a flat string (`"2.5"` today; `"2.5.1"` for a small additive iteration, `"3.0"` for a clean break). Auto-bumping on every commit defeats the purpose — it floods the version field with noise and makes the re-extract eligibility filter useless.
 
 Legacy rows ingested before Phase 1 shipped have `metadata.extraction = NULL`. Phase 2/Phase 4 treats NULL as "unknown version, eligible to be re-extracted."
+
+## Backfill / re-derivation — `places` (Phase 2 of #80)
+
+Phase 2 of the 3-layer data-model rollout ([#80](https://github.com/TINKPA/receipt-assistant/issues/80) / [#89](https://github.com/TINKPA/receipt-assistant/issues/89)) ships two endpoints that re-run Layer 2 projection over the existing `places.raw_response` — no Google calls, no Anthropic calls in the hot path.
+
+```
+POST /v1/places/{id}/re-derive          # single
+POST /v1/admin/re-derive?scope=places   # batch over every place
+```
+
+### How the projection runs
+
+Pure TypeScript, deterministic. `src/projection/derive.ts ::projectPlace(rawResponse)` is the single source of truth — it ports the rules in `src/ingest/prompt.ts` Phase 3c (CJK extraction, branch-suffix stripping, `is_native` heuristic with a `GLOBAL_ENGLISH_BRANDS` allowlist) into a rule-encoded function. No `claude -p` invocation, no Anthropic SDK call. Rationale: the heuristics are stable enough to encode once; running them through an LLM per place would add 5–15 s of latency × N for the batch path with no judgment-call payoff the rules can't deliver. The "AI-native" principle still holds — initial extraction (OCR, payee + items, merchant aggregation) stays LLM-driven; only the cheap re-projection step is deterministic.
+
+When you change the projection logic (e.g. add a brand to `GLOBAL_ENGLISH_BRANDS`, refine the CJK strip rules), bump `PROJECTION_VERSION` in `src/projection/derive.ts` in the same PR and run `POST /v1/admin/re-derive?scope=places` after deploy to roll the new logic across the corpus.
+
+### Field-write policy
+
+Re-derive **overwrites** projection-domain fields with the new projection result (NOT COALESCE — re-derive is authoritative, NULL is a valid new value). Two narrow exceptions:
+
+- **Layer 3 user-truth** (`places.custom_name_zh`) is never in the UPDATE column list. Mirrors the existing pattern at `src/ingest/prompt.ts:712-713`. New Layer 3 fields must be added to the service-side allowlist in `src/routes/places.service.ts ::reDerivePlace`.
+- **OCR-sourced zh fields** (`display_name_zh_source IN ('photo_ocr', 'receipt_ocr')`) are preserved verbatim. The projection only consumes Google's response; a row whose Chinese name came from a storefront photo or the receipt's own letterhead is outside this projection's input domain and must not be reclassified to `NULL` just because Google has no Chinese.
+
+Physical facts (`lat`, `lng`, the legacy `formatted_address`) are also untouched — those were set at fetch time and don't change with projection logic.
+
+### Audit log — `derivation_events`
+
+Every re-derive INSERTs one row into `derivation_events` **before** the UPDATE lands, inside the same transaction. Schema is shared across entity types (Phase 2 only writes `entity_type='place'`; #91 will add `'document'` / `'merchant'`):
+
+```sql
+SELECT entity_id, prompt_version, prompt_git_sha, model, ran_at, changed_keys
+  FROM derivation_events
+ WHERE entity_type = 'place' AND entity_id = $1
+ ORDER BY ran_at DESC;
+```
+
+- **Diff a version bump after the fact**: `WHERE prompt_version = '2.6'` gives every row touched by that release.
+- **Roll back a bad re-derive**: write the `before` jsonb back to the entity, then INSERT a new event documenting the rollback.
+- **Audit no-op runs**: rows where `changed_keys = []` still get an event — so a version bump that happened to produce the same output is visible (and gives you a known-good checkpoint to compare future runs against).
+
+The `places.metadata.derivation` jsonb on the row itself answers "what produced *this* current row" without a join — equivalent to `transactions.metadata.extraction` from Phase 1.
+
+### Why no merchants cascade
+
+The user-facing question raised during planning was: when re-derive changes `places.display_name_en`, should `merchants.canonical_name` auto-update for the linked brand? The code says no — `merchants.canonical_name` / `brand_id` / `category` come from the LLM looking at the **receipt** at ingest time, not from `places` projection output. `merchants.address` / `lat` / `lng` come from `src/enrichment/merchants.ts` calling Google's `findPlaceFromText` endpoint, which is separate from `places.raw_response`. So a `places` projection change doesn't introduce any new inconsistency in `merchants`, and a cascade UPDATE would be dead code. The cascade architecture slot belongs to [#91](https://github.com/TINKPA/receipt-assistant/issues/91) (re-extract), where re-reading the receipt with new place data can plausibly change `canonical_name`.
 
 ## Known Pitfalls
 

--- a/drizzle/0011_phase2_re_derive.sql
+++ b/drizzle/0011_phase2_re_derive.sql
@@ -1,0 +1,49 @@
+-- Phase 2 of the 3-layer data-model rollout (#80 / #89).
+--
+-- Adds the plumbing for `POST /v1/places/:id/re-derive` and
+-- `POST /v1/admin/re-derive`: a per-row provenance bag on `places`,
+-- and a shared append-only audit log for every Layer 2 overwrite.
+--
+--   `places.metadata`       — jsonb. Re-derive writes
+--                             `metadata.derivation = { projection_version,
+--                             prompt_git_sha, model, ran_at }`. Mirrors
+--                             the `transactions.metadata.extraction`
+--                             pattern shipped in #88. Lets a single
+--                             query answer "what produced this row?"
+--                             without joining `derivation_events`.
+--
+--   `derivation_events`     — append-only audit. Every re-derive
+--                             INSERTs one row BEFORE the UPDATE lands,
+--                             with the field-level `before` / `after`
+--                             jsonb diff. Used to (a) diff a projection
+--                             bump after the fact, (b) roll back a bad
+--                             re-derive by writing `before` back, (c)
+--                             audit `WHERE prompt_version = 'X.Y'` to
+--                             see which rows a given version touched.
+--                             `entity_id` is `text` to accept both UUIDs
+--                             (place / transaction) and Google-style
+--                             `ChIJ…` identifiers without a join.
+--
+-- Layer-3 user-truth columns (e.g. `places.custom_name_zh`) are NEVER
+-- written here — re-derive omits them from the UPDATE entirely. New
+-- Layer-3 fields must be added to the service-side allowlist when
+-- introduced; this is enforced in code, not DB.
+
+CREATE TABLE "derivation_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"entity_type" text NOT NULL,
+	"entity_id" text NOT NULL,
+	"prompt_version" text NOT NULL,
+	"prompt_git_sha" text NOT NULL,
+	"model" text NOT NULL,
+	"ran_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	"before" jsonb NOT NULL,
+	"after" jsonb NOT NULL,
+	"changed_keys" text[] NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "places" ADD COLUMN "metadata" jsonb;--> statement-breakpoint
+ALTER TABLE "derivation_events" ADD CONSTRAINT "derivation_events_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "derivation_events_entity_idx" ON "derivation_events" USING btree ("entity_type","entity_id","ran_at");--> statement-breakpoint
+CREATE INDEX "derivation_events_version_idx" ON "derivation_events" USING btree ("prompt_version","ran_at");

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,2687 @@
+{
+  "id": "dd84fdf0-f546-4bfc-beed-3f59912996ba",
+  "prevId": "58df4350-a2bc-4ee4-ba42-7bd5ba5d8aa6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_uniq": {
+          "name": "users_email_lower_uniq",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_users_id_fk": {
+          "name": "workspace_members_user_id_users_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_workspace_id_user_id_pk": {
+          "name": "workspace_members_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_owner_id_users_id_fk": {
+          "name": "workspaces_owner_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_balance_minor": {
+          "name": "opening_balance_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "accounts_workspace_idx": {
+          "name": "accounts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_parent_idx": {
+          "name": "accounts_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_workspace_type_idx": {
+          "name": "accounts_workspace_type_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_workspace_id_workspaces_id_fk": {
+          "name": "accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_parent_id_accounts_id_fk": {
+          "name": "accounts_parent_id_accounts_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narration": {
+          "name": "narration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "txn_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "voided_by_id": {
+          "name": "voided_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transactions_keyset_idx": {
+          "name": "transactions_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_created_at_keyset_idx": {
+          "name": "transactions_created_at_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_source_ingest_idx": {
+          "name": "transactions_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_trip_idx": {
+          "name": "transactions_trip_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_place_idx": {
+          "name": "transactions_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_merchant_idx": {
+          "name": "transactions_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_workspace_id_workspaces_id_fk": {
+          "name": "transactions_workspace_id_workspaces_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_voided_by_id_transactions_id_fk": {
+          "name": "transactions_voided_by_id_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "voided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_source_ingest_id_ingests_id_fk": {
+          "name": "transactions_source_ingest_id_ingests_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_place_id_places_id_fk": {
+          "name": "transactions_place_id_places_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_merchant_id_merchants_id_fk": {
+          "name": "transactions_merchant_id_merchants_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_created_by_users_id_fk": {
+          "name": "transactions_created_by_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.postings": {
+      "name": "postings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fx_rate": {
+          "name": "fx_rate",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_base_minor": {
+          "name": "amount_base_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "postings_transaction_idx": {
+          "name": "postings_transaction_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_account_idx": {
+          "name": "postings_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_workspace_idx": {
+          "name": "postings_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "postings_workspace_id_workspaces_id_fk": {
+          "name": "postings_workspace_id_workspaces_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_transaction_id_transactions_id_fk": {
+          "name": "postings_transaction_id_transactions_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_account_id_accounts_id_fk": {
+          "name": "postings_account_id_accounts_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_links": {
+      "name": "document_links",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "document_links_txn_idx": {
+          "name": "document_links_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_links_document_id_documents_id_fk": {
+          "name": "document_links_document_id_documents_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_links_transaction_id_transactions_id_fk": {
+          "name": "document_links_transaction_id_transactions_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_links_document_id_transaction_id_pk": {
+          "name": "document_links_document_id_transaction_id_pk",
+          "columns": [
+            "document_id",
+            "transaction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocr_text": {
+          "name": "ocr_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_meta": {
+          "name": "extraction_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "documents_workspace_sha_uniq": {
+          "name": "documents_workspace_sha_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_kind_idx": {
+          "name": "documents_kind_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_source_ingest_idx": {
+          "name": "documents_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_workspace_live_idx": {
+          "name": "documents_workspace_live_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"documents\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_workspace_id_workspaces_id_fk": {
+          "name": "documents_workspace_id_workspaces_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_source_ingest_id_ingests_id_fk": {
+          "name": "documents_source_ingest_id_ingests_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_events": {
+      "name": "transaction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "txn_events_txn_idx": {
+          "name": "txn_events_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_events_workspace_id_workspaces_id_fk": {
+          "name": "transaction_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_transaction_id_transactions_id_fk": {
+          "name": "transaction_events_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_actor_id_users_id_fk": {
+          "name": "transaction_events_actor_id_users_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "idempotency_keys_uniq": {
+          "name": "idempotency_keys_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_workspace_id_workspaces_id_fk": {
+          "name": "idempotency_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reconcile": {
+          "name": "auto_reconcile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "batches_workspace_created_idx": {
+          "name": "batches_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_status_idx": {
+          "name": "batches_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batches_workspace_id_workspaces_id_fk": {
+          "name": "batches_workspace_id_workspaces_id_fk",
+          "tableFrom": "batches",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingests": {
+      "name": "ingests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ingest_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "produced": {
+          "name": "produced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingests_batch_idx": {
+          "name": "ingests_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_workspace_created_idx": {
+          "name": "ingests_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_status_idx": {
+          "name": "ingests_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingests_workspace_id_workspaces_id_fk": {
+          "name": "ingests_workspace_id_workspaces_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingests_batch_id_batches_id_fk": {
+          "name": "ingests_batch_id_batches_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconcile_proposals": {
+      "name": "reconcile_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconcile_proposals_batch_idx": {
+          "name": "reconcile_proposals_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconcile_proposals_kind_idx": {
+          "name": "reconcile_proposals_kind_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconcile_proposals_batch_id_batches_id_fk": {
+          "name": "reconcile_proposals_batch_id_batches_id_fk",
+          "tableFrom": "reconcile_proposals",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_photos": {
+      "name": "place_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_photo_name": {
+          "name": "google_photo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width_px": {
+          "name": "width_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_px": {
+          "name": "height_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_attributions": {
+          "name": "author_attributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_extracted": {
+          "name": "ocr_extracted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_reviews": {
+      "name": "place_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_review_name": {
+          "name": "google_review_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_language": {
+          "name": "text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_text": {
+          "name": "original_text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_language": {
+          "name": "original_text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relative_publish_time": {
+          "name": "relative_publish_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_time": {
+          "name": "publish_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_uri": {
+          "name": "author_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_photo_uri": {
+          "name": "author_photo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_taken_at": {
+          "name": "snapshot_taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "google_place_id": {
+          "name": "google_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_name_en": {
+          "name": "display_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh": {
+          "name": "display_name_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_locale": {
+          "name": "display_name_zh_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_source": {
+          "name": "display_name_zh_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_is_native": {
+          "name": "display_name_zh_is_native",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name_zh": {
+          "name": "custom_name_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type_display_zh": {
+          "name": "primary_type_display_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maps_type_label_zh": {
+          "name": "maps_type_label_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "types": {
+          "name": "types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_en": {
+          "name": "formatted_address_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_zh": {
+          "name": "formatted_address_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_status": {
+          "name": "business_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_hours": {
+          "name": "business_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_rating_count": {
+          "name": "user_rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "national_phone_number": {
+          "name": "national_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_uri": {
+          "name": "website_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_maps_uri": {
+          "name": "google_maps_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_business_id": {
+          "name": "yelp_business_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_alias": {
+          "name": "yelp_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_price_level": {
+          "name": "yelp_price_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_categories": {
+          "name": "yelp_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_raw_response": {
+          "name": "yelp_raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "places_lat_lng_idx": {
+          "name": "places_lat_lng_idx",
+          "columns": [
+            {
+              "expression": "lat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lng",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "places_google_place_id_unique": {
+          "name": "places_google_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_place_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merchants": {
+      "name": "merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_attribution": {
+          "name": "photo_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_status": {
+          "name": "enrichment_status",
+          "type": "merchant_enrichment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enrichment_attempted_at": {
+          "name": "enrichment_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "merchants_workspace_brand_idx": {
+          "name": "merchants_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merchants_workspace_idx": {
+          "name": "merchants_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merchants_enrichment_pending_idx": {
+          "name": "merchants_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "merchants_workspace_id_workspaces_id_fk": {
+          "name": "merchants_workspace_id_workspaces_id_fk",
+          "tableFrom": "merchants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "merchants_brand_id_format": {
+          "name": "merchants_brand_id_format",
+          "value": "\"merchants\".\"brand_id\" ~ '^[a-z0-9-]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.derivation_events": {
+      "name": "derivation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_git_sha": {
+          "name": "prompt_git_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_keys": {
+          "name": "changed_keys",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "derivation_events_entity_idx": {
+          "name": "derivation_events_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "derivation_events_version_idx": {
+          "name": "derivation_events_version_idx",
+          "columns": [
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "derivation_events_workspace_id_workspaces_id_fk": {
+          "name": "derivation_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "derivation_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "asset",
+        "liability",
+        "equity",
+        "income",
+        "expense"
+      ]
+    },
+    "public.batch_status": {
+      "name": "batch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "extracted",
+        "reconciling",
+        "reconciled",
+        "failed",
+        "reconcile_error"
+      ]
+    },
+    "public.document_kind": {
+      "name": "document_kind",
+      "schema": "public",
+      "values": [
+        "receipt_image",
+        "receipt_email",
+        "receipt_pdf",
+        "statement_pdf",
+        "other"
+      ]
+    },
+    "public.ingest_status": {
+      "name": "ingest_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "done",
+        "error",
+        "unsupported"
+      ]
+    },
+    "public.merchant_enrichment_status": {
+      "name": "merchant_enrichment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "not_found",
+        "failed"
+      ]
+    },
+    "public.txn_status": {
+      "name": "txn_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided",
+        "reconciled",
+        "error"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778715060674,
       "tag": "0010_display_name_zh_is_native",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778838477369,
+      "tag": "0011_phase2_re_derive",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2728,6 +2728,81 @@
             ]
           }
         }
+      },
+      "ReDerivePlaceResponse": {
+        "type": "object",
+        "properties": {
+          "place_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "changed_keys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "derivation_event_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          }
+        },
+        "required": [
+          "place_id",
+          "changed_keys",
+          "derivation_event_id"
+        ]
+      },
+      "ReDeriveBatchResponse": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "type": "string",
+            "enum": [
+              "places"
+            ]
+          },
+          "total": {
+            "type": "integer"
+          },
+          "updated": {
+            "type": "integer"
+          },
+          "skipped": {
+            "type": "integer"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "message"
+              ]
+            }
+          },
+          "ran_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "scope",
+          "total",
+          "updated",
+          "skipped",
+          "errors",
+          "ran_at"
+        ]
       }
     },
     "parameters": {}
@@ -5626,6 +5701,59 @@
         }
       }
     },
+    "/v1/places/{id}/re-derive": {
+      "post": {
+        "summary": "Re-run Layer 2 projection over cached raw_response.",
+        "description": "Re-applies the current projection logic to the cached Google Places response, overwriting derived columns. Layer 3 user-truth (`custom_name_zh`) is never touched. OCR-sourced zh fields (`display_name_zh_source IN ('photo_ocr','receipt_ocr')`) are preserved verbatim. Every run inserts a `derivation_events` row with a `before`/`after` jsonb diff; the returned `derivation_event_id` lets you correlate. Returns 422 when `raw_response` is NULL.",
+        "tags": [
+          "places"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Re-derive committed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReDerivePlaceResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Place not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Place has no raw_response — nothing to project from",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/places/{id}/photos/{rank}/content": {
       "get": {
         "summary": "Stream the binary of a cached Google Places photo.",
@@ -5668,6 +5796,51 @@
           },
           "404": {
             "description": "Not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/re-derive": {
+      "post": {
+        "summary": "Re-run Layer 2 projection across every row in scope.",
+        "description": "Phase 2 (#89): scope=places walks every `places` row and re-runs the projection over its cached `raw_response`. Rows with `raw_response IS NULL` are counted as `skipped` (not errored). Each updated row produces a `derivation_events` entry — including no-op runs that match the current state, so a version bump is auditable even when nothing visibly changes. Sync execution at current corpus scale (<1 s for tens to low hundreds of places).",
+        "tags": [
+          "admin"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "places"
+              ],
+              "default": "places"
+            },
+            "required": false,
+            "name": "scope",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Batch summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReDeriveBatchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid scope",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,6 +30,7 @@ import { reconcileRouter } from "./routes/reconcile.js";
 import { reportsRouter } from "./routes/reports.js";
 import { merchantsRouter } from "./routes/merchants.js";
 import { placesRouter } from "./routes/places.js";
+import { adminRouter } from "./routes/admin.js";
 import { buildInfo } from "./generated/build-info.js";
 
 export function buildApp(): Express {
@@ -82,6 +83,7 @@ export function buildApp(): Express {
   app.use("/v1/reports", reportsRouter);
   app.use("/v1/merchants", merchantsRouter);
   app.use("/v1/places", placesRouter);
+  app.use("/v1/admin", adminRouter);
 
   // ── Final error handler ─────────────────────────────────────────────
   app.use(problemHandler);

--- a/src/http/problem.ts
+++ b/src/http/problem.ts
@@ -153,6 +153,18 @@ export class PostingsImbalanceProblem extends HttpProblem {
   }
 }
 
+export class NoRawResponseProblem extends HttpProblem {
+  constructor(placeId: string) {
+    super(
+      422,
+      "place-no-raw-response",
+      "Cannot re-derive",
+      `Place ${placeId} has no raw_response; re-derive needs cached Google data to project from. Refresh the place via the (Phase 4) re-fetch path before re-deriving.`,
+      { place_id: placeId },
+    );
+  }
+}
+
 export class DocumentHasLinksProblem extends HttpProblem {
   constructor(documentId: string, linkCount: number) {
     super(

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -29,6 +29,7 @@ import { registerReconcileOpenApi } from "./routes/reconcile.js";
 import { registerReportsOpenApi } from "./routes/reports.js";
 import { registerMerchantsOpenApi } from "./routes/merchants.js";
 import { registerPlacesOpenApi } from "./routes/places.js";
+import { registerAdminOpenApi } from "./routes/admin.js";
 
 export function buildRegistry(): OpenAPIRegistry {
   const registry = new OpenAPIRegistry();
@@ -81,6 +82,7 @@ export function buildRegistry(): OpenAPIRegistry {
   registerReportsOpenApi(registry);
   registerMerchantsOpenApi(registry);
   registerPlacesOpenApi(registry);
+  registerAdminOpenApi(registry);
 
   return registry;
 }

--- a/src/projection/derive.ts
+++ b/src/projection/derive.ts
@@ -1,0 +1,309 @@
+/**
+ * Deterministic Layer 2 projection from a cached Google Places v1
+ * raw response (`places.raw_response`) — the read side of the
+ * 3-layer data model rollout in #80, used by `POST
+ * /v1/places/:id/re-derive` (#89).
+ *
+ * Why TS-deterministic and not an LLM call:
+ *   - 95 % of the projection is rote field mapping. The remaining
+ *     5 % (CJK stripping + `is_native` heuristic) is rule-encodable
+ *     faithfully from `src/ingest/prompt.ts` Phase 3c. An LLM call
+ *     per place would add 5–15 s of latency × N for the batch path
+ *     with no judgment-call payoff the rules can't deliver.
+ *   - The pre-existing `scripts/backfill-multilingual-places.ts`
+ *     `derive(en, zh)` (now superseded by this module) has been
+ *     running this exact projection over the production corpus
+ *     since #74 shipped. This module is a hardened extraction +
+ *     extension of that proven code, NOT a from-scratch port of
+ *     the prompt.
+ *
+ * AI-native principle: LLM still owns initial extraction (the
+ * agent that wrote `raw_response` in the first place), photo OCR,
+ * receipt OCR, and merchant aggregation at ingest time. Re-derive
+ * deliberately stays cheap so it can run frequently without
+ * burning Anthropic credits — the prompt's Phase 3c heuristics are
+ * stable enough to encode once and reuse across re-derive runs.
+ *
+ * Domain boundary: this module only projects from Google data. It
+ * NEVER touches:
+ *   - `places.custom_name_zh`     (Layer 3 user-truth)
+ *   - `places.display_name_zh_*`  when the current source is
+ *                                  `photo_ocr` / `receipt_ocr`
+ *                                  (different input domain — the
+ *                                  service layer enforces this)
+ *   - `places.lat / .lng`         (physical facts, set at fetch)
+ *   - `places.formatted_address`  (legacy primary, never rewritten)
+ */
+
+/** Google Places v1 dual-language envelope, as stored on
+ *  `places.raw_response`. Pre-#74 rows may have a different shape;
+ *  the caller is responsible for type-narrowing before passing in. */
+export interface RawResponseV1 {
+  v1: {
+    en?: Record<string, unknown> | null;
+    "zh-CN"?: Record<string, unknown> | null;
+  };
+  fetched_at?: string;
+}
+
+/** Layer 2 fields produced by a projection run. Every key here
+ *  is something `reDerivePlace` will write to `places`. Keys not
+ *  in this shape are NOT touched by re-derive. */
+export interface ProjectedPlaceFields {
+  display_name_en: string | null;
+  display_name_zh: string | null;
+  display_name_zh_locale: string | null;
+  /** Source attribution for `display_name_zh`. This module only
+   *  ever emits `"google_text"` or `null`; OCR-based sources are
+   *  preserved by the service layer if the current row carries
+   *  them (re-derive never reclassifies a photo/receipt-OCR name
+   *  as Google-sourced). */
+  display_name_zh_source: "google_text" | null;
+  /** Native-script flag per prompt.ts:277-304 heuristic. */
+  display_name_zh_is_native: boolean | null;
+
+  primary_type: string | null;
+  primary_type_display_zh: string | null;
+  maps_type_label_zh: string | null;
+  types: string[] | null;
+
+  formatted_address_en: string | null;
+  formatted_address_zh: string | null;
+  postal_code: string | null;
+  country_code: string | null;
+
+  business_status: string | null;
+  business_hours: unknown | null;
+  time_zone: string | null;
+
+  rating: string | null;
+  user_rating_count: number | null;
+
+  national_phone_number: string | null;
+  website_uri: string | null;
+  google_maps_uri: string | null;
+}
+
+/** Constant identifying this projection's "model" in audit logs.
+ *  Bumped only when the projection logic in this file changes in a
+ *  way that should mark rows as re-derive-eligible (i.e. the
+ *  equivalent of `PROMPT_VERSION` for the deterministic side). */
+export const PROJECTION_VERSION = "1.0";
+
+/** `derivation_events.model` value for runs of this module.
+ *  LLM-backed re-derive paths (e.g. future merchant cascade in
+ *  #91) stamp the actual model name instead. */
+export const PROJECTION_MODEL = "ts-deterministic";
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+/** Read a string at `obj.path[0].path[1]…`, return `null` for any
+ *  missing / non-string node. Doubles as a runtime type guard. */
+function s(
+  obj: Record<string, unknown> | null | undefined,
+  ...path: string[]
+): string | null {
+  let cur: unknown = obj;
+  for (const k of path) {
+    if (cur == null || typeof cur !== "object") return null;
+    cur = (cur as Record<string, unknown>)[k];
+  }
+  return typeof cur === "string" ? cur : null;
+}
+
+/** Same as `s` but for numeric leaves. */
+function n(
+  obj: Record<string, unknown> | null | undefined,
+  ...path: string[]
+): number | null {
+  let cur: unknown = obj;
+  for (const k of path) {
+    if (cur == null || typeof cur !== "object") return null;
+    cur = (cur as Record<string, unknown>)[k];
+  }
+  return typeof cur === "number" ? cur : null;
+}
+
+/** CJK Unified Ideographs (U+4E00–U+9FFF) + Extension A
+ *  (U+3400–U+4DBF). Extension B+ (surrogate pairs) is rare in
+ *  Google Places responses and adds complexity for marginal
+ *  recall — defer until we see an actual case. */
+const CJK_RE = /[一-鿿㐀-䶿]/;
+const CJK_RUN_RE = /[一-鿿㐀-䶿]+/g;
+const LATIN_RE = /[A-Za-z]/;
+
+function hasCJK(str: string): boolean {
+  return CJK_RE.test(str);
+}
+function hasLatin(str: string): boolean {
+  return LATIN_RE.test(str);
+}
+
+/** Step A from prompt.ts:254-267 — keep only the longest
+ *  contiguous CJK run, the rest (Latin / parens / branch
+ *  suffixes) gets discarded. Examples:
+ *
+ *    "Wing Hop Fung(永合豐)Monterey Park Store" → "永合豐"
+ *    "Jiu Ji Dessert (九记八方甜品）"           → "九记八方甜品"
+ *    "Starbucks 星巴克"                         → "星巴克"
+ *    "永合豐"                                   → "永合豐"
+ *    "Costco"                                   → null
+ */
+export function stripToLongestCjkRun(input: string): string | null {
+  const runs = input.match(CJK_RUN_RE);
+  if (!runs || runs.length === 0) return null;
+  // ties → first occurrence wins, which matches the prompt's
+  // "leftmost is usually the brand" intuition for inputs like
+  // "永合豐 Monterey Park 永和" (rare).
+  let best = runs[0]!;
+  for (const r of runs) if (r.length > best.length) best = r;
+  return best;
+}
+
+/** Brands the prompt calls out as "globally-recognized English
+ *  brand whose identity is unambiguously English-first".
+ *  Lowercased; matched against `en_name` after locator-suffix
+ *  stripping. Expand when you find a Chinese gloss masquerading
+ *  as the brand identity, then re-run `re-derive` to fix the
+ *  corpus. The list is INTENTIONALLY conservative — the prompt
+ *  says "when unsure, default true" because false negatives
+ *  (hiding the real brand identity behind a pinyin name) hurt
+ *  more than false positives. */
+const GLOBAL_ENGLISH_BRANDS: ReadonlyArray<string> = [
+  "costco",
+  "walmart",
+  "target",
+  "mcdonald's",
+  "mcdonalds",
+  "whole foods",
+  "trader joe's",
+  "trader joes",
+  "cvs",
+  "usps",
+  "apple",
+  "amazon",
+  "starbucks",
+  "7-eleven",
+  "7 eleven",
+  "seven eleven",
+  "best buy",
+  "home depot",
+  "lowe's",
+  "lowes",
+  "kroger",
+  "ralphs",
+  "albertsons",
+  "safeway",
+];
+
+/** True when the leading brand token of `enName` matches a known
+ *  English-first global brand. Accepts trailing locator junk —
+ *  "Costco #479" / "COSTCO WHOLESALE Monterey Park" both match. */
+function isGlobalEnglishBrand(enName: string): boolean {
+  const cleaned = enName
+    .toLowerCase()
+    // Strip everything from the first store-locator marker on.
+    .replace(/\s*[#(\[].*$/, "")
+    .trim();
+  for (const brand of GLOBAL_ENGLISH_BRANDS) {
+    if (cleaned === brand) return true;
+    if (cleaned.startsWith(brand + " ")) return true;
+  }
+  return false;
+}
+
+/** is_native heuristic from prompt.ts:277-304.
+ *
+ * Default: true. Set false ONLY in the narrow Costco/星巴克 case
+ * where all three conditions hold:
+ *   (a) the zh response's raw displayName is pure CJK (no Latin),
+ *   (b) the en response's displayName is pure Latin (no CJK), AND
+ *   (c) en is one of the globally-English brands we know about.
+ *
+ * Note we test against the **raw** zh displayName (pre-strip), not
+ * the stripped one — the gloss detection cares about whether
+ * Google's response is monolingual CJK, not whether we extracted a
+ * CJK substring after the fact.
+ */
+export function computeIsNative(args: {
+  enName: string | null;
+  zhDisplayNameRaw: string | null;
+}): boolean | null {
+  const { enName, zhDisplayNameRaw } = args;
+  if (zhDisplayNameRaw == null) return null;     // no zh → no flag
+  if (enName == null) return true;                // can't disprove
+  if (hasLatin(zhDisplayNameRaw)) return true;    // mixed zh → native
+  if (hasCJK(enName)) return true;                // en has CJK → native
+  if (!isGlobalEnglishBrand(enName)) return true; // not a known gloss
+  return false;
+}
+
+// ── Main entry point ────────────────────────────────────────────
+
+/** Project the cached Google response into Layer 2 fields.
+ *
+ * Pure function: no DB, no network, no clock side effects. Re-runs
+ * are bit-identical given the same input. */
+export function projectPlace(raw: RawResponseV1 | null): ProjectedPlaceFields {
+  const en = raw?.v1?.en ?? null;
+  const zh = raw?.v1?.["zh-CN"] ?? null;
+
+  const enName = s(en, "displayName", "text");
+  const zhRawName = s(zh, "displayName", "text");
+  const zhLocale = s(zh, "displayName", "languageCode");
+
+  // Phase 3c gate: only honor a zh response when (i) Google
+  // tagged the response with a real CJK locale (not zh-Latn),
+  // and (ii) the displayName actually contains CJK. Without (ii)
+  // Google sometimes returns the Latin name under a `zh` tag for
+  // places that have no native Chinese name.
+  const zhIsChinese =
+    zhLocale != null &&
+    zhLocale.startsWith("zh") &&
+    !zhLocale.startsWith("zh-Latn") &&
+    zhRawName != null &&
+    hasCJK(zhRawName);
+
+  // Step A — strip Latin / branch suffixes; keep the longest CJK
+  // run. If the response was tagged `zh` but the displayName is
+  // entirely Latin (rare; treated above), `zhRawName` would have
+  // failed the `hasCJK` gate already.
+  const zhStripped = zhIsChinese && zhRawName ? stripToLongestCjkRun(zhRawName) : null;
+
+  const isNative = zhStripped
+    ? computeIsNative({ enName, zhDisplayNameRaw: zhRawName })
+    : null;
+
+  const typesRaw = en != null ? (en as Record<string, unknown>).types : null;
+  const ratingNum = n(en, "rating");
+
+  return {
+    display_name_en: enName,
+    display_name_zh: zhStripped,
+    display_name_zh_locale: zhStripped ? zhLocale : null,
+    display_name_zh_source: zhStripped ? "google_text" : null,
+    display_name_zh_is_native: isNative,
+
+    primary_type: s(en, "primaryType"),
+    primary_type_display_zh: s(zh, "primaryTypeDisplayName", "text"),
+    maps_type_label_zh: s(zh, "googleMapsTypeLabel", "text"),
+    types: Array.isArray(typesRaw) ? (typesRaw as string[]) : null,
+
+    formatted_address_en: s(en, "formattedAddress"),
+    formatted_address_zh: s(zh, "formattedAddress"),
+    postal_code: s(en, "postalAddress", "postalCode"),
+    country_code: s(en, "postalAddress", "regionCode"),
+
+    business_status: s(en, "businessStatus"),
+    business_hours:
+      (en as Record<string, unknown> | null)?.regularOpeningHours ?? null,
+    time_zone: s(en, "timeZone", "id"),
+
+    rating: ratingNum != null ? String(ratingNum) : null,
+    user_rating_count: n(en, "userRatingCount"),
+
+    national_phone_number: s(en, "nationalPhoneNumber"),
+    website_uri: s(en, "websiteUri"),
+    google_maps_uri: s(en, "googleMapsUri"),
+  };
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,0 +1,93 @@
+/**
+ * `/v1/admin/*` — operator-facing batch endpoints (#89).
+ *
+ * Phase 2 ships one route: `POST /v1/admin/re-derive?scope=places`,
+ * which walks every `places` row and re-runs Layer 2 projection
+ * over its cached `raw_response`. See `places.service.ts ::
+ * reDeriveAllPlaces` for behavior + skipping rules and
+ * `derivation_events` for the per-row audit trail.
+ *
+ * Auth: none yet. The endpoint reads `req.ctx.workspaceId` from
+ * the seeded single-workspace context — when the auth epic lands,
+ * this router will gate on admin role.
+ *
+ * Future scopes (out of Phase 2 / #89):
+ *   - `scope=merchants`   — re-aggregate brand info (#91)
+ *   - `scope=documents`   — re-OCR with newer model
+ *   - `scope=transactions`— full re-extract (#91)
+ */
+import { type Request, type Response, type NextFunction, Router } from "express";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+
+import { parseOrThrow } from "../http/validate.js";
+import { reDeriveAllPlaces } from "./places.service.js";
+import {
+  ReDeriveQuery,
+  ReDeriveBatchResponse,
+} from "../schemas/v1/place.js";
+import { ProblemDetails } from "../schemas/v1/common.js";
+
+type AsyncHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<unknown>;
+
+function ah(fn: AsyncHandler) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    fn(req, res, next).catch(next);
+  };
+}
+
+export const adminRouter = Router({ mergeParams: true });
+
+adminRouter.post(
+  "/re-derive",
+  ah(async (req, res) => {
+    const { scope } = parseOrThrow(ReDeriveQuery, req.query);
+    // Phase 2 only knows about `places`. The schema enum already
+    // narrows the type, so this switch is here for the structural
+    // slot when more scopes land.
+    switch (scope) {
+      case "places": {
+        const out = await reDeriveAllPlaces(req.ctx.workspaceId);
+        res.json(out);
+        return;
+      }
+    }
+  }),
+);
+
+export function registerAdminOpenApi(registry: OpenAPIRegistry): void {
+  const problemContent = {
+    "application/problem+json": { schema: ProblemDetails },
+  };
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/admin/re-derive",
+    summary: "Re-run Layer 2 projection across every row in scope.",
+    description:
+      "Phase 2 (#89): scope=places walks every `places` row and " +
+      "re-runs the projection over its cached `raw_response`. Rows " +
+      "with `raw_response IS NULL` are counted as `skipped` (not " +
+      "errored). Each updated row produces a `derivation_events` " +
+      "entry — including no-op runs that match the current state, " +
+      "so a version bump is auditable even when nothing visibly " +
+      "changes. Sync execution at current corpus scale (<1 s for " +
+      "tens to low hundreds of places).",
+    tags: ["admin"],
+    request: { query: ReDeriveQuery },
+    responses: {
+      200: {
+        description: "Batch summary",
+        content: { "application/json": { schema: ReDeriveBatchResponse } },
+      },
+      422: {
+        description: "Invalid scope",
+        content: problemContent,
+      },
+    },
+  });
+}

--- a/src/routes/places.service.ts
+++ b/src/routes/places.service.ts
@@ -13,6 +13,17 @@
 import { and, eq, inArray, sql, isNotNull } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { places, placePhotos } from "../schema/places.js";
+import { derivationEvents } from "../schema/derivation_events.js";
+import {
+  PROJECTION_MODEL,
+  PROJECTION_VERSION,
+  projectPlace,
+  type ProjectedPlaceFields,
+  type RawResponseV1,
+} from "../projection/derive.js";
+import { PROMPT_VERSION } from "../ingest/prompt.js";
+import { buildInfo } from "../generated/build-info.js";
+import { NoRawResponseProblem } from "../http/problem.js";
 
 /**
  * Public-facing shape of a place. Mirrors the v1 zod Place schema —
@@ -194,6 +205,296 @@ export async function updatePlace(
     .returning();
   if (rows.length === 0) return null;
   return loadPlaceById(id);
+}
+
+// ── Re-derive (#89) ────────────────────────────────────────────────
+
+/** Keys in `ProjectedPlaceFields` that re-derive is eligible to
+ *  touch. Reused for the `before` / `after` snapshots and the
+ *  `changed_keys[]` diff in `derivation_events`. */
+const PROJECTED_KEYS = [
+  "display_name_en",
+  "display_name_zh",
+  "display_name_zh_locale",
+  "display_name_zh_source",
+  "display_name_zh_is_native",
+  "primary_type",
+  "primary_type_display_zh",
+  "maps_type_label_zh",
+  "types",
+  "formatted_address_en",
+  "formatted_address_zh",
+  "postal_code",
+  "country_code",
+  "business_status",
+  "business_hours",
+  "time_zone",
+  "rating",
+  "user_rating_count",
+  "national_phone_number",
+  "website_uri",
+  "google_maps_uri",
+] as const satisfies ReadonlyArray<keyof ProjectedPlaceFields>;
+
+/** True when `display_name_zh` was set by reading the merchant's
+ *  own surface (storefront photo, receipt header) rather than by
+ *  projecting Google's response. Those sources are outside this
+ *  module's input domain — re-derive must preserve them, not
+ *  overwrite them with `NULL` just because Google has no Chinese. */
+function isOcrSourcedZh(source: string | null | undefined): boolean {
+  return source === "photo_ocr" || source === "receipt_ocr";
+}
+
+/** Pick the Layer 2 keys from a `places` row into the JSON shape
+ *  we put on `derivation_events.before / .after`. Drizzle returns
+ *  `numeric` as `string`; we keep it as-is so a re-derive that
+ *  hands back the same numeric value produces an exact diff hit. */
+function snapshotProjectedFields(
+  row: typeof places.$inferSelect,
+): ProjectedPlaceFields {
+  return {
+    display_name_en: row.displayNameEn,
+    display_name_zh: row.displayNameZh,
+    display_name_zh_locale: row.displayNameZhLocale,
+    display_name_zh_source:
+      (row.displayNameZhSource as ProjectedPlaceFields["display_name_zh_source"]) ?? null,
+    display_name_zh_is_native: row.displayNameZhIsNative,
+    primary_type: row.primaryType,
+    primary_type_display_zh: row.primaryTypeDisplayZh,
+    maps_type_label_zh: row.mapsTypeLabelZh,
+    types: row.types,
+    formatted_address_en: row.formattedAddressEn,
+    formatted_address_zh: row.formattedAddressZh,
+    postal_code: row.postalCode,
+    country_code: row.countryCode,
+    business_status: row.businessStatus,
+    business_hours: row.businessHours,
+    time_zone: row.timeZone,
+    rating: row.rating,
+    user_rating_count: row.userRatingCount,
+    national_phone_number: row.nationalPhoneNumber,
+    website_uri: row.websiteUri,
+    google_maps_uri: row.googleMapsUri,
+  };
+}
+
+/** Equality test for projection field values. Arrays compare
+ *  element-wise; everything else uses `===`. JSON values
+ *  (business_hours) compare by JSON.stringify — good enough since
+ *  the projection is deterministic and emits stable key orders. */
+function projectedFieldEq(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => v === b[i]);
+  }
+  if (typeof a === "object" || typeof b === "object") {
+    try {
+      return JSON.stringify(a) === JSON.stringify(b);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+export interface ReDeriveResult {
+  /** Internal UUID of the place row. */
+  place_id: string;
+  /** Always present in the response. Empty array means the
+   *  projection happened to match the current row; `derivation_event_id`
+   *  is still set (we audit the no-op run too — see schema header). */
+  changed_keys: string[];
+  /** UUID of the `derivation_events` row written by this call. */
+  derivation_event_id: string;
+}
+
+/**
+ * Re-run the Layer 2 projection over a single `places` row's cached
+ * `raw_response` and commit the result.
+ *
+ * Behavior contract (Phase 2 / #89):
+ *   - 422 `NoRawResponseProblem` when `raw_response IS NULL`.
+ *   - `places.custom_name_zh` is NEVER in the UPDATE column list
+ *     (Layer 3 user-truth — see schema header).
+ *   - When the current `display_name_zh_source` is `'photo_ocr'`
+ *     or `'receipt_ocr'`, the four zh-related fields are preserved
+ *     verbatim (the projection only handles Google-source data).
+ *   - All other projection fields are direct overwrites (NOT
+ *     COALESCE) — this is the whole point of re-derive: the new
+ *     projection's value, including `NULL`, wins.
+ *   - `places.metadata.derivation` is stamped with the current
+ *     `PROJECTION_VERSION` + `buildInfo.gitSha` + run timestamp.
+ *   - A `derivation_events` row is INSERTED inside the same
+ *     transaction as the UPDATE — never one without the other.
+ *
+ * `placeId` accepts either the internal UUID `id` or Google's
+ * stable `google_place_id`, matching `loadPlaceById`.
+ */
+export async function reDerivePlace(
+  workspaceId: string,
+  placeId: string,
+): Promise<ReDeriveResult | null> {
+  const isUuid =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      placeId,
+    );
+  const rows = await db
+    .select()
+    .from(places)
+    .where(isUuid ? eq(places.id, placeId) : eq(places.googlePlaceId, placeId));
+  if (rows.length === 0) return null;
+  const row = rows[0]!;
+
+  if (row.rawResponse == null) {
+    throw new NoRawResponseProblem(row.id);
+  }
+
+  const before = snapshotProjectedFields(row);
+  const projected = projectPlace(row.rawResponse as RawResponseV1);
+
+  // Policy: preserve OCR-sourced zh fields. The projection only
+  // looks at Google's response, but a row's zh name may have come
+  // from a storefront photo / receipt OCR. Don't reclassify those
+  // back to NULL just because Google has no Chinese.
+  if (isOcrSourcedZh(row.displayNameZhSource)) {
+    projected.display_name_zh = before.display_name_zh;
+    projected.display_name_zh_locale = before.display_name_zh_locale;
+    projected.display_name_zh_source = before.display_name_zh_source;
+    projected.display_name_zh_is_native = before.display_name_zh_is_native;
+  }
+
+  const changedKeys: string[] = [];
+  for (const k of PROJECTED_KEYS) {
+    if (!projectedFieldEq(before[k], projected[k])) changedKeys.push(k);
+  }
+
+  const ranAt = new Date();
+  const derivation = {
+    projection_version: PROJECTION_VERSION,
+    prompt_git_sha: buildInfo.gitSha,
+    model: PROJECTION_MODEL,
+    ran_at: ranAt.toISOString(),
+  };
+
+  return await db.transaction(async (tx) => {
+    const [evt] = await tx
+      .insert(derivationEvents)
+      .values({
+        workspaceId,
+        entityType: "place",
+        entityId: row.id,
+        promptVersion: PROMPT_VERSION,
+        promptGitSha: buildInfo.gitSha,
+        model: PROJECTION_MODEL,
+        ranAt,
+        before: before as unknown as Record<string, unknown>,
+        after: projected as unknown as Record<string, unknown>,
+        changedKeys,
+      })
+      .returning({ id: derivationEvents.id });
+
+    await tx
+      .update(places)
+      .set({
+        displayNameEn: projected.display_name_en,
+        displayNameZh: projected.display_name_zh,
+        displayNameZhLocale: projected.display_name_zh_locale,
+        displayNameZhSource: projected.display_name_zh_source,
+        displayNameZhIsNative: projected.display_name_zh_is_native,
+        primaryType: projected.primary_type,
+        primaryTypeDisplayZh: projected.primary_type_display_zh,
+        mapsTypeLabelZh: projected.maps_type_label_zh,
+        types: projected.types,
+        formattedAddressEn: projected.formatted_address_en,
+        formattedAddressZh: projected.formatted_address_zh,
+        postalCode: projected.postal_code,
+        countryCode: projected.country_code,
+        businessStatus: projected.business_status,
+        businessHours: projected.business_hours,
+        timeZone: projected.time_zone,
+        rating: projected.rating,
+        userRatingCount: projected.user_rating_count,
+        nationalPhoneNumber: projected.national_phone_number,
+        websiteUri: projected.website_uri,
+        googleMapsUri: projected.google_maps_uri,
+        // Layer-3 (customNameZh) and physical facts (lat/lng,
+        // formattedAddress) are intentionally absent — see
+        // service header.
+        metadata: sql`jsonb_set(COALESCE(${places.metadata}, '{}'::jsonb), '{derivation}', ${JSON.stringify(derivation)}::jsonb)`,
+      })
+      .where(eq(places.id, row.id));
+
+    return {
+      place_id: row.id,
+      changed_keys: changedKeys,
+      derivation_event_id: evt!.id,
+    };
+  });
+}
+
+/**
+ * Iterate every `places` row and re-derive in sequence. Per #89
+ * out-of-scope, this is sync — at the current corpus size (~tens
+ * of places) it finishes in <1 s. Async / queued is Phase 4.
+ *
+ * Rows with `raw_response IS NULL` are skipped (NOT errored —
+ * mirrors the single-place 422 semantically: nothing to project
+ * from, so nothing to update). Rows where the projection happens
+ * to match the current row are counted as `updated` because we
+ * still write a `derivation_events` row marking the version bump.
+ */
+export interface ReDeriveBatchResult {
+  scope: "places";
+  total: number;
+  updated: number;
+  skipped: number;
+  errors: Array<{ id: string; message: string }>;
+  ran_at: string;
+}
+
+export async function reDeriveAllPlaces(
+  workspaceId: string,
+): Promise<ReDeriveBatchResult> {
+  const startedAt = new Date();
+  const rows = await db
+    .select({ id: places.id, hasRaw: sql<boolean>`raw_response IS NOT NULL` })
+    .from(places);
+
+  const result: ReDeriveBatchResult = {
+    scope: "places",
+    total: rows.length,
+    updated: 0,
+    skipped: 0,
+    errors: [],
+    ran_at: startedAt.toISOString(),
+  };
+
+  for (const r of rows) {
+    if (!r.hasRaw) {
+      result.skipped += 1;
+      continue;
+    }
+    try {
+      const out = await reDerivePlace(workspaceId, r.id);
+      if (out == null) {
+        // Row vanished between the SELECT and the re-derive. Race
+        // is harmless — count as error so the operator sees it.
+        result.errors.push({ id: r.id, message: "row not found" });
+      } else {
+        result.updated += 1;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      result.errors.push({ id: r.id, message });
+    }
+  }
+
+  console.info(
+    `[re-derive] scope=places total=${result.total} updated=${result.updated} skipped=${result.skipped} errors=${result.errors.length}`,
+  );
+  return result;
 }
 
 /**

--- a/src/routes/places.ts
+++ b/src/routes/places.ts
@@ -23,10 +23,12 @@ import {
   loadPlaceById,
   updatePlace,
   loadPlacePhotoForStream,
+  reDerivePlace,
 } from "./places.service.js";
 import {
   Place,
   UpdatePlaceRequest,
+  ReDerivePlaceResponse,
 } from "../schemas/v1/place.js";
 import { ProblemDetails, Uuid } from "../schemas/v1/common.js";
 import { z } from "zod";
@@ -63,6 +65,16 @@ placesRouter.patch(
     const place = await updatePlace(id, patch);
     if (!place) throw new NotFoundProblem("Place", id);
     res.json(place);
+  }),
+);
+
+placesRouter.post(
+  "/:id/re-derive",
+  ah(async (req, res) => {
+    const id = String(req.params.id);
+    const result = await reDerivePlace(req.ctx.workspaceId, id);
+    if (!result) throw new NotFoundProblem("Place", id);
+    res.json(result);
   }),
 );
 
@@ -133,6 +145,34 @@ export function registerPlacesOpenApi(registry: OpenAPIRegistry): void {
     responses: {
       200: { description: "Updated", content: { "application/json": { schema: Place } } },
       404: { description: "Not found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/places/{id}/re-derive",
+    summary: "Re-run Layer 2 projection over cached raw_response.",
+    description:
+      "Re-applies the current projection logic to the cached Google " +
+      "Places response, overwriting derived columns. Layer 3 user-truth " +
+      "(`custom_name_zh`) is never touched. OCR-sourced zh fields " +
+      "(`display_name_zh_source IN ('photo_ocr','receipt_ocr')`) are " +
+      "preserved verbatim. Every run inserts a `derivation_events` row " +
+      "with a `before`/`after` jsonb diff; the returned " +
+      "`derivation_event_id` lets you correlate. Returns 422 when " +
+      "`raw_response` is NULL.",
+    tags: ["places"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: {
+        description: "Re-derive committed",
+        content: { "application/json": { schema: ReDerivePlaceResponse } },
+      },
+      404: { description: "Place not found", content: problemContent },
+      422: {
+        description: "Place has no raw_response — nothing to project from",
+        content: problemContent,
+      },
     },
   });
 

--- a/src/schema/derivation_events.ts
+++ b/src/schema/derivation_events.ts
@@ -1,0 +1,97 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  jsonb,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { workspaces } from "./workspaces.js";
+
+/**
+ * Append-only audit log for Layer 2 re-derivations (#80 / #89).
+ *
+ * Every overwrite of a derived ("Layer 2") field — by `POST
+ * /v1/places/:id/re-derive`, `POST /v1/admin/re-derive`, future
+ * `/v1/documents/:id/re-extract` (#91), or any subsequent
+ * derivation path — inserts a row here BEFORE the UPDATE lands.
+ * The row carries (a) which entity changed, (b) the prompt /
+ * model version under which the new derivation ran, and (c) the
+ * field-level `before` / `after` diff.
+ *
+ * Why an audit table rather than versioning Layer 2 itself:
+ * Layer 2 stays a flat snapshot that downstream joins read
+ * cheaply; the audit log is queried only when (a) we want to
+ * diff a projection-version bump after the fact, or (b) we want
+ * to roll back a bad re-derivation by writing the `before` jsonb
+ * back. Both are rare operations — putting their cost into a
+ * separate, ran_at-indexed table keeps the hot path clean.
+ *
+ * `entity_id` is `text` (not `uuid`) deliberately: for `place`
+ * events we sometimes audit by `google_place_id` (a `ChIJ…`
+ * string), and future `document` / `transaction` events use
+ * UUIDs. A text column accepts both without an extra join.
+ *
+ * Layer-3 user-truth columns (e.g. `places.custom_name_zh`,
+ * `documents.deleted_at`) are NEVER part of `before` / `after`
+ * — re-derive omits them from the UPDATE entirely, so they
+ * never reach this table. This is enforced at the service layer,
+ * not the DB layer; new Layer-3 fields must be added to the
+ * service-side allowlist when introduced.
+ */
+export const derivationEvents = pgTable(
+  "derivation_events",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    /** Workspace whose action triggered the re-derivation. For
+     *  shared-across-workspaces entities like `places`, this is the
+     *  requester's workspace, not an entity property. */
+    workspaceId: uuid("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    /** `'place'` (Phase 2 / #89). Future: `'merchant'` (#91),
+     *  `'document'`, `'transaction'`, `'place_photo'`. */
+    entityType: text("entity_type").notNull(),
+    /** Stable identifier of the affected row. For `place` events
+     *  this is the `places.id` UUID. */
+    entityId: text("entity_id").notNull(),
+    /** `PROMPT_VERSION` constant at the time of the run. */
+    promptVersion: text("prompt_version").notNull(),
+    /** `buildInfo.gitSha` — exactly which commit's projection
+     *  code produced the new values. */
+    promptGitSha: text("prompt_git_sha").notNull(),
+    /** Model identifier. Phase 2 uses a deterministic TS
+     *  projection (no LLM call), so this is `'ts-deterministic'`;
+     *  future LLM-backed re-derives stamp the actual model name. */
+    model: text("model").notNull(),
+    ranAt: timestamp("ran_at", { withTimezone: true })
+      .notNull()
+      .default(sql`NOW()`),
+    /** JSON object: the Layer-2 field values before the UPDATE,
+     *  restricted to the keys this run was eligible to touch. */
+    before: jsonb("before").notNull(),
+    /** JSON object: the Layer-2 field values after the UPDATE.
+     *  Diff against `before` to recover `changed_keys`. */
+    after: jsonb("after").notNull(),
+    /** Keys whose value actually changed (i.e.
+     *  `before[k] !== after[k]`). A row may have zero changed
+     *  keys — re-derive still writes the event so we can see
+     *  that a version bump touched the row even when the new
+     *  projection happened to match the old. */
+    changedKeys: text("changed_keys").array().notNull(),
+  },
+  (t) => [
+    // Browse-by-entity: "show me every re-derivation of place X".
+    index("derivation_events_entity_idx").on(
+      t.entityType,
+      t.entityId,
+      t.ranAt,
+    ),
+    // Audit-by-version: "how many rows did prompt_version 2.6 touch?"
+    index("derivation_events_version_idx").on(
+      t.promptVersion,
+      t.ranAt,
+    ),
+  ],
+);

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -12,3 +12,4 @@ export * from "./ingests.js";
 export * from "./reconcile_proposals.js";
 export * from "./places.js";
 export * from "./merchants.js";
+export * from "./derivation_events.js";

--- a/src/schema/places.ts
+++ b/src/schema/places.ts
@@ -136,6 +136,17 @@ export const places = pgTable(
     yelpPriceLevel: text("yelp_price_level"),
     yelpCategories: jsonb("yelp_categories"),
     yelpRawResponse: jsonb("yelp_raw_response"),
+
+    /**
+     * Provenance + ad-hoc metadata bag. Phase 2 (#89) writes
+     * `metadata.derivation = { projection_version, prompt_git_sha,
+     * model, ran_at }` on every re-derive; mirrors the
+     * `transactions.metadata.extraction` pattern shipped in #88.
+     * Field-level audit lives in `derivation_events`; this column
+     * just answers "what projection produced the current row?"
+     * without a join.
+     */
+    metadata: jsonb("metadata"),
   },
   (t) => [
     // Geo-bbox filtering for future trip clustering. Btree on (lat, lng)

--- a/src/schemas/v1/place.ts
+++ b/src/schemas/v1/place.ts
@@ -88,3 +88,51 @@ export const UpdatePlaceRequest = z
     custom_name_zh: z.string().nullable().optional(),
   })
   .openapi("UpdatePlaceRequest");
+
+/**
+ * Response from `POST /v1/places/:id/re-derive` (#89). Reports
+ * what the projection rerun changed; the operator can correlate
+ * `derivation_event_id` against the `derivation_events` audit log
+ * for the full `before` / `after` jsonb.
+ */
+export const ReDerivePlaceResponse = z
+  .object({
+    place_id: Uuid,
+    changed_keys: z.array(z.string()),
+    derivation_event_id: Uuid,
+  })
+  .openapi("ReDerivePlaceResponse");
+
+/**
+ * Query params for `POST /v1/admin/re-derive`. Only `scope=places`
+ * is implemented in Phase 2 (#89); Phase 3+ will add `merchants`,
+ * `documents`, and the LLM-backed paths.
+ */
+export const ReDeriveQuery = z
+  .object({
+    scope: z.enum(["places"]).default("places"),
+  })
+  .openapi("ReDeriveQuery");
+
+/**
+ * Response from `POST /v1/admin/re-derive`. `updated` counts rows
+ * whose UPDATE landed (including no-op runs that still get a
+ * `derivation_events` row); `skipped` counts rows with no
+ * `raw_response` to project from; `errors` carries per-row
+ * exceptions so a partial batch is debuggable.
+ */
+export const ReDeriveBatchResponse = z
+  .object({
+    scope: z.enum(["places"]),
+    total: z.number().int(),
+    updated: z.number().int(),
+    skipped: z.number().int(),
+    errors: z.array(
+      z.object({
+        id: z.string(),
+        message: z.string(),
+      }),
+    ),
+    ran_at: z.string(),
+  })
+  .openapi("ReDeriveBatchResponse");


### PR DESCRIPTION
## Summary

Phase 2 of the 3-layer data-model rollout (#80). Adds two endpoints that re-run Layer 2 projection over `places.raw_response` — no Google / Yelp / Anthropic calls in the hot path.

```
POST /v1/places/{id}/re-derive          # single place
POST /v1/admin/re-derive?scope=places   # batch over every place
```

Both go through one shared `reDerivePlace(workspaceId, placeId)` service that runs deterministic TS projection, diffs against current, audits the run, and commits.

## Architecture decisions

Two judgment calls made with the user during planning, both documented in the new "Backfill / re-derivation — `places`" section of `CLAUDE.md`:

**1 — Pure-TS projection, not LLM-per-place.** All projection rules from `src/ingest/prompt.ts:213-720` (CJK extraction, branch-suffix stripping, `is_native` heuristic) port cleanly into deterministic TS in `src/projection/derive.ts ::projectPlace`. The AI-native principle still holds — OCR, extraction, merchant aggregation at ingest are still LLM-driven. The re-derive step specifically stays cheap so it can run frequently without burning Anthropic credits or adding 5–15 s of latency × N to the batch path. Per-place LLM was considered and rejected; existing production-tested `derive(en, zh)` in `scripts/backfill-multilingual-places.ts` already covered ~90 % of the projection, the rest extends it.

**2 — No merchants cascade.** Originally planned the cascade (places → merchants re-aggregate), but file reads revealed `merchants.canonical_name`/`brand_id`/`category` come from LLM-on-receipt at ingest, and `merchants.address`/`lat`/`lng` come from a separate `findPlaceFromText` call in `src/enrichment/merchants.ts`. Neither depends on `places` projection output. Cascading would be dead code. The cascade slot belongs to #91 (re-extract), where re-reading the receipt with new place data can plausibly change `canonical_name`.

## What this PR adds

| Piece | Where |
|---|---|
| Migration: `places.metadata` jsonb + `derivation_events` table | `drizzle/0011_phase2_re_derive.sql` |
| Drizzle schema for the audit log | `src/schema/derivation_events.ts` |
| Deterministic projection (`projectPlace`) | `src/projection/derive.ts` |
| `reDerivePlace` + `reDeriveAllPlaces` service | `src/routes/places.service.ts` |
| `NoRawResponseProblem` (RFC 7807, 422) | `src/http/problem.ts` |
| `POST /v1/places/{id}/re-derive` route | `src/routes/places.ts` |
| `POST /v1/admin/re-derive` route + router | `src/routes/admin.ts` |
| Zod schemas | `src/schemas/v1/place.ts` |
| OpenAPI registration | `src/openapi.ts`, regenerated `openapi/openapi.json` |
| CLAUDE.md "Backfill / re-derivation" subsection | `CLAUDE.md` |

## Field-write policy

- **Layer 3** (`places.custom_name_zh`) explicitly omitted from the UPDATE column list. New Layer 3 fields must be added to the allowlist in `reDerivePlace`. Mirrors the existing pattern in `src/ingest/prompt.ts:712-713`.
- **OCR-sourced zh fields** (`display_name_zh_source IN ('photo_ocr','receipt_ocr')`) preserved verbatim — projection's input domain is Google data only.
- **All other projection fields**: direct overwrite (NOT COALESCE). Re-derive is authoritative; `NULL` is a valid new value.
- **Physical facts** (`lat`/`lng`/legacy `formatted_address`) never touched.

## Audit log shape

```sql
SELECT entity_id, prompt_version, prompt_git_sha, model, ran_at, changed_keys
  FROM derivation_events
 WHERE entity_type = 'place' AND entity_id = $1
 ORDER BY ran_at DESC;
```

Every re-derive INSERTs one row BEFORE the UPDATE, in the same transaction. Even no-op runs (`changed_keys=[]`) write an event — so a version bump that produces no visible change is still auditable and gives a known-good checkpoint.

## Test plan

All 5 scenarios from `/Users/danieltang/.claude/plans/89-phase-2-breezy-gizmo.md` ran against the live local stack (commit `4eb88ad9`, 82-place corpus):

- [x] Single re-derive — 200 OK, `derivation_event_id` returned
- [x] **Layer 3 preserved** — seeded `custom_name_zh='小测试守护'`, untouched after re-derive
- [x] **OCR-source preserved** — `display_name_zh='永安'` / `source=photo_ocr` for Wing On Market untouched (no `displayName.zh` in raw_response)
- [x] **422 path** — `UPDATE places SET raw_response=NULL` then POST → 422 `application/problem+json` with `type=https://receipts.dev/errors/place-no-raw-response`
- [x] **Forced change** — cleared `display_name_en`, re-derive restored it from raw_response, `changed_keys=["display_name_en"]`
- [x] **Batch** — `total=82, updated=82, skipped=0, errors=[]`
- [x] **Provenance** — `derivation_events` rows all stamped with `PROMPT_VERSION=2.5`, `prompt_git_sha=4eb88ad…`, `model=ts-deterministic`
- [x] **is_native heuristic spot-check** — Starbucks → `false` (gloss); every Chinese-owned merchant in the corpus → `true`
- [x] `npx tsc --noEmit` clean
- [x] OpenAPI spec regenerated (`41 paths, 70 schemas`)
- [x] Doc-sync sweep across all `*.md` — no stale "Phase 2 not implemented" references

## Out of scope

Per #80 phases:
- Async / job-queued batch reprocessing (Phase 4+)
- Re-fetching Google / Yelp (Phase 4)
- Re-running photo OCR / vision LLM (Phase 4)
- Re-deriving `documents.ocr_text` (needs `ocr_model_version` column first)
- Frontend trigger UI (Phase 5)
- `places.custom_name_zh` → `custom_name` rename (#79)
- Merchant cascade (#91 will own this)

## Impact / Relation

- Fixes #89
- Tracks #80
- Depends on #88 (Phase 1 provenance, already shipped) for the `PROMPT_VERSION` / `buildInfo.gitSha` plumbing reused here
- Unblocks #91 (re-extract endpoint) — the audit + provenance plumbing is shared

🤖 Generated with [Claude Code](https://claude.com/claude-code)