### PR TITLE
feat(documents): re-extract endpoint — re-OCR + UPDATE linked tx in place (#91)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,63 @@ Re-extract only needs to know *whether* the user has touched a field. The timest
 - Writer side of `metadata.user_edited` flagging in `updateTransaction`
 - `derivation_events` rows with `entity_type='document'` (the audit-table extension was already designed into #89's schema)
 
+## Re-extract — `documents` (Phase 4c of #80)
+
+Phase 4c of the 3-layer data-model rollout ([#80](https://github.com/TINKPA/receipt-assistant/issues/80) / [#91](https://github.com/TINKPA/receipt-assistant/issues/91), last sub-PR — closes #91).
+
+```
+POST /v1/documents/{id}/re-extract    # re-OCR + UPDATE linked transaction
+```
+
+### What it does
+
+1. Resolves the linked transaction via `document_links` (errors 422 on zero or >1 links — we don't pick).
+2. Snapshots Layer-2 transaction fields (`payee`, `occurred_on`, `occurred_at`, `metadata.extraction`) + `documents.ocr_text` + `documents.ocr_model_version` BEFORE.
+3. Spawns `claude -p` with `src/ingest/reextract-prompt.ts ::buildReExtractPrompt` — a narrow prompt that tells the agent to UPDATE the existing transaction by id, NOT INSERT a new one.
+4. Agent re-reads the receipt image and runs one psql block:
+   - `UPDATE transactions` with Layer-3 CASE shielding (see below)
+   - `UPDATE documents` setting `ocr_text` + `ocr_model_version`
+   - `INSERT INTO transaction_events` with `event_type='re_extracted'`
+5. Snapshots AFTER, computes diff, writes one `derivation_events` row with `entity_type='document'`.
+
+### Layer-3 shielding (the safety contract)
+
+**HARD Layer 3** (`HARD_LAYER3_TX_FIELDS` in `src/projection/layer3.ts`): `status`, `voided_by_id`, `trip_id`, `narration`, `id`, `workspace_id`, `source_ingest_id`, `created_by`, `created_at`, `version`. The prompt's UPDATE doesn't mention these columns at all (omission = perfect shielding). `version` is the lone exception — re-extract always bumps it via `version + 1` to advance optimistic-concurrency.
+
+**SOFT Layer 3** (`SOFT_LAYER3_TX_FIELDS`): `payee`, `occurred_on`, `occurred_at`. The agent generates new values but the SQL wraps them in CASE expressions:
+
+```sql
+payee = CASE
+  WHEN (metadata->'user_edited'->>'payee')::boolean IS TRUE THEN payee
+  ELSE '<NEW_PAYEE>'
+END
+```
+
+`metadata.user_edited.<field> = true` is set by `updateTransaction` (PATCH path) whenever the user changes that field. The flag survives re-extract; once flagged, the field is read-only to re-extract forever (the user can re-flag by PATCHing back to the new agent value if they want re-extract to take over again).
+
+### What's NOT included (deferred)
+
+- **Postings rewrite.** Re-extract does not DELETE+INSERT `postings` for the transaction. Reason: postings carry the sum-to-zero ledger invariant; re-running extraction could produce different categories / amounts and risk balance violations. If category drift matters, edit postings explicitly via the postings endpoints. A later scope (call it 91d) can extend re-extract to safely rewrite postings inside a balance-checking transaction.
+- **`place_id` / `merchant_id`.** Place refresh is `POST /v1/places/:id/refresh` (Phase 4a). Merchant aggregation has its own enrichment loop.
+- **`document_links` rebuild.** The link is already correct — re-extract doesn't change which document points to which transaction.
+
+### Error shapes
+
+| Condition | Status | `type` |
+|---|---|---|
+| Document not found (or soft-deleted) | 404 | `errors/not-found` |
+| Document has no `file_path` | 422 | `errors/document-no-file-path` |
+| Document linked to zero transactions | 422 | `errors/document-no-transaction` |
+| Document linked to >1 transaction | 422 | `errors/document-multiple-transactions` (carries `transaction_ids[]`) |
+
+### Observability
+
+The `session_id` field in the response is the pre-allocated UUID passed to `claude -p`; query the Langfuse trace API at `http://localhost:3333/api/public/traces?sessionId=<X>` to inspect the model's reasoning and the SQL it wrote. Re-extract follows the same Langfuse pattern as ingest — no UI scraping, REST only.
+
+### Idempotency, sort of
+
+Re-running re-extract on the same document with the same `REEXTRACT_PROMPT_VERSION` and model should produce no Layer-2 diff in the *transaction* (the agent should produce the same payee/date). It will always produce a `metadata.extraction` diff (the `ran_at` timestamp moves) and may produce an `ocr_text` diff (vision OCR is not 100% deterministic — punctuation, line-break differences). The `derivation_events` row is written every time regardless, so the audit trail tracks every re-run.
+
 ## Known Pitfalls
 
 1. **`--json-schema` degrades OCR accuracy vs plain-text output**:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1104,7 +1104,8 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Model identifier under which ocr_text was produced. NULL on legacy rows."
           },
           "extraction_meta": {
             "type": [
@@ -2724,6 +2725,48 @@
             ]
           }
         }
+      },
+      "ReExtractDocumentResponse": {
+        "type": "object",
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "transaction_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "derivation_event_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "changed_keys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ocr_text_changed": {
+            "type": "boolean"
+          },
+          "session_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          }
+        },
+        "required": [
+          "document_id",
+          "transaction_id",
+          "derivation_event_id",
+          "changed_keys",
+          "ocr_text_changed",
+          "session_id"
+        ]
       },
       "UpdatePlaceRequest": {
         "type": "object",
@@ -4693,6 +4736,59 @@
           },
           "404": {
             "description": "Document not found or not deleted",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/documents/{id}/re-extract": {
+      "post": {
+        "summary": "Re-OCR the receipt and UPDATE the linked transaction in place.",
+        "description": "Phase 4c of the 3-layer rollout (#80 / #91). Spawns `claude -p` with a narrow re-extract prompt; the agent reads the cached image bytes and refreshes `transactions.{payee, occurred_on, occurred_at, metadata.extraction}` plus `documents.{ocr_text, ocr_model_version}`. **Out of scope**: postings, place_id, merchant_id, document_links — those have their own paths. **Layer-3 shielded**: HARD fields (status, narration, trip_id, identity columns) never touched; SOFT fields (occurred_on, occurred_at, payee) protected by `metadata.user_edited.<field>` CASE expressions, so user PATCH overrides survive. Returns 422 if the document has zero or >1 linked transactions.",
+        "tags": [
+          "documents"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Re-extract committed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReExtractDocumentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Document not found or soft-deleted",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Document not linked to exactly one transaction, or has no file_path",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/src/ingest/extractor.ts
+++ b/src/ingest/extractor.ts
@@ -9,6 +9,10 @@
 import { spawn } from "child_process";
 import { randomUUID } from "crypto";
 import { buildExtractorPrompt, type ExtractorPromptContext } from "./prompt.js";
+import {
+  buildReExtractPrompt,
+  type ReExtractPromptContext,
+} from "./reextract-prompt.js";
 
 const CLAUDE_TIMEOUT_MS = Number(process.env.CLAUDE_TIMEOUT_MS ?? 300_000);
 
@@ -109,6 +113,47 @@ export const defaultClaudeExtractor: Extractor = async (input) => {
     userId: input.userId,
   };
   const prompt = buildExtractorPrompt(ctx);
+  const stdout = await runClaude(prompt, sessionId, CLAUDE_TIMEOUT_MS);
+  return { sessionId, stdout };
+};
+
+// ── Re-extract path (Phase 4c of #80 / #91) ────────────────────────────
+
+export interface ReExtractorInput {
+  /** Absolute path on disk for the original upload. */
+  filePath: string;
+  workspaceId: string;
+  /** Document row whose `ocr_text` / `ocr_model_version` re-extract refreshes. */
+  documentId: string;
+  /** Transaction row re-extract UPDATEs in place. */
+  transactionId: string;
+  /** Owner user id, recorded in `transaction_events`. */
+  userId: string;
+}
+
+export interface ReExtractorResult {
+  sessionId: string;
+  stdout: string;
+}
+
+export type ReExtractor = (input: ReExtractorInput) => Promise<ReExtractorResult>;
+
+/**
+ * Re-extract spawn — same shape as `defaultClaudeExtractor` but with
+ * the narrower re-extract prompt (no classify, no postings, no place
+ * fetch). The agent writes directly to Postgres via psql; this fn
+ * just spawns + waits.
+ */
+export const defaultClaudeReExtractor: ReExtractor = async (input) => {
+  const sessionId = randomUUID();
+  const ctx: ReExtractPromptContext = {
+    filePath: input.filePath,
+    workspaceId: input.workspaceId,
+    documentId: input.documentId,
+    transactionId: input.transactionId,
+    userId: input.userId,
+  };
+  const prompt = buildReExtractPrompt(ctx);
   const stdout = await runClaude(prompt, sessionId, CLAUDE_TIMEOUT_MS);
   return { sessionId, stdout };
 };

--- a/src/ingest/reextract-prompt.ts
+++ b/src/ingest/reextract-prompt.ts
@@ -1,0 +1,190 @@
+/**
+ * Re-extract prompt — the agent re-reads an already-ingested receipt
+ * and UPDATEs the existing transaction in place.
+ *
+ * Scope decision (Phase 4c of #80 / #91 MVP):
+ *   - Re-extract = re-OCR the receipt against the **current** prompt
+ *     and model. Refines payee, occurred_on, occurred_at, currency,
+ *     total_minor on the existing transaction; refreshes `documents.ocr_text`.
+ *   - It does NOT touch postings — re-running extraction could change
+ *     category/amount and risk the double-entry sum-to-zero invariant.
+ *     If category drift matters, edit postings explicitly via the
+ *     postings endpoints. A later 91d-style scope can extend re-extract
+ *     to safely rewrite postings (DELETE + INSERT in one tx with
+ *     balance re-check).
+ *   - It does NOT touch `place_id` / `merchant_id`. Place refresh is
+ *     `POST /v1/places/:id/refresh` (91a). Merchant aggregation is its
+ *     own enrichment loop.
+ *
+ * Layer-3 shielding (matches `src/projection/layer3.ts`):
+ *   - HARD fields (status, voided_by_id, trip_id, narration, identity,
+ *     version) are NEVER in the UPDATE column list — extraction can't
+ *     even mention them.
+ *   - SOFT fields (occurred_on, occurred_at, payee) use a CASE WHEN
+ *     reading `metadata.user_edited.<field>` so a user override survives
+ *     re-extract verbatim.
+ *
+ * The prompt itself stays short because the heavy lifting (classify,
+ * postings, place resolution) is gone. ~70 lines of prose vs.
+ * `src/ingest/prompt.ts`'s ~800.
+ */
+import { buildInfo } from "../generated/build-info.js";
+
+/**
+ * Bumped on meaningful re-extract prompt edits. Separate from
+ * `PROMPT_VERSION` in `src/ingest/prompt.ts` because the two prompts
+ * can drift independently — re-extract has a narrower job. Stamped
+ * into `transactions.metadata.extraction.prompt_version` on every run
+ * (overwriting the prior value), and into `derivation_events.prompt_version`.
+ */
+export const REEXTRACT_PROMPT_VERSION = "1.0";
+
+/**
+ * The model identifier we stamp into `documents.ocr_model_version`.
+ * Matches the `--model` flag we pass to `claude -p`; kept in sync
+ * with the env var fallback in `extractor.ts`.
+ */
+export const REEXTRACT_MODEL = process.env.CLAUDE_MODEL || "sonnet";
+
+export interface ReExtractPromptContext {
+  /** Absolute path inside the container where the original upload lives. */
+  filePath: string;
+  /** Workspace scope (UPDATE WHERE clause). */
+  workspaceId: string;
+  /** Document row that holds `ocr_text` + `ocr_model_version` to refresh. */
+  documentId: string;
+  /** Existing transaction row to UPDATE. Looked up by the service via
+   *  `document_links`; the prompt does not search for it. */
+  transactionId: string;
+  /** Owner user id, recorded in the `transaction_events` row. */
+  userId: string;
+}
+
+export function buildReExtractPrompt(ctx: ReExtractPromptContext): string {
+  return `You are re-running extraction on a previously-ingested receipt.
+The transaction row already exists; your job is to refresh the
+receipt-readable fields against the current prompt/model. You will
+write directly to Postgres via the \`psql\` Bash tool.
+
+── Context ─────────────────────────────────────────────────────────────
+
+File path (inside this container):
+  ${ctx.filePath}
+
+Context variables for SQL (use as-is):
+  TX_ID         = '${ctx.transactionId}'
+  WORKSPACE_ID  = '${ctx.workspaceId}'
+  DOCUMENT_ID   = '${ctx.documentId}'
+  USER_ID       = '${ctx.userId}'
+  PROMPT_VERSION   = '${REEXTRACT_PROMPT_VERSION}'
+  PROMPT_GIT_SHA   = '${buildInfo.gitSha}'
+  MODEL            = '${REEXTRACT_MODEL}'
+
+DB connection: \`psql "\$DATABASE_URL"\` — the env var is set.
+
+── Phase 1 — Extract ──────────────────────────────────────────────────
+
+Read the file at the path above (same image / pdf / .eml the original
+ingest read). Reason in plain text first — chain-of-thought measurably
+improves OCR. Do NOT use \`--json-schema\`-style structured output.
+
+Pull these fields. Use NULL when the field is not visible — never
+guess, never fall back to today's date.
+
+  payee         : merchant name as printed on the document
+  occurred_on   : date in YYYY-MM-DD form (read from the document)
+  occurred_at   : timestamp YYYY-MM-DD HH:MM:SS+TZ if a time is
+                  printed; NULL otherwise
+  total_minor   : FINAL amount in the currency's minor unit (integer
+                  cents for USD, whole units for JPY). Include
+                  handwritten tips if visible.
+  currency      : ISO 4217 (USD, CNY, EUR, JPY, …)
+  raw_text      : full transcription (for \`documents.ocr_text\`)
+
+Place resolution and merchant canonicalization are OUT OF SCOPE for
+re-extract — those have their own endpoints (\`POST /v1/places/:id/refresh\`
+and the merchant enrichment loop). Do NOT touch \`place_id\`,
+\`merchant_id\`, \`merchants\`, or \`places\`.
+
+Postings (the double-entry debit/credit rows under the transaction) are
+also OUT OF SCOPE — re-extract does not rewrite them. Do NOT touch
+\`postings\` or \`document_links\`.
+
+── Phase 2 — Write ────────────────────────────────────────────────────
+
+Run exactly ONE psql block. Substitute your extracted values for the
+placeholders; the CASE statements consult \`metadata.user_edited\` so a
+user override survives this re-extract.
+
+  psql "\$DATABASE_URL" <<'SQL'
+  BEGIN;
+
+  UPDATE transactions SET
+    occurred_on = CASE
+      WHEN (metadata->'user_edited'->>'occurred_on')::boolean IS TRUE THEN occurred_on
+      ELSE '<YYYY-MM-DD>'
+    END,
+    occurred_at = CASE
+      WHEN (metadata->'user_edited'->>'occurred_at')::boolean IS TRUE THEN occurred_at
+      ELSE <'<YYYY-MM-DD HH:MM:SS+TZ>'::timestamptz | NULL>
+    END,
+    payee = CASE
+      WHEN (metadata->'user_edited'->>'payee')::boolean IS TRUE THEN payee
+      ELSE '<PAYEE>'
+    END,
+    metadata = jsonb_set(
+      jsonb_set(
+        COALESCE(metadata, '{}'::jsonb),
+        '{extraction}',
+        jsonb_build_object(
+          'prompt_version', '${REEXTRACT_PROMPT_VERSION}',
+          'prompt_git_sha', '${buildInfo.gitSha}',
+          'model',          '${REEXTRACT_MODEL}',
+          'ran_at',         NOW()::text,
+          'source',         're-extract'
+        )
+      ),
+      '{re_extracted_at}',
+      to_jsonb(NOW()::text)
+    ),
+    version = version + 1
+  WHERE id = '${ctx.transactionId}' AND workspace_id = '${ctx.workspaceId}';
+
+  UPDATE documents SET
+    ocr_text          = '<RAW_TEXT, single-quote-escaped>',
+    ocr_model_version = '${REEXTRACT_MODEL}',
+    updated_at        = NOW()
+  WHERE id = '${ctx.documentId}' AND workspace_id = '${ctx.workspaceId}';
+
+  INSERT INTO transaction_events (
+    id, workspace_id, transaction_id, event_type, actor_id, payload
+  ) VALUES (
+    gen_random_uuid(), '${ctx.workspaceId}', '${ctx.transactionId}',
+    're_extracted', '${ctx.userId}',
+    jsonb_build_object(
+      'prompt_version', '${REEXTRACT_PROMPT_VERSION}',
+      'model',          '${REEXTRACT_MODEL}'
+    )
+  );
+
+  COMMIT;
+  SQL
+
+IMPORTANT escaping rule: SQL single quotes inside values must be
+doubled (\`O''Brien\`). Newlines inside \`raw_text\` are fine inside a
+single-quoted SQL literal as long as no single quote is unescaped.
+
+── Done ────────────────────────────────────────────────────────────────
+
+After the psql block exits 0, print ONE line:
+
+  DONE re_extracted tx=${ctx.transactionId} prompt_version=${REEXTRACT_PROMPT_VERSION}
+
+If you cannot read the receipt at all (unsupported / illegible /
+corrupted), do NOT write anything to the database. Print:
+
+  ERROR <one-line reason>
+
+and exit. The service will mark the document accordingly.
+`;
+}

--- a/src/routes/documents.service.ts
+++ b/src/routes/documents.service.ts
@@ -11,12 +11,22 @@ import { and, eq, sql, isNull } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { documents, documentLinks } from "../schema/documents.js";
 import { transactions, postings, transactionEvents } from "../schema/index.js";
+import { derivationEvents } from "../schema/derivation_events.js";
 import { newId } from "../http/uuid.js";
 import {
   DocumentHasLinksProblem,
   HttpProblem,
   NotFoundProblem,
 } from "../http/problem.js";
+import {
+  defaultClaudeReExtractor,
+  type ReExtractor,
+} from "../ingest/extractor.js";
+import {
+  REEXTRACT_PROMPT_VERSION,
+  REEXTRACT_MODEL,
+} from "../ingest/reextract-prompt.js";
+import { buildInfo } from "../generated/build-info.js";
 
 export type DocumentKindValue =
   | "receipt_image"
@@ -641,4 +651,223 @@ async function voidTransactionInTx(
       payload: { voids: txId, reason },
     },
   ]);
+}
+
+// ── Re-extract (Phase 4c of #80 / #91) ─────────────────────────────────
+
+export interface ReExtractDocumentResult {
+  document_id: string;
+  transaction_id: string;
+  derivation_event_id: string;
+  changed_keys: string[];
+  /** Convenience flag so the caller can tell "OCR text actually changed"
+   *  from "only metadata.extraction was stamped." */
+  ocr_text_changed: boolean;
+  /** Re-extract is observability-first; carry the session id so the
+   *  operator can pull the Langfuse trace without a join. */
+  session_id: string;
+}
+
+/**
+ * Re-OCR an already-ingested receipt and UPDATE the linked transaction
+ * in place. Layer-3 shielded — see `src/projection/layer3.ts`.
+ *
+ * Contract:
+ *   - Resolves the linked transaction via `document_links`. If the
+ *     document has zero links or more than one, returns null (404) or
+ *     422 respectively — re-extract is per-tx and we don't pick.
+ *   - Snapshots Layer-2 tx fields BEFORE spawning the agent. The agent
+ *     writes the UPDATE itself (Layer-3 CASE shielding lives in the
+ *     prompt). After the agent returns we snapshot again, diff, and
+ *     INSERT a `derivation_events` row with `entity_type='document'`
+ *     so the audit trail is unified with re-derive (#89).
+ *   - Soft-deleted documents are rejected (404).
+ *   - Out-of-scope: postings, place_id, merchant_id, document_links.
+ *     See `src/ingest/reextract-prompt.ts` header for why.
+ *
+ * Returns null when the document is missing or soft-deleted.
+ * Throws a `MultipleLinksProblem` (422) when the document links to
+ * more than one transaction.
+ */
+export async function reExtractDocument(
+  workspaceId: string,
+  userId: string,
+  documentId: string,
+  options: { reExtractor?: ReExtractor } = {},
+): Promise<ReExtractDocumentResult | null> {
+  const reExtractor = options.reExtractor ?? defaultClaudeReExtractor;
+
+  // 1) Resolve the document + linked transaction.
+  const docRows = await db
+    .select({
+      id: documents.id,
+      workspaceId: documents.workspaceId,
+      filePath: documents.filePath,
+      ocrText: documents.ocrText,
+      deletedAt: documents.deletedAt,
+    })
+    .from(documents)
+    .where(
+      and(
+        eq(documents.id, documentId),
+        eq(documents.workspaceId, workspaceId),
+      ),
+    );
+  if (docRows.length === 0) return null;
+  const doc = docRows[0]!;
+  if (doc.deletedAt) return null;
+  if (!doc.filePath) {
+    throw new HttpProblem(
+      422,
+      "document-no-file-path",
+      "Re-extract requires the original file",
+      "Document has no file_path on disk; re-extract has nothing to read.",
+      { document_id: documentId },
+    );
+  }
+
+  const linkRows = await db
+    .select({ transactionId: documentLinks.transactionId })
+    .from(documentLinks)
+    .where(eq(documentLinks.documentId, documentId));
+  if (linkRows.length === 0) {
+    throw new HttpProblem(
+      422,
+      "document-no-transaction",
+      "Document not linked to a transaction",
+      "Re-extract operates per-transaction; this document has zero linked transactions.",
+      { document_id: documentId },
+    );
+  }
+  if (linkRows.length > 1) {
+    throw new HttpProblem(
+      422,
+      "document-multiple-transactions",
+      "Document linked to multiple transactions",
+      "Re-extract refuses when a document links to more than one transaction; pick a tx and use a per-tx flow.",
+      {
+        document_id: documentId,
+        transaction_ids: linkRows.map((r) => r.transactionId),
+      },
+    );
+  }
+  const transactionId = linkRows[0]!.transactionId;
+
+  // 2) Snapshot BEFORE — projection-domain tx fields only. Layer-3
+  //    fields are excluded from the diff because re-extract can't
+  //    change them anyway; including them would clutter `changed_keys`.
+  const beforeSnapshot = await snapshotReExtractFields(transactionId, doc.id);
+
+  // 3) Spawn the agent. Errors here bubble to the route handler;
+  //    nothing has been written yet so the DB state is untouched.
+  const { sessionId, stdout } = await reExtractor({
+    filePath: doc.filePath,
+    workspaceId,
+    documentId,
+    transactionId,
+    userId,
+  });
+
+  // 4) Snapshot AFTER. Agent has now UPDATEd transactions + documents.
+  const afterSnapshot = await snapshotReExtractFields(transactionId, doc.id);
+
+  // 5) Compute diff and write derivation_events. We do this in TS
+  //    (not the prompt) so the audit row reflects ground truth after
+  //    the agent's writes have committed, not the agent's intent.
+  const changedKeys: string[] = [];
+  const beforeAny = beforeSnapshot as unknown as Record<string, unknown>;
+  const afterAny = afterSnapshot as unknown as Record<string, unknown>;
+  for (const k of Object.keys(beforeAny)) {
+    if (!reExtractFieldEq(beforeAny[k], afterAny[k])) changedKeys.push(k);
+  }
+
+  const [evt] = await db
+    .insert(derivationEvents)
+    .values({
+      workspaceId,
+      entityType: "document",
+      entityId: documentId,
+      promptVersion: REEXTRACT_PROMPT_VERSION,
+      promptGitSha: buildInfo.gitSha,
+      model: REEXTRACT_MODEL,
+      ranAt: new Date(),
+      before: beforeSnapshot as unknown as Record<string, unknown>,
+      after: afterSnapshot as unknown as Record<string, unknown>,
+      // (`as unknown as` so TS accepts the cast across the
+      // ReExtractSnapshot → Record<string, unknown> jump.)
+      changedKeys,
+    })
+    .returning({ id: derivationEvents.id });
+
+  // Surface stdout to console so operators can grep DONE/ERROR lines.
+  if (stdout && stdout.trim().length > 0) {
+    console.info(`[re-extract] doc=${documentId} tx=${transactionId} ${stdout.trim().split("\n").pop()}`);
+  }
+
+  return {
+    document_id: documentId,
+    transaction_id: transactionId,
+    derivation_event_id: evt!.id,
+    changed_keys: changedKeys,
+    ocr_text_changed: !reExtractFieldEq(
+      beforeSnapshot.ocr_text,
+      afterSnapshot.ocr_text,
+    ),
+    session_id: sessionId,
+  };
+}
+
+interface ReExtractSnapshot {
+  payee: string | null;
+  occurred_on: string | null;
+  occurred_at: string | null;
+  metadata_extraction: unknown;
+  ocr_text: string | null;
+  ocr_model_version: string | null;
+}
+
+async function snapshotReExtractFields(
+  transactionId: string,
+  documentId: string,
+): Promise<ReExtractSnapshot> {
+  const tx = await db
+    .select({
+      payee: transactions.payee,
+      occurredOn: transactions.occurredOn,
+      occurredAt: transactions.occurredAt,
+      metadata: transactions.metadata,
+    })
+    .from(transactions)
+    .where(eq(transactions.id, transactionId));
+
+  const doc = await db
+    .select({
+      ocrText: documents.ocrText,
+      ocrModelVersion: documents.ocrModelVersion,
+    })
+    .from(documents)
+    .where(eq(documents.id, documentId));
+
+  const t = tx[0]!;
+  const d = doc[0]!;
+  const meta = (t.metadata as Record<string, unknown> | null) ?? {};
+
+  return {
+    payee: t.payee,
+    occurred_on: t.occurredOn,
+    occurred_at:
+      t.occurredAt instanceof Date ? t.occurredAt.toISOString() : null,
+    metadata_extraction: meta.extraction ?? null,
+    ocr_text: d.ocrText,
+    ocr_model_version: d.ocrModelVersion,
+  };
+}
+
+function reExtractFieldEq(a: unknown, b: unknown): boolean {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  if (typeof a === "object" || typeof b === "object") {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  return a === b;
 }

--- a/src/routes/documents.ts
+++ b/src/routes/documents.ts
@@ -34,6 +34,7 @@ import {
   DocumentKind,
   CreateDocumentLinkRequest,
   UploadDocumentForm,
+  ReExtractDocumentResponse,
 } from "../schemas/v1/document.js";
 import { ProblemDetails, Uuid } from "../schemas/v1/common.js";
 import { NotFoundProblem } from "../http/problem.js";
@@ -48,6 +49,7 @@ import {
   hardDeleteDocument,
   restoreDocument,
   cascadeDeleteDocument,
+  reExtractDocument,
   extForMime,
   type DocumentKindValue,
 } from "./documents.service.js";
@@ -284,6 +286,22 @@ documentsRouter.post(
   }),
 );
 
+// ── POST /v1/documents/:id/re-extract ──────────────────────────────────
+
+documentsRouter.post(
+  "/:id/re-extract",
+  asyncHandler(async (req, res) => {
+    const { id } = parseOrThrow(IdOnlyParams, req.params);
+    const out = await reExtractDocument(
+      req.ctx.workspaceId,
+      req.ctx.userId,
+      id,
+    );
+    if (!out) throw new NotFoundProblem("Document", id);
+    res.json(out);
+  }),
+);
+
 // ── OpenAPI registration ───────────────────────────────────────────────
 
 export function registerDocumentsOpenApi(registry: OpenAPIRegistry): void {
@@ -462,6 +480,41 @@ export function registerDocumentsOpenApi(registry: OpenAPIRegistry): void {
       },
       404: {
         description: "Document not found or not deleted",
+        content: problemContent,
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/documents/{id}/re-extract",
+    summary: "Re-OCR the receipt and UPDATE the linked transaction in place.",
+    description:
+      "Phase 4c of the 3-layer rollout (#80 / #91). Spawns `claude -p` " +
+      "with a narrow re-extract prompt; the agent reads the cached " +
+      "image bytes and refreshes `transactions.{payee, occurred_on, " +
+      "occurred_at, metadata.extraction}` plus `documents.{ocr_text, " +
+      "ocr_model_version}`. **Out of scope**: postings, place_id, " +
+      "merchant_id, document_links — those have their own paths. " +
+      "**Layer-3 shielded**: HARD fields (status, narration, trip_id, " +
+      "identity columns) never touched; SOFT fields (occurred_on, " +
+      "occurred_at, payee) protected by `metadata.user_edited.<field>` " +
+      "CASE expressions, so user PATCH overrides survive. " +
+      "Returns 422 if the document has zero or >1 linked transactions.",
+    tags: ["documents"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: {
+        description: "Re-extract committed",
+        content: { "application/json": { schema: ReExtractDocumentResponse } },
+      },
+      404: {
+        description: "Document not found or soft-deleted",
+        content: problemContent,
+      },
+      422: {
+        description:
+          "Document not linked to exactly one transaction, or has no file_path",
         content: problemContent,
       },
     },

--- a/src/routes/transactions.service.ts
+++ b/src/routes/transactions.service.ts
@@ -620,17 +620,26 @@ export async function updateTransaction(
 
     const updates: Record<string, unknown> = {};
     const oldSnap: Record<string, unknown> = {};
+    // SOFT Layer-3 fields (see `src/projection/layer3.ts`) — when the
+    // user PATCHes one of these, we flag `metadata.user_edited.<field>`
+    // so re-extract (#91 Phase 4c) preserves the user value across
+    // a re-OCR. Builds up alongside the column updates and is merged
+    // into the final `metadata` update below.
+    const userEditedAdditions: Record<string, true> = {};
     if (patch.occurred_on !== undefined) {
       updates.occurredOn = patch.occurred_on;
       oldSnap.occurred_on = current.occurredOn;
+      userEditedAdditions.occurred_on = true;
     }
     if (patch.occurred_at !== undefined) {
       updates.occurredAt = patch.occurred_at === null ? null : new Date(patch.occurred_at);
       oldSnap.occurred_at = current.occurredAt;
+      userEditedAdditions.occurred_at = true;
     }
     if (patch.payee !== undefined) {
       updates.payee = patch.payee;
       oldSnap.payee = current.payee;
+      userEditedAdditions.payee = true;
     }
     if (patch.narration !== undefined) {
       updates.narration = patch.narration;
@@ -643,6 +652,30 @@ export async function updateTransaction(
     if (patch.metadata !== undefined) {
       updates.metadata = patch.metadata;
       oldSnap.metadata = current.metadata;
+    }
+
+    // Merge user_edited flags into the metadata write. If the patch
+    // didn't specify `metadata`, we still need to update it (to add
+    // the flags); if it did, we layer flags on top so they always
+    // win — the user can't accidentally drop their own edit-protection
+    // by sending a `metadata: {}` patch.
+    if (Object.keys(userEditedAdditions).length > 0) {
+      const currentMetadata =
+        (current.metadata as Record<string, unknown> | null) ?? {};
+      const patchMetadata =
+        (patch.metadata as Record<string, unknown> | undefined) ?? null;
+      const baseMetadata = patchMetadata ?? currentMetadata;
+      const existingUserEdited =
+        (baseMetadata.user_edited as Record<string, unknown> | undefined) ??
+        (currentMetadata.user_edited as Record<string, unknown> | undefined) ??
+        {};
+      updates.metadata = {
+        ...baseMetadata,
+        user_edited: {
+          ...existingUserEdited,
+          ...userEditedAdditions,
+        },
+      };
     }
 
     if (Object.keys(updates).length === 0) {

--- a/src/schemas/v1/document.ts
+++ b/src/schemas/v1/document.ts
@@ -24,7 +24,10 @@ export const Document = z
     /** Model identifier under which `ocr_text` was produced. NULL on
      *  legacy rows (pre-#91 Phase 4b). Independent of
      *  `transactions.metadata.extraction.model` — see schema header. */
-    ocr_model_version: z.string().nullable(),
+    ocr_model_version: z.string().nullable().openapi({
+      description:
+        "Model identifier under which ocr_text was produced. NULL on legacy rows.",
+    }),
     extraction_meta: z.record(z.string(), z.unknown()).nullable(),
     source_ingest_id: Uuid.nullable(),
     deleted_at: IsoDateTime.nullable(),
@@ -36,6 +39,24 @@ export const Document = z
 export const CreateDocumentLinkRequest = z
   .object({ transaction_id: Uuid })
   .openapi("CreateDocumentLinkRequest");
+
+/**
+ * Response from `POST /v1/documents/:id/re-extract` (Phase 4c of #80 / #91).
+ * The agent has re-OCR'd the receipt and UPDATEd the linked transaction
+ * + document. `changed_keys` reflects what actually moved (Layer-3
+ * shielding may have suppressed some changes the agent attempted).
+ * `derivation_event_id` lets the caller correlate against the audit log.
+ */
+export const ReExtractDocumentResponse = z
+  .object({
+    document_id: Uuid,
+    transaction_id: Uuid,
+    derivation_event_id: Uuid,
+    changed_keys: z.array(z.string()),
+    ocr_text_changed: z.boolean(),
+    session_id: Uuid,
+  })
+  .openapi("ReExtractDocumentResponse");
 
 // Multipart form is described inline in the route registration;
 // Zod can't fully model multipart, but we register the field shape


### PR DESCRIPTION
## Summary

Phase 4c of the 3-layer data-model rollout ([#80](https://github.com/TINKPA/receipt-assistant/issues/80)) — **third and final sub-PR**, closes [#91](https://github.com/TINKPA/receipt-assistant/issues/91). Wave 0 backend goes 5-for-5 with this merge (#88, #89, #90, #91a, #91b, #91c — only frontend #49 remains).

`POST /v1/documents/{id}/re-extract` re-runs OCR against an already-ingested receipt and UPDATEs the linked transaction in place. Layer-3 shielded — user edits and explicit state changes survive.

## What's in

**Endpoint**:
- Resolves the linked transaction via `document_links` (422 on 0 or >1 links)
- Spawns `claude -p` with a narrow re-extract prompt (`src/ingest/reextract-prompt.ts`)
- Agent re-reads the image and runs one psql block:
  - `UPDATE transactions` with Layer-3 CASE shielding
  - `UPDATE documents` (`ocr_text` + `ocr_model_version`)
  - `INSERT transaction_events` with `event_type='re_extracted'`
- Service computes before/after diff and INSERTs `derivation_events` with `entity_type='document'`

Response:
```json
{
  "document_id": "uuid",
  "transaction_id": "uuid",
  "derivation_event_id": "uuid",
  "changed_keys": ["occurred_at", "metadata_extraction", "ocr_text", "ocr_model_version"],
  "ocr_text_changed": true,
  "session_id": "uuid"
}
```

The `session_id` is the pre-allocated UUID handed to `claude -p` — same Langfuse trace handle as ingest.

**Layer-3 shielding** (this PR completes the contract from 91b):

- HARD fields (`status`, `voided_by_id`, `trip_id`, `narration`, identity columns, `version`) are simply absent from the prompt's UPDATE — perfect shielding by omission. `version` is the lone exception, always bumped via `version + 1`.
- SOFT fields (`payee`, `occurred_on`, `occurred_at`) wrapped in:
  ```sql
  payee = CASE WHEN (metadata->'user_edited'->>'payee')::boolean IS TRUE
               THEN payee
               ELSE '<NEW>' END
  ```
- `updateTransaction` (the PATCH path) now sets `metadata.user_edited.<field> = true` when the user changes a SOFT field — completes the writer/reader pair 91b set up. Existing user metadata is preserved (we layer flags on top, never replace).

## Design choices

**Why so narrow.** Original #91 body asked for re-fetch Google + re-aggregate merchants + rewrite postings + rebuild document_links. Strict interpretation = another full epic. Each item has its own reason to be deferred:
- **Postings rewrite** — ledger sum-to-zero invariant. Re-extracting category/amounts and writing without a balance re-check risks invalid postings. A safe rewrite means DELETE + INSERT + verify in one transaction. Future scope (call it 91d).
- **place_id / merchant_id** — already have their own paths (`POST /v1/places/:id/refresh` from 91a, the merchant enrichment loop). Doubling them in re-extract is dead code.
- **document_links** — already correct; re-extract changes the data inside the rows, not which document points where.

The MVP is "re-OCR text + payee + date + bump `metadata.extraction`" — which is exactly the use case driving #91 (prompt upgrade → roll new logic over old corpus).

**Why SOFT shielding via SQL CASE, not TS post-processing.** Considered: agent emits JSON, TS computes the UPDATE. Rejected because the "agent writes SQL directly" pattern is the one that was verified to give good OCR accuracy (#11 / pre-#32 A/B). Switching to "agent emits JSON, TS assembles SQL" is an unverified path; not worth the risk for Layer-3 enforcement that fits cleanly in Postgres CASE expressions.

**Why a separate prompt file, not parameterize `src/ingest/prompt.ts`.** Re-extract's prompt is ~50% shorter (no classify, no postings, no place resolution). Folding both into one prompt with `mode: 'ingest' | 'reextract'` conditionals would add branching to a hot path that's been stable. Two files, two prompt versions (`PROMPT_VERSION` for ingest stays at "2.5"; `REEXTRACT_PROMPT_VERSION` starts at "1.0"), each can drift independently.

## Files

- **NEW** `src/ingest/reextract-prompt.ts` — `buildReExtractPrompt()`, `REEXTRACT_PROMPT_VERSION`, `REEXTRACT_MODEL`
- `src/ingest/extractor.ts` — `defaultClaudeReExtractor` (symmetric with the existing extractor)
- `src/routes/documents.service.ts` — `reExtractDocument()` (resolves tx, snapshots, spawns, diffs, writes audit row)
- `src/routes/documents.ts` — `POST /:id/re-extract` handler + OpenAPI registration
- `src/routes/transactions.service.ts` — `updateTransaction` writes `metadata.user_edited` flags
- `src/schemas/v1/document.ts` — `ReExtractDocumentResponse`
- `CLAUDE.md` — new "Re-extract — `documents` (Phase 4c of #80)" subsection

## Smoke verification

All three on local stack, image: Sichuan Spicy Bay receipt at `019e2dc8-0bce-7488-b8f4-3f9cf846b8a7`:

| Scenario | Wall-time | Result |
|---|---|---|
| Single-link doc, no user-edits | 50s | `ocr_text` populated (was empty), `ocr_model_version` `null` → `'sonnet'`, `version` 2 → 3, `prompt_version` 2.5 → 1.0, `derivation_events` row written |
| Multi-link doc (Euclid Coffee, 2 linked tx) | <1s | 422 `errors/document-multiple-transactions` with `transaction_ids[]` in problem+json |
| Layer-3: `payee='MY CUSTOM NAME'` + `metadata.user_edited.payee=true` | 47s | payee **intact** post-re-extract; `changed_keys` correctly excludes `payee` |

- [x] Single-link path produces the expected updates
- [x] Multi-link case rejected with the right problem+json shape
- [x] HARD shielding works (status etc. omitted from UPDATE)
- [x] SOFT shielding works (`metadata.user_edited` prevents overwrite)
- [x] `derivation_events` row written with `entity_type='document'`
- [x] `documents.ocr_model_version` stamped with current model
- [x] `transactions.version` bumped (optimistic concurrency contract maintained)
- [ ] Post-merge: redeploy container, sanity-check `/version` reports new gitSha, repeat one smoke call

## What this closes

Wave 0 backend: 5 phase tickets shipped.

| # | Phase | Shipped |
|---|---|---|
| #88 | Phase 1: extraction provenance | 2026-05-15 |
| #89 | Phase 2: re-derive endpoints + audit log | 2026-05-15 |
| #90 | Phase 3: place_snapshots append-only | 2026-05-16 |
| #91 91a | Phase 4a: refresh place | 2026-05-16 |
| #91 91b | Phase 4b: schema prep + Layer-3 contract | 2026-05-16 |
| #91 91c | Phase 4c: re-extract document | **this PR** |

Only frontend [#49](https://github.com/TINKPA/receipt-assistant-frontend/issues/49) (reprocess UI + admin batch view) remains in the Wave 0 epic — different repo, requires browser smoke-test per the project's UI evidence rule.

Fixes #91.
Refs #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)