### PR TITLE
feat(extraction): structured line items in metadata.items (#81 Phase 1)

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1033,6 +1033,108 @@
           "place"
         ]
       },
+      "TransactionItem": {
+        "type": "object",
+        "properties": {
+          "line_no": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "raw_name": {
+            "type": "string"
+          },
+          "normalized_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "quantity": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "unit": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "unit_price_minor": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "line_total_minor": {
+            "type": "integer"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "item_class": {
+            "type": "string",
+            "enum": [
+              "durable",
+              "consumable",
+              "food_drink",
+              "service",
+              "other"
+            ]
+          },
+          "durability_tier": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "luxury",
+              "standard"
+            ]
+          },
+          "food_kind": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "restaurant_dish",
+              "grocery_food",
+              "beverage"
+            ]
+          },
+          "tags": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "confidence": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ]
+          }
+        },
+        "required": [
+          "line_no",
+          "raw_name",
+          "normalized_name",
+          "quantity",
+          "unit",
+          "unit_price_minor",
+          "line_total_minor",
+          "currency",
+          "item_class",
+          "confidence"
+        ]
+      },
       "BulkResultItem": {
         "type": "object",
         "properties": {

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -17,7 +17,7 @@ import { buildInfo } from "../generated/build-info.js";
  * `extraction.prompt_version` ≠ `PROMPT_VERSION` are eligible to be
  * re-derived. See #80 / #88 for the 3-layer data model rationale.
  */
-export const PROMPT_VERSION = "2.5";
+export const PROMPT_VERSION = "2.6";
 
 export interface ExtractorPromptContext {
   /** Absolute path inside the container where the file was staged. */
@@ -90,8 +90,121 @@ For receipt_image / receipt_email / receipt_pdf, pull out:
                   (CNY vs JPY).
   category_hint : one of
                   groceries | dining | retail | cafe | transport | other
-  items         : optional list of line items (for later inventory use)
+  items         : REQUIRED structured line-item array (#81). Each
+                  item is one object with the exact shape below;
+                  the array MUST be non-empty for receipt_image /
+                  receipt_email / receipt_pdf. Statement PDFs
+                  continue to skip items (each statement row IS a
+                  transaction, no sub-itemization possible).
   raw_text      : optional full transcription (helps debugging)
+
+── items[] shape (per line on the receipt) ───────────────────────────
+
+Each \`item\` object has these fields:
+
+  line_no            int      1-based, preserves the order printed
+                              on the receipt
+  raw_name           text     the line as printed, verbatim (don't
+                              normalize — preserve abbreviations,
+                              brand prefixes, codes)
+  normalized_name    text|null brand-stripped human-readable form
+                              (e.g. "KS PPR TWLS 12CT" → "Paper
+                              Towels"). NULL when the raw name is
+                              already clean or impossible to clean.
+  quantity           num|null  2, 0.5, 1 default if unprinted
+  unit               text|null "ct", "lb", "kg", "oz", "ea", "ml",
+                              or NULL when not printed
+  unit_price_minor   int|null  minor units (cents for USD), NULL when
+                              not printed (single line items often omit)
+  line_total_minor   int       REQUIRED. Minor units. Signed —
+                              negative for line-level discounts /
+                              coupons / store-applied promos
+  currency           text      ISO 4217, same as the transaction
+  item_class         enum      one of:
+                                 durable      — expected life ≥ 1 year
+                                                (electronics, furniture,
+                                                appliances, clothing,
+                                                kitchenware, tools)
+                                 consumable   — used up in weeks/months
+                                                (cleaning supplies,
+                                                toiletries, batteries,
+                                                fuel, OTC meds, paper
+                                                products, light bulbs)
+                                 food_drink   — anything edible/potable
+                                 service      — non-physical (massage,
+                                                haircut, delivery fee,
+                                                itemized service charge)
+                                 other        — refunds, gift cards,
+                                                tax appearing as its
+                                                own line. Rare; if you
+                                                use this often, the
+                                                receipt is probably
+                                                ambiguous — flag in tags.
+  durability_tier    enum|null only when item_class='durable':
+                                 luxury   — line total > \$200 OR brand
+                                            is luxury-list (Apple
+                                            high-end, LV, Hermès, …)
+                                 standard — otherwise
+                                NULL for non-durable items.
+  food_kind          enum|null only when item_class='food_drink':
+                                 restaurant_dish — dining/cafe merchant
+                                 grocery_food    — market for home cook
+                                 beverage        — drinks bought as
+                                                   drinks (latte, water,
+                                                   beer). Alcohol →
+                                                   add "alcohol" tag.
+                                NULL for non-food items.
+  tags               text[]|null freeform low-trust signals:
+                                ["alcohol","cold","organic","sale",
+                                 "imported","handwritten","unclear"]
+  confidence         enum      one of:
+                                 high   — line crisp, totals tie
+                                 medium — readable but ambiguous
+                                 low    — thermal-paper smudge,
+                                          ink fade, partial occlusion
+
+Arithmetic invariant — Σ line_total_minor across all items SHOULD
+approximate the receipt's printed subtotal (within \$0.01 rounding;
+tax/tip/discount lines are themselves items or excluded — see
+Examples). When the sum is off by more than \$0.50, drop confidence
+to "low" on the items that look most suspect.
+
+If you cannot itemize at all (total-only receipt, unreadable item
+section, illegible thermal print) emit ONE item with
+item_class='other', confidence='low', raw_name='TOTAL ONLY',
+line_total_minor=<TOTAL_MINOR>, and a tags entry explaining why
+("unreadable", "no-item-section").
+
+── Worked examples ───────────────────────────────────────────────────
+
+Costco gas (single line):
+  items = [
+    {"line_no":1, "raw_name":"GAS REG", "normalized_name":"Regular Gas",
+     "quantity":12.345, "unit":"gal", "unit_price_minor":419,
+     "line_total_minor":5176, "currency":"USD",
+     "item_class":"consumable", "tags":["fuel"], "confidence":"high"}
+  ]
+
+AYCE sushi dinner ($46.20):
+  items = [
+    {"line_no":1, "raw_name":"AYCE Lunch", "normalized_name":"All-You-Can-Eat Lunch",
+     "quantity":2, "unit":"ea", "unit_price_minor":2199,
+     "line_total_minor":4398, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"restaurant_dish", "confidence":"high"},
+    {"line_no":2, "raw_name":"Hot Tea", "normalized_name":"Hot Tea",
+     "quantity":2, "unit":"ea", "unit_price_minor":150,
+     "line_total_minor":300, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"beverage", "confidence":"high"}
+  ]
+
+Best Buy laptop ($1,599):
+  items = [
+    {"line_no":1, "raw_name":"MBA M3 13 256GB", "normalized_name":"MacBook Air M3 13\" 256GB",
+     "quantity":1, "unit":"ea", "unit_price_minor":159900,
+     "line_total_minor":159900, "currency":"USD",
+     "item_class":"durable", "durability_tier":"luxury",
+     "tags":["electronics","apple"], "confidence":"high"}
+  ]
 
 For statement_pdf, pull rows: { date, payee, amount_minor }.
 
@@ -606,8 +719,12 @@ them first):
             'prompt_git_sha', '${buildInfo.gitSha}',
             'model',          '${process.env.CLAUDE_MODEL ?? "sonnet"}',
             'ran_at',         NOW()
-          )
-          -- add tax/tip/items/raw_text here if useful, as extra JSONB keys
+          ),
+          -- items[] is REQUIRED for receipt_image / receipt_email /
+          -- receipt_pdf per #81 / PROMPT_VERSION 2.6. Statement_pdf
+          -- omits this key. Each object follows the schema in Phase 2.
+          'items', '<ITEMS_JSON_ARRAY>'::jsonb
+          -- add tax/tip/raw_text here if useful, as extra JSONB keys
         ),
         '${ctx.userId}'
       )

--- a/src/ingest/reextract-prompt.ts
+++ b/src/ingest/reextract-prompt.ts
@@ -37,7 +37,7 @@ import { buildInfo } from "../generated/build-info.js";
  * into `transactions.metadata.extraction.prompt_version` on every run
  * (overwriting the prior value), and into `derivation_events.prompt_version`.
  */
-export const REEXTRACT_PROMPT_VERSION = "1.0";
+export const REEXTRACT_PROMPT_VERSION = "1.1";
 
 /**
  * The model identifier we stamp into `documents.ocr_model_version`.
@@ -100,6 +100,39 @@ guess, never fall back to today's date.
                   handwritten tips if visible.
   currency      : ISO 4217 (USD, CNY, EUR, JPY, …)
   raw_text      : full transcription (for \`documents.ocr_text\`)
+  items         : REQUIRED structured line-item array per #81 / REEXTRACT_PROMPT_VERSION 1.1.
+                  Each item is one object with these fields:
+                    line_no            int (1-based, preserves order)
+                    raw_name           text (verbatim line)
+                    normalized_name    text|null (brand-stripped)
+                    quantity           num|null
+                    unit               text|null ("ct","lb","ea",…)
+                    unit_price_minor   int|null (minor units)
+                    line_total_minor   int REQUIRED (signed; negative for discounts)
+                    currency           ISO 4217 (same as transaction)
+                    item_class         enum:
+                                         durable    — life ≥ 1 year
+                                         consumable — used in weeks/months (fuel, paper, batteries)
+                                         food_drink — edible/potable
+                                         service    — non-physical (massage, delivery fee)
+                                         other      — refunds, gift cards, rare
+                    durability_tier    enum|null (only if durable): luxury|standard
+                                       (luxury when single-line total > \$200 OR known
+                                        luxury brand: Apple high-end, LV, Hermès, …)
+                    food_kind          enum|null (only if food_drink):
+                                         restaurant_dish|grocery_food|beverage
+                    tags               text[]|null (freeform: alcohol, cold, organic,
+                                                   sale, imported, handwritten, unclear)
+                    confidence         enum: high|medium|low
+
+                  Σ line_total_minor across items SHOULD approximate the
+                  receipt's subtotal (within \$0.01). If sum is off by >\$0.50,
+                  drop confidence='low' on items that look suspect.
+
+                  If you cannot itemize at all (total-only receipt, illegible
+                  thermal print), emit ONE item with item_class='other',
+                  confidence='low', raw_name='TOTAL ONLY',
+                  line_total_minor=<TOTAL_MINOR>, tags=['no-item-section'].
 
 Place resolution and merchant canonicalization are OUT OF SCOPE for
 re-extract — those have their own endpoints (\`POST /v1/places/:id/refresh\`
@@ -134,15 +167,19 @@ user override survives this re-extract.
     END,
     metadata = jsonb_set(
       jsonb_set(
-        COALESCE(metadata, '{}'::jsonb),
-        '{extraction}',
-        jsonb_build_object(
-          'prompt_version', '${REEXTRACT_PROMPT_VERSION}',
-          'prompt_git_sha', '${buildInfo.gitSha}',
-          'model',          '${REEXTRACT_MODEL}',
-          'ran_at',         NOW()::text,
-          'source',         're-extract'
-        )
+        jsonb_set(
+          COALESCE(metadata, '{}'::jsonb),
+          '{extraction}',
+          jsonb_build_object(
+            'prompt_version', '${REEXTRACT_PROMPT_VERSION}',
+            'prompt_git_sha', '${buildInfo.gitSha}',
+            'model',          '${REEXTRACT_MODEL}',
+            'ran_at',         NOW()::text,
+            'source',         're-extract'
+          )
+        ),
+        '{items}',
+        '<ITEMS_JSON_ARRAY>'::jsonb
       ),
       '{re_extracted_at}',
       to_jsonb(NOW()::text)

--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -26,6 +26,7 @@ import {
   BulkRequest,
   Transaction as TransactionSchema,
   Posting as PostingSchema,
+  TransactionItem,
   BulkResponse,
 } from "../schemas/v1/transaction.js";
 import { parseOrThrow } from "../http/validate.js";
@@ -457,6 +458,7 @@ transactionsRouter.delete(
 export function registerTransactionsOpenApi(registry: OpenAPIRegistry): void {
   registry.register("Transaction", TransactionSchema);
   registry.register("Posting", PostingSchema);
+  registry.register("TransactionItem", TransactionItem);
   registry.register("BulkResponse", BulkResponse);
 
   const problemContent = {

--- a/src/schemas/v1/transaction.ts
+++ b/src/schemas/v1/transaction.ts
@@ -175,3 +175,55 @@ export const BulkResultItem = z
 export const BulkResponse = z
   .object({ results: z.array(BulkResultItem) })
   .openapi("BulkResponse");
+
+// ── Line items (#81 Phase 1) ───────────────────────────────────────────
+
+/**
+ * Per-line item shape stored under `transactions.metadata.items` (#81
+ * Phase 1 — JSONB only, no dedicated table yet). The agent populates
+ * this array on every ingest and re-extract of receipt_image /
+ * receipt_email / receipt_pdf; statement_pdf transactions omit items
+ * (their rows ARE the line equivalents).
+ *
+ * Read-only from the API today — clients consume `Transaction.metadata.items`
+ * via this typed view. Phase 2 lifts the data to a `transaction_items`
+ * table; the field names stay identical so client code doesn't change
+ * shape on that migration.
+ */
+export const TransactionItem = z
+  .object({
+    /** 1-based, preserves the printed order on the receipt. */
+    line_no: z.number().int().positive(),
+    /** Verbatim line as printed (abbreviations, brand prefixes preserved). */
+    raw_name: z.string(),
+    /** Brand-stripped human-readable form, or NULL when raw is already clean. */
+    normalized_name: z.string().nullable(),
+    quantity: z.number().nullable(),
+    /** "ct", "lb", "kg", "oz", "ea", "ml", "gal", or NULL. */
+    unit: z.string().nullable(),
+    /** Minor units (cents for USD). NULL for single-line items that omit. */
+    unit_price_minor: z.number().int().nullable(),
+    /** Minor units, signed. Negative for line-level discounts / coupons. */
+    line_total_minor: z.number().int(),
+    /** ISO 4217. Matches the parent transaction's currency in MVP. */
+    currency: z.string(),
+    item_class: z.enum([
+      "durable",
+      "consumable",
+      "food_drink",
+      "service",
+      "other",
+    ]),
+    /** Only when `item_class='durable'`. NULL otherwise. */
+    durability_tier: z.enum(["luxury", "standard"]).nullable().optional(),
+    /** Only when `item_class='food_drink'`. NULL otherwise. */
+    food_kind: z
+      .enum(["restaurant_dish", "grocery_food", "beverage"])
+      .nullable()
+      .optional(),
+    tags: z.array(z.string()).nullable().optional(),
+    confidence: z.enum(["high", "medium", "low"]),
+  })
+  .openapi("TransactionItem");
+
+export type TransactionItemShape = z.infer<typeof TransactionItem>;


### PR DESCRIPTION
## Summary

Phase 1 of [#81](https://github.com/TINKPA/receipt-assistant/issues/81). Until now \`items\` was hand-waved as an "optional list of line items (for later inventory use)" with no shape spec, no schema, and no downstream consumer. This PR makes items **required** on every receipt ingest / re-extract, with a 5-class taxonomy and a full field shape that doubles as the contract for the Phase-2 \`transaction_items\` table.

Phase 1 is JSONB-only — items land under \`transactions.metadata.items\` with no new table. Phase 2 will lift them to a normalized table with indexes for queries like "all durable purchases in 2025".

## What's in

**Prompts** (ingest + re-extract, in lockstep):
- \`src/ingest/prompt.ts\` Phase 2 documents the full item shape — \`line_no\`, \`raw_name\`, \`normalized_name\`, \`quantity\`, \`unit\`, \`unit_price_minor\`, \`line_total_minor\`, \`currency\`, \`item_class\`, \`durability_tier\`, \`food_kind\`, \`tags\`, \`confidence\` — plus the arithmetic invariant (Σ line_total_minor ≈ subtotal within \$0.01) and an explicit fallback (\`'TOTAL ONLY'\` single-item with \`item_class='other'\` and \`confidence='low'\`). Three worked examples: Costco gas, AYCE sushi, Best Buy laptop.
- Phase 4 SQL template adds \`items: <ITEMS_JSON_ARRAY>\` to the metadata jsonb_build_object alongside \`extraction\` / \`merchant\` / \`classification\`.
- \`PROMPT_VERSION\` 2.5 → 2.6.
- \`src/ingest/reextract-prompt.ts\` mirrors the same items spec so re-extract populates items on existing receipts going forward. \`REEXTRACT_PROMPT_VERSION\` 1.0 → 1.1.

**5-class taxonomy** (per issue spec, broader than the issue title's "3-class" name suggests):
- \`durable\` — life ≥ 1 year (electronics, furniture, clothing). Drives the durable-goods register.
- \`consumable\` — used in weeks/months (cleaning supplies, fuel, paper, batteries). Drives consumption-rhythm signals.
- \`food_drink\` — anything edible/potable. Drives the eating log.
- \`service\` — non-physical (massage, haircut, delivery fee).
- \`other\` — refunds, gift cards, the fallback. Rare in normal use.

**Zod / OpenAPI**:
- New \`TransactionItem\` schema in \`src/schemas/v1/transaction.ts\` exposing the typed view of \`metadata.items[]\` to clients.
- \`src/routes/transactions.ts\` registers the schema; clients codegen the type starting now.

## Smoke verification

\`POST /v1/documents/019e2dc8-.../re-extract\` (Sichuan Spicy Bay):

| Before | After |
|---|---|
| \`prompt_version: '1.0'\` | \`prompt_version: '1.1'\` |
| \`items_count: 0\` | \`items_count: 1\` |
| — | items = \`[{"raw_name":"TOTAL ONLY","item_class":"other","confidence":"low","tags":["no-item-section"],"line_total_minor":8281,...}]\` |

The agent correctly followed the fallback path for this particular receipt (couldn't itemize confidently), producing a single-item array matching the documented escape hatch. Every field present matches the zod schema. \`line_total_minor=8281\` exactly mirrors the receipt's \$82.81 total. This validates both the happy-path schema and the fallback-path semantics.

## Out of scope (per #81 phased plan)

- **Phase 2**: \`transaction_items\` table + per-line INSERT loop in the prompt's Phase 4 SQL + \`GET /v1/items?class=durable&from=...\` listing endpoint. Filed as next PR in the post-Wave-0 roadmap.
- **Phase 3**: Frontend surfaces (durable inventory view, consumption rhythm, eating log) — separate frontend ticket once Phase 2 ships and there are real items to query.
- Token-cost delta measurement — to do after a multi-receipt smoke run.

Refs #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)