### PR TITLE
feat(#81): Phase 2 — lift items to transaction_items table

### DIFF
--- a/drizzle/0015_natural_ezekiel_stane.sql
+++ b/drizzle/0015_natural_ezekiel_stane.sql
@@ -1,0 +1,43 @@
+-- #81 Phase 2: lift `transactions.metadata.items` to a typed table.
+-- Phase 1 (#105) parked items inside `metadata.items` JSONB; this
+-- creates the relational store. Same field names, no taxonomy churn.
+-- Idempotency: UNIQUE (transaction_id, line_no) lets re-extract do
+-- DELETE-then-INSERT in one txn. Transactions service falls back to
+-- reading `metadata.items` when no rows exist (pre-#105 history).
+
+CREATE TABLE "transaction_items" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"transaction_id" uuid NOT NULL,
+	"line_no" integer NOT NULL,
+	"raw_name" text NOT NULL,
+	"normalized_name" text,
+	"quantity" numeric,
+	"unit" text,
+	"unit_price_minor" bigint,
+	"line_total_minor" bigint NOT NULL,
+	"currency" text NOT NULL,
+	"item_class" text NOT NULL,
+	"durability_tier" text,
+	"food_kind" text,
+	"tags" text[],
+	"confidence" text NOT NULL,
+	"extraction_version" text NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	CONSTRAINT "transaction_items_item_class_ck"
+		CHECK (item_class IN ('durable','consumable','food_drink','service','other')),
+	CONSTRAINT "transaction_items_durability_tier_ck"
+		CHECK (durability_tier IS NULL OR durability_tier IN ('luxury','standard')),
+	CONSTRAINT "transaction_items_food_kind_ck"
+		CHECK (food_kind IS NULL OR food_kind IN ('restaurant_dish','grocery_food','beverage')),
+	CONSTRAINT "transaction_items_confidence_ck"
+		CHECK (confidence IN ('high','medium','low'))
+);
+--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD CONSTRAINT "transaction_items_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD CONSTRAINT "transaction_items_transaction_id_transactions_id_fk" FOREIGN KEY ("transaction_id") REFERENCES "public"."transactions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "transaction_items_line_no_uq" ON "transaction_items" USING btree ("transaction_id","line_no");--> statement-breakpoint
+CREATE INDEX "transaction_items_tx_idx" ON "transaction_items" USING btree ("transaction_id");--> statement-breakpoint
+CREATE INDEX "transaction_items_workspace_class_created_idx" ON "transaction_items" USING btree ("workspace_id","item_class","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "transaction_items_tags_idx" ON "transaction_items" USING GIN ("tags");

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "4f5dda51-6503-4597-8d1e-958f64fbb88c",
-  "prevId": "82d57b64-34e4-4467-9b20-113a797ac434",
+  "id": "e64c1107-892e-4811-b95c-f6a015c84e44",
+  "prevId": "4f5dda51-6503-4597-8d1e-958f64fbb88c",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -732,6 +732,226 @@
             "id"
           ],
           "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_items": {
+      "name": "transaction_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price_minor": {
+          "name": "unit_price_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_total_minor": {
+          "name": "line_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability_tier": {
+          "name": "durability_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_kind": {
+          "name": "food_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transaction_items_line_no_uq": {
+          "name": "transaction_items_line_no_uq",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_items_tx_idx": {
+          "name": "transaction_items_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_items_workspace_class_created_idx": {
+          "name": "transaction_items_workspace_class_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_items_workspace_id_workspaces_id_fk": {
+          "name": "transaction_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_items_transaction_id_transactions_id_fk": {
+          "name": "transaction_items_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
           "onUpdate": "no action"
         }
       },

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1778908371437,
       "tag": "0014_places_custom_name",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1778911497324,
+      "tag": "0015_natural_ezekiel_stane",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -909,6 +909,108 @@
           "photos"
         ]
       },
+      "TransactionItem": {
+        "type": "object",
+        "properties": {
+          "line_no": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "raw_name": {
+            "type": "string"
+          },
+          "normalized_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "quantity": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "unit": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "unit_price_minor": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "line_total_minor": {
+            "type": "integer"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "item_class": {
+            "type": "string",
+            "enum": [
+              "durable",
+              "consumable",
+              "food_drink",
+              "service",
+              "other"
+            ]
+          },
+          "durability_tier": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "luxury",
+              "standard"
+            ]
+          },
+          "food_kind": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "restaurant_dish",
+              "grocery_food",
+              "beverage"
+            ]
+          },
+          "tags": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "confidence": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ]
+          }
+        },
+        "required": [
+          "line_no",
+          "raw_name",
+          "normalized_name",
+          "quantity",
+          "unit",
+          "unit_price_minor",
+          "line_total_minor",
+          "currency",
+          "item_class",
+          "confidence"
+        ]
+      },
       "Transaction": {
         "type": "object",
         "properties": {
@@ -1012,6 +1114,12 @@
           },
           "place": {
             "$ref": "#/components/schemas/Place"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransactionItem"
+            }
           }
         },
         "required": [
@@ -1030,109 +1138,8 @@
           "updated_at",
           "postings",
           "documents",
-          "place"
-        ]
-      },
-      "TransactionItem": {
-        "type": "object",
-        "properties": {
-          "line_no": {
-            "type": "integer",
-            "exclusiveMinimum": 0
-          },
-          "raw_name": {
-            "type": "string"
-          },
-          "normalized_name": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "quantity": {
-            "type": [
-              "number",
-              "null"
-            ]
-          },
-          "unit": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "unit_price_minor": {
-            "type": [
-              "integer",
-              "null"
-            ]
-          },
-          "line_total_minor": {
-            "type": "integer"
-          },
-          "currency": {
-            "type": "string"
-          },
-          "item_class": {
-            "type": "string",
-            "enum": [
-              "durable",
-              "consumable",
-              "food_drink",
-              "service",
-              "other"
-            ]
-          },
-          "durability_tier": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "enum": [
-              "luxury",
-              "standard"
-            ]
-          },
-          "food_kind": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "enum": [
-              "restaurant_dish",
-              "grocery_food",
-              "beverage"
-            ]
-          },
-          "tags": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
-          },
-          "confidence": {
-            "type": "string",
-            "enum": [
-              "high",
-              "medium",
-              "low"
-            ]
-          }
-        },
-        "required": [
-          "line_no",
-          "raw_name",
-          "normalized_name",
-          "quantity",
-          "unit",
-          "unit_price_minor",
-          "line_total_minor",
-          "currency",
-          "item_class",
-          "confidence"
+          "place",
+          "items"
         ]
       },
       "BulkResultItem": {
@@ -1163,6 +1170,34 @@
         },
         "required": [
           "results"
+        ]
+      },
+      "ListedTransactionItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TransactionItem"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "transaction_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "created_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "transaction_id",
+              "created_at"
+            ]
+          }
         ]
       },
       "Document": {
@@ -4321,6 +4356,124 @@
           },
           "422": {
             "description": "Would leave <2 postings",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/items": {
+      "get": {
+        "summary": "List transaction items (admin / aggregation)",
+        "tags": [
+          "items"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "durable",
+                "consumable",
+                "food_drink",
+                "service",
+                "other"
+              ]
+            },
+            "required": false,
+            "name": "class",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "transaction_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "tag",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ListedTransactionItem"
+                      }
+                    },
+                    "next_cursor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "next_cursor"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import { contextMiddleware } from "./http/context.js";
 import { problemHandler } from "./http/problem.js";
 import { accountsRouter } from "./routes/accounts.js";
 import { transactionsRouter } from "./routes/transactions.js";
+import { itemsRouter } from "./routes/items.js";
 import { postingsRouter } from "./routes/postings.js";
 import { documentsRouter } from "./routes/documents.js";
 import {
@@ -71,6 +72,7 @@ export function buildApp(): Express {
   // ── v1 resource routers ─────────────────────────────────────────────
   app.use("/v1/accounts", accountsRouter);
   app.use("/v1/transactions", transactionsRouter);
+  app.use("/v1/items", itemsRouter);
   app.use("/v1/postings", postingsRouter);
   app.use("/v1/documents", documentsRouter);
   app.use("/v1/ingest", ingestRouter);

--- a/src/generated/build-info.ts
+++ b/src/generated/build-info.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant",
   "version": "1.0.0",
-  "gitSha": "bbfd45567c0c8a50c63be228740e37f35b260b90",
-  "gitShortSha": "bbfd455",
-  "gitBranch": "feat/merchant-aggregation-backend-64",
-  "builtAt": "2026-05-12T07:31:34.523Z"
+  "gitSha": "ed41b9b8144bee6f0aa3e4b831b848b9630b852e",
+  "gitShortSha": "ed41b9b",
+  "gitBranch": "feat/81-phase2-transaction-items",
+  "builtAt": "2026-05-16T06:09:18.217Z"
 } as const;

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -747,6 +747,39 @@ them first):
       SELECT '${ctx.documentId}', tx.id FROM tx
       ON CONFLICT DO NOTHING
       RETURNING transaction_id
+    ),
+    -- #81 Phase 2: relational line-items. One INSERT per item from
+    -- your Phase 2 items[] array. The shape is identical to the
+    -- jsonb_build_object's 'items' key — both stay in sync this
+    -- release; clients read items off the table, the metadata copy
+    -- is the on-the-wire archive of the agent's exact emission.
+    -- Use ARRAY[]::text[] when tags is empty / NULL.
+    -- Re-extract on the same tx clears + reinserts via the (tx_id,
+    -- line_no) unique constraint; ingest only ever inserts (the
+    -- transaction is brand new here, so no conflicts possible).
+    ti AS (
+      INSERT INTO transaction_items (
+        id, workspace_id, transaction_id, line_no,
+        raw_name, normalized_name, quantity, unit,
+        unit_price_minor, line_total_minor, currency,
+        item_class, durability_tier, food_kind, tags, confidence,
+        extraction_version
+      )
+      SELECT gen_random_uuid(), '${ctx.workspaceId}', tx.id, item.line_no,
+             item.raw_name, item.normalized_name, item.quantity, item.unit,
+             item.unit_price_minor, item.line_total_minor, item.currency,
+             item.item_class, item.durability_tier, item.food_kind,
+             item.tags, item.confidence,
+             '${PROMPT_VERSION}'
+      FROM tx,
+        jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb) AS item(
+          line_no int, raw_name text, normalized_name text,
+          quantity numeric, unit text,
+          unit_price_minor bigint, line_total_minor bigint, currency text,
+          item_class text, durability_tier text, food_kind text,
+          tags text[], confidence text
+        )
+      RETURNING id
     )
   SELECT tx.id AS tx_id FROM tx;
   COMMIT;

--- a/src/ingest/reextract-prompt.ts
+++ b/src/ingest/reextract-prompt.ts
@@ -37,7 +37,7 @@ import { buildInfo } from "../generated/build-info.js";
  * into `transactions.metadata.extraction.prompt_version` on every run
  * (overwriting the prior value), and into `derivation_events.prompt_version`.
  */
-export const REEXTRACT_PROMPT_VERSION = "1.1";
+export const REEXTRACT_PROMPT_VERSION = "1.2";
 
 /**
  * The model identifier we stamp into `documents.ocr_model_version`.
@@ -192,6 +192,35 @@ user override survives this re-extract.
     ocr_model_version = '${REEXTRACT_MODEL}',
     updated_at        = NOW()
   WHERE id = '${ctx.documentId}' AND workspace_id = '${ctx.workspaceId}';
+
+  -- #81 Phase 2: refresh relational items in lockstep with metadata.
+  -- DELETE-then-INSERT inside the same txn is idempotent because the
+  -- UNIQUE (transaction_id, line_no) constraint would otherwise reject
+  -- a second pass. Always reset, even on a no-item receipt (the agent
+  -- emits the 'TOTAL ONLY' fallback row in that case).
+  DELETE FROM transaction_items
+  WHERE transaction_id = '${ctx.transactionId}';
+
+  INSERT INTO transaction_items (
+    id, workspace_id, transaction_id, line_no,
+    raw_name, normalized_name, quantity, unit,
+    unit_price_minor, line_total_minor, currency,
+    item_class, durability_tier, food_kind, tags, confidence,
+    extraction_version
+  )
+  SELECT gen_random_uuid(), '${ctx.workspaceId}', '${ctx.transactionId}', item.line_no,
+         item.raw_name, item.normalized_name, item.quantity, item.unit,
+         item.unit_price_minor, item.line_total_minor, item.currency,
+         item.item_class, item.durability_tier, item.food_kind,
+         item.tags, item.confidence,
+         '${REEXTRACT_PROMPT_VERSION}'
+  FROM jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb) AS item(
+    line_no int, raw_name text, normalized_name text,
+    quantity numeric, unit text,
+    unit_price_minor bigint, line_total_minor bigint, currency text,
+    item_class text, durability_tier text, food_kind text,
+    tags text[], confidence text
+  );
 
   INSERT INTO transaction_events (
     id, workspace_id, transaction_id, event_type, actor_id, payload

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -22,6 +22,7 @@ import { BuildInfoResponse, HealthResponse } from "./schemas/health.js";
 import { ProblemDetails } from "./schemas/v1/common.js";
 import { registerAccountsOpenApi } from "./routes/accounts.js";
 import { registerTransactionsOpenApi } from "./routes/transactions.js";
+import { registerItemsOpenApi } from "./routes/items.js";
 import { registerPostingsOpenApi } from "./routes/postings.js";
 import { registerDocumentsOpenApi } from "./routes/documents.js";
 import { registerIngestOpenApi } from "./routes/ingest.js";
@@ -75,6 +76,7 @@ export function buildRegistry(): OpenAPIRegistry {
   // v1 resource routers register their own paths + response schemas.
   registerAccountsOpenApi(registry);
   registerTransactionsOpenApi(registry);
+  registerItemsOpenApi(registry);
   registerPostingsOpenApi(registry);
   registerDocumentsOpenApi(registry);
   registerIngestOpenApi(registry);

--- a/src/routes/items.ts
+++ b/src/routes/items.ts
@@ -1,0 +1,174 @@
+/**
+ * `GET /v1/items` — line-item listing for admin / aggregation.
+ *
+ * Lives at the top level (not nested under `/v1/transactions/:id/items`)
+ * because the use case is "show me every durable I bought in 2026",
+ * not "show me what's on this one receipt". Use the transaction
+ * endpoint (`GET /v1/transactions/:id`) for the latter — items are
+ * already embedded in that response.
+ *
+ * Filters mirror the index in migration 0015:
+ *   (workspace_id, item_class, created_at DESC) — fast for "give me
+ *   every durable, newest first" without a sequential scan.
+ *
+ * Pagination uses the same keyset pattern as transactions; cursor
+ * encodes `(created_at, id)`.
+ */
+import { Router, type Request, type Response, type NextFunction } from "express";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+import { sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { parseOrThrow } from "../http/validate.js";
+import { paginated, ProblemDetails } from "../schemas/v1/common.js";
+import { TransactionItem } from "../schemas/v1/transaction.js";
+import {
+  clampLimit,
+  encodeCursor,
+  decodeCursor,
+  DEFAULT_PAGE_LIMIT,
+} from "../http/pagination.js";
+import { emitNextLink } from "../http/pagination.js";
+
+export const itemsRouter: Router = Router();
+
+const ItemClassEnum = z.enum([
+  "durable",
+  "consumable",
+  "food_drink",
+  "service",
+  "other",
+]);
+
+const ListItemsQuery = z.object({
+  class: ItemClassEnum.optional(),
+  from: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  to: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  transaction_id: z.string().uuid().optional(),
+  tag: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+});
+
+interface ItemsCursor {
+  created_at: string;
+  id: string;
+}
+
+itemsRouter.get(
+  "/",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const query = parseOrThrow(ListItemsQuery, req.query);
+      const limit = clampLimit(query.limit ?? DEFAULT_PAGE_LIMIT);
+      const cursor = decodeCursor<ItemsCursor>(query.cursor ?? undefined);
+
+      const conditions: ReturnType<typeof sql>[] = [];
+      conditions.push(sql`ti.workspace_id = ${req.ctx.workspaceId}::uuid`);
+      if (query.class) conditions.push(sql`ti.item_class = ${query.class}`);
+      if (query.transaction_id) {
+        conditions.push(sql`ti.transaction_id = ${query.transaction_id}::uuid`);
+      }
+      if (query.tag) conditions.push(sql`${query.tag} = ANY(ti.tags)`);
+      if (query.from) {
+        conditions.push(
+          sql`ti.created_at >= (${query.from}::date)::timestamptz`,
+        );
+      }
+      if (query.to) {
+        conditions.push(
+          sql`ti.created_at < ((${query.to}::date) + INTERVAL '1 day')::timestamptz`,
+        );
+      }
+      if (cursor) {
+        conditions.push(
+          sql`(ti.created_at, ti.id) < (${cursor.created_at}::timestamptz, ${cursor.id}::uuid)`,
+        );
+      }
+
+      const where = sql.join(conditions, sql` AND `);
+      const rowsRes = await db.execute(
+        sql`SELECT * FROM transaction_items ti WHERE ${where} ORDER BY ti.created_at DESC, ti.id DESC LIMIT ${limit + 1}`,
+      );
+      const rows = rowsRes.rows as any[];
+      const hasMore = rows.length > limit;
+      const page = hasMore ? rows.slice(0, limit) : rows;
+
+      const items = page.map((r) => ({
+        line_no: Number(r.line_no),
+        raw_name: r.raw_name,
+        normalized_name: r.normalized_name ?? null,
+        quantity: r.quantity === null ? null : Number(r.quantity),
+        unit: r.unit ?? null,
+        unit_price_minor:
+          r.unit_price_minor === null ? null : Number(r.unit_price_minor),
+        line_total_minor: Number(r.line_total_minor),
+        currency: r.currency,
+        item_class: r.item_class,
+        durability_tier: r.durability_tier ?? null,
+        food_kind: r.food_kind ?? null,
+        tags: Array.isArray(r.tags) ? r.tags : null,
+        confidence: r.confidence,
+        // Extras only on the listing endpoint — handy for admin
+        // aggregation views without round-tripping to /transactions/:id.
+        id: r.id,
+        transaction_id: r.transaction_id,
+        created_at:
+          r.created_at instanceof Date
+            ? r.created_at.toISOString()
+            : String(r.created_at),
+      }));
+
+      const nextCursor = hasMore
+        ? encodeCursor({
+            created_at:
+              page[page.length - 1]!.created_at instanceof Date
+                ? page[page.length - 1]!.created_at.toISOString()
+                : String(page[page.length - 1]!.created_at),
+            id: page[page.length - 1]!.id,
+          })
+        : null;
+
+      emitNextLink(req, res, nextCursor);
+      res.json({ items, next_cursor: nextCursor });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export function registerItemsOpenApi(registry: OpenAPIRegistry): void {
+  const problemContent = {
+    "application/problem+json": { schema: ProblemDetails },
+  };
+
+  // Listing item shape: TransactionItem plus row-level fields useful
+  // for cross-receipt aggregation.
+  const ListedItem = TransactionItem.extend({
+    id: z.string().uuid(),
+    transaction_id: z.string().uuid(),
+    created_at: z.string(),
+  }).openapi("ListedTransactionItem");
+  registry.register("ListedTransactionItem", ListedItem);
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/items",
+    summary: "List transaction items (admin / aggregation)",
+    tags: ["items"],
+    request: { query: ListItemsQuery },
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: paginated(ListedItem) } },
+      },
+      400: { description: "Bad request", content: problemContent },
+    },
+  });
+}

--- a/src/routes/transactions.service.ts
+++ b/src/routes/transactions.service.ts
@@ -15,6 +15,7 @@ import { sql, eq, and, inArray } from "drizzle-orm";
 import { db } from "../db/client.js";
 import {
   transactions,
+  transactionItems,
   postings,
   accounts,
   documents,
@@ -68,6 +69,28 @@ export interface PostingRow {
   created_at: string;
 }
 
+/**
+ * Per-line item DTO. Mirrors `TransactionItem` in
+ * `src/schemas/v1/transaction.ts` exactly. Source priority:
+ *   1. `transaction_items` rows (post-#81 Phase 2 — relational SSOT)
+ *   2. `metadata.items` JSONB array (pre-#81 Phase 2 fallback)
+ */
+export interface TransactionItemRow {
+  line_no: number;
+  raw_name: string;
+  normalized_name: string | null;
+  quantity: number | null;
+  unit: string | null;
+  unit_price_minor: number | null;
+  line_total_minor: number;
+  currency: string;
+  item_class: "durable" | "consumable" | "food_drink" | "service" | "other";
+  durability_tier: "luxury" | "standard" | null;
+  food_kind: "restaurant_dish" | "grocery_food" | "beverage" | null;
+  tags: string[] | null;
+  confidence: "high" | "medium" | "low";
+}
+
 export interface TransactionRow {
   id: string;
   workspace_id: string;
@@ -92,6 +115,13 @@ export interface TransactionRow {
    * the places feature, or when the row has been unlinked.
    */
   place: PlaceRow | null;
+  /**
+   * Receipt line items (#81). Phase 2 reads `transaction_items`;
+   * empty array means the receipt has no items section (e.g. the
+   * agent emitted no rows, or this is a `statement_pdf` parent),
+   * NOT "items missing from this response".
+   */
+  items: TransactionItemRow[];
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -181,12 +211,61 @@ function mapPostingRow(row: any): PostingRow {
   };
 }
 
+/**
+ * Coerce a single row from `transaction_items` or a JSONB object to the
+ * `TransactionItemRow` DTO. The two sources are intentionally aligned
+ * field-for-field so this can swallow either shape.
+ */
+function mapTransactionItem(row: any): TransactionItemRow {
+  return {
+    line_no: Number(row.lineNo ?? row.line_no),
+    raw_name: row.rawName ?? row.raw_name,
+    normalized_name: row.normalizedName ?? row.normalized_name ?? null,
+    quantity:
+      row.quantity === null || row.quantity === undefined
+        ? null
+        : Number(row.quantity),
+    unit: row.unit ?? null,
+    unit_price_minor:
+      (row.unitPriceMinor ?? row.unit_price_minor) === null ||
+      (row.unitPriceMinor ?? row.unit_price_minor) === undefined
+        ? null
+        : Number(row.unitPriceMinor ?? row.unit_price_minor),
+    line_total_minor: Number(row.lineTotalMinor ?? row.line_total_minor),
+    currency: row.currency,
+    item_class: row.itemClass ?? row.item_class,
+    durability_tier: row.durabilityTier ?? row.durability_tier ?? null,
+    food_kind: row.foodKind ?? row.food_kind ?? null,
+    tags: Array.isArray(row.tags) ? row.tags : null,
+    confidence: row.confidence,
+  };
+}
+
+/**
+ * Read items for a transaction, preferring the relational table; fall
+ * back to `metadata.items` for rows ingested before #81 Phase 2.
+ */
+function itemsFromMetadataFallback(metadata: unknown): TransactionItemRow[] {
+  if (!metadata || typeof metadata !== "object") return [];
+  const raw = (metadata as Record<string, unknown>).items;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((x): x is Record<string, unknown> => !!x && typeof x === "object")
+    .map(mapTransactionItem);
+}
+
 function mapTransactionRow(
   row: any,
   posts: any[],
   docs: Array<{ id: string; kind: string }>,
   place: PlaceRow | null = null,
+  itemRows: any[] = [],
 ): TransactionRow {
+  const metadata = row.metadata ?? {};
+  const items =
+    itemRows.length > 0
+      ? itemRows.map(mapTransactionItem)
+      : itemsFromMetadataFallback(metadata);
   return {
     id: row.id,
     workspace_id: row.workspaceId ?? row.workspace_id,
@@ -200,13 +279,14 @@ function mapTransactionRow(
     voided_by_id: row.voidedById ?? row.voided_by_id ?? null,
     source_ingest_id: row.sourceIngestId ?? row.source_ingest_id ?? null,
     trip_id: row.tripId ?? row.trip_id ?? null,
-    metadata: row.metadata ?? {},
+    metadata,
     version: Number(row.version),
     created_at: toIsoString(row.createdAt ?? row.created_at),
     updated_at: toIsoString(row.updatedAt ?? row.updated_at),
     postings: posts.map(mapPostingRow),
     documents: docs,
     place,
+    items,
   };
 }
 
@@ -237,7 +317,12 @@ async function loadTransactionFull(
     .where(eq(documentLinks.transactionId, id));
   const placeMap = t.placeId ? await loadPlacesByIds([t.placeId]) : null;
   const place = placeMap?.get(t.placeId!) ?? null;
-  return mapTransactionRow(t, posts, docLinks, place);
+  const itemRows = await runner
+    .select()
+    .from(transactionItems)
+    .where(eq(transactionItems.transactionId, id))
+    .orderBy(transactionItems.lineNo);
+  return mapTransactionRow(t, posts, docLinks, place, itemRows);
 }
 
 async function loadWorkspaceBaseCurrency(
@@ -569,12 +654,25 @@ export async function listTransactions(
     .filter((v): v is string => typeof v === "string" && v.length > 0);
   const placeMap = placeIds.length > 0 ? await loadPlacesByIds(placeIds) : null;
 
+  // Bulk-load relational line-items for this page. Empty → fallback
+  // path in mapTransactionRow reads metadata.items for pre-#81 rows.
+  const itemRes = await db.execute(
+    sql`SELECT * FROM transaction_items WHERE transaction_id = ANY(${sql.raw(`ARRAY[${ids.map((i) => `'${i}'`).join(",")}]::uuid[]`)}) ORDER BY transaction_id, line_no ASC`,
+  );
+  const itemsByTx = new Map<string, any[]>();
+  for (const it of itemRes.rows as any[]) {
+    const arr = itemsByTx.get(it.transaction_id) ?? [];
+    arr.push(it);
+    itemsByTx.set(it.transaction_id, arr);
+  }
+
   const items = page.map((r) =>
     mapTransactionRow(
       r,
       postByTx.get(r.id) ?? [],
       docByTx.get(r.id) ?? [],
       r.place_id && placeMap ? (placeMap.get(r.place_id) ?? null) : null,
+      itemsByTx.get(r.id) ?? [],
     ),
   );
 

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -3,6 +3,7 @@ export * from "./users.js";
 export * from "./workspaces.js";
 export * from "./accounts.js";
 export * from "./transactions.js";
+export * from "./transaction_items.js";
 export * from "./postings.js";
 export * from "./documents.js";
 export * from "./audit.js";

--- a/src/schema/transaction_items.ts
+++ b/src/schema/transaction_items.ts
@@ -1,0 +1,64 @@
+/**
+ * #81 Phase 2 — relational line-items table.
+ *
+ * The shape mirrors `TransactionItem` in `src/schemas/v1/transaction.ts`
+ * one-to-one. Phase 1 (#105) shipped items inside `transactions.metadata.items`;
+ * this table is the canonical store going forward. The transactions
+ * service falls back to `metadata.items` when no rows exist, so old
+ * receipts keep rendering unchanged.
+ */
+import {
+  pgTable,
+  uuid,
+  text,
+  integer,
+  bigint,
+  numeric,
+  timestamp,
+  jsonb,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { workspaces } from "./workspaces.js";
+import { transactions } from "./transactions.js";
+
+export const transactionItems = pgTable(
+  "transaction_items",
+  {
+    id: uuid("id").primaryKey(),
+    workspaceId: uuid("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    transactionId: uuid("transaction_id")
+      .notNull()
+      .references(() => transactions.id, { onDelete: "cascade" }),
+    lineNo: integer("line_no").notNull(),
+    rawName: text("raw_name").notNull(),
+    normalizedName: text("normalized_name"),
+    quantity: numeric("quantity"),
+    unit: text("unit"),
+    unitPriceMinor: bigint("unit_price_minor", { mode: "number" }),
+    lineTotalMinor: bigint("line_total_minor", { mode: "number" }).notNull(),
+    currency: text("currency").notNull(),
+    itemClass: text("item_class").notNull(),
+    durabilityTier: text("durability_tier"),
+    foodKind: text("food_kind"),
+    tags: text("tags").array(),
+    confidence: text("confidence").notNull(),
+    extractionVersion: text("extraction_version").notNull(),
+    metadata: jsonb("metadata").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .default(sql`NOW()`),
+  },
+  (t) => [
+    uniqueIndex("transaction_items_line_no_uq").on(t.transactionId, t.lineNo),
+    index("transaction_items_tx_idx").on(t.transactionId),
+    index("transaction_items_workspace_class_created_idx").on(
+      t.workspaceId,
+      t.itemClass,
+      t.createdAt.desc(),
+    ),
+  ],
+);

--- a/src/schemas/v1/transaction.ts
+++ b/src/schemas/v1/transaction.ts
@@ -55,6 +55,50 @@ export const TransactionDocumentRef = z
 // Place schema moved to ./place.ts (#74). The Place is now a richer
 // multilingual record — see src/schemas/v1/place.ts.
 
+/**
+ * Per-line item shape. Phase 1 stored these as JSONB under
+ * `transactions.metadata.items`; Phase 2 (#81) lifts them to a typed
+ * `transaction_items` table. Field names are identical between
+ * jsonb-fallback and table reads — the response stays stable.
+ */
+export const TransactionItem = z
+  .object({
+    /** 1-based, preserves the printed order on the receipt. */
+    line_no: z.number().int().positive(),
+    /** Verbatim line as printed (abbreviations, brand prefixes preserved). */
+    raw_name: z.string(),
+    /** Brand-stripped human-readable form, or NULL when raw is already clean. */
+    normalized_name: z.string().nullable(),
+    quantity: z.number().nullable(),
+    /** "ct", "lb", "kg", "oz", "ea", "ml", "gal", or NULL. */
+    unit: z.string().nullable(),
+    /** Minor units (cents for USD). NULL for single-line items that omit. */
+    unit_price_minor: z.number().int().nullable(),
+    /** Minor units, signed. Negative for line-level discounts / coupons. */
+    line_total_minor: z.number().int(),
+    /** ISO 4217. Matches the parent transaction's currency in MVP. */
+    currency: z.string(),
+    item_class: z.enum([
+      "durable",
+      "consumable",
+      "food_drink",
+      "service",
+      "other",
+    ]),
+    /** Only when `item_class='durable'`. NULL otherwise. */
+    durability_tier: z.enum(["luxury", "standard"]).nullable().optional(),
+    /** Only when `item_class='food_drink'`. NULL otherwise. */
+    food_kind: z
+      .enum(["restaurant_dish", "grocery_food", "beverage"])
+      .nullable()
+      .optional(),
+    tags: z.array(z.string()).nullable().optional(),
+    confidence: z.enum(["high", "medium", "low"]),
+  })
+  .openapi("TransactionItem");
+
+export type TransactionItemShape = z.infer<typeof TransactionItem>;
+
 export const Transaction = z
   .object({
     id: Uuid,
@@ -74,6 +118,15 @@ export const Transaction = z
     postings: z.array(Posting),
     documents: z.array(TransactionDocumentRef),
     place: Place.nullable(),
+    /**
+     * Receipt line items (#81 Phase 2). Reads from the
+     * `transaction_items` table when present; falls back to
+     * `metadata.items` for receipts ingested before this PR. Empty
+     * array is meaningful — it indicates a transaction with no
+     * itemizable lines (e.g. statement_pdf parent, or extraction
+     * could not produce any), not "field missing from response".
+     */
+    items: z.array(TransactionItem),
   })
   .openapi("Transaction");
 
@@ -176,54 +229,3 @@ export const BulkResponse = z
   .object({ results: z.array(BulkResultItem) })
   .openapi("BulkResponse");
 
-// ── Line items (#81 Phase 1) ───────────────────────────────────────────
-
-/**
- * Per-line item shape stored under `transactions.metadata.items` (#81
- * Phase 1 — JSONB only, no dedicated table yet). The agent populates
- * this array on every ingest and re-extract of receipt_image /
- * receipt_email / receipt_pdf; statement_pdf transactions omit items
- * (their rows ARE the line equivalents).
- *
- * Read-only from the API today — clients consume `Transaction.metadata.items`
- * via this typed view. Phase 2 lifts the data to a `transaction_items`
- * table; the field names stay identical so client code doesn't change
- * shape on that migration.
- */
-export const TransactionItem = z
-  .object({
-    /** 1-based, preserves the printed order on the receipt. */
-    line_no: z.number().int().positive(),
-    /** Verbatim line as printed (abbreviations, brand prefixes preserved). */
-    raw_name: z.string(),
-    /** Brand-stripped human-readable form, or NULL when raw is already clean. */
-    normalized_name: z.string().nullable(),
-    quantity: z.number().nullable(),
-    /** "ct", "lb", "kg", "oz", "ea", "ml", "gal", or NULL. */
-    unit: z.string().nullable(),
-    /** Minor units (cents for USD). NULL for single-line items that omit. */
-    unit_price_minor: z.number().int().nullable(),
-    /** Minor units, signed. Negative for line-level discounts / coupons. */
-    line_total_minor: z.number().int(),
-    /** ISO 4217. Matches the parent transaction's currency in MVP. */
-    currency: z.string(),
-    item_class: z.enum([
-      "durable",
-      "consumable",
-      "food_drink",
-      "service",
-      "other",
-    ]),
-    /** Only when `item_class='durable'`. NULL otherwise. */
-    durability_tier: z.enum(["luxury", "standard"]).nullable().optional(),
-    /** Only when `item_class='food_drink'`. NULL otherwise. */
-    food_kind: z
-      .enum(["restaurant_dish", "grocery_food", "beverage"])
-      .nullable()
-      .optional(),
-    tags: z.array(z.string()).nullable().optional(),
-    confidence: z.enum(["high", "medium", "low"]),
-  })
-  .openapi("TransactionItem");
-
-export type TransactionItemShape = z.infer<typeof TransactionItem>;


### PR DESCRIPTION
## Summary

Phase 1 (#105) shipped the items schema in `transactions.metadata.items` (JSONB). This PR lifts those items to a typed `transaction_items` table so we can JOIN/index/aggregate across receipts without JSON scans.

## Scope

**Migration `0015_natural_ezekiel_stane`** creates `transaction_items` with the same 5-class taxonomy + durability_tier + food_kind enums Phase 1 already established. No taxonomy churn. Constraints + indexes:
- `UNIQUE (transaction_id, line_no)` — makes re-extract idempotent
- `(workspace_id, item_class, created_at DESC)` — for `GET /v1/items?class=…`
- GIN index on `tags[]` — for future tag search
- CHECK constraints on item_class / durability_tier / food_kind / confidence

**Ingest path** (`src/ingest/prompt.ts`, Phase 4 receipt template): adds a `ti` CTE alongside the existing `tx` / `p1` / `p2` / `dl` writes. Uses `jsonb_to_recordset` on the same `<ITEMS_JSON_ARRAY>` placeholder Phase 1 already populated — zero new agent work.

**Re-extract path** (`src/ingest/reextract-prompt.ts`): bumps `REEXTRACT_PROMPT_VERSION` 1.1 → 1.2 and adds a `DELETE FROM transaction_items WHERE transaction_id = $tx; INSERT …` pair so re-extract is idempotent against the UNIQUE constraint.

**Read path** (`src/routes/transactions.service.ts`):
- `loadTransactionFull` (single-tx GET) and the list path both bulk-load `transaction_items` and surface them as `items[]` on the Transaction DTO.
- Falls back to reading `metadata.items` when zero table rows exist — old receipts keep rendering. Old shapes (PROMPT v2.5's `description`/`amount_minor`) surface as `null` for the new canonical names; acceptable since those can be re-extracted under v2.6 later.

**New endpoint**: `GET /v1/items?class=&from=&to=&tag=&transaction_id=&cursor=&limit=` — workspace-scoped, keyset paginated, returns `TransactionItem` + `id` / `transaction_id` / `created_at`.

## Smoke test

Re-extracted `bda79c9a-47f6-4559-ae69-72342e89c5a7` (Sichuan Spicy Bay) with the new prompt:

```
\d transaction_items   →   table exists, 19 cols, 4 indexes
SELECT ... FROM transaction_items WHERE transaction_id = '...'
→ line_no=1, raw_name='TOTAL ONLY', line_total_minor=8281,
  tags={no-item-section}, extraction_version='1.2'

GET /v1/transactions/bda79c9a... → items[0].raw_name = 'TOTAL ONLY' ✅
GET /v1/items?class=other&limit=5 → 1 row, id+transaction_id present ✅
GET /v1/transactions/04982592... (pre-#81 Costco) → items[0] from metadata
  fallback (raw_name=null, description present in metadata.items) ✅
```

## Acceptance criteria

- [x] `transaction_items` table created with full CHECK + UNIQUE + index set
- [x] Drizzle journal updated (0015 hash inserted into `__drizzle_migrations`)
- [x] Re-extract is idempotent (delete-then-insert, no UNIQUE violation)
- [x] `loadTransactionFull` returns `items[]` from the table
- [x] `listTransactions` bulk-loads items for all page rows
- [x] `metadata.items` fallback preserves pre-#81 receipt visibility
- [x] `GET /v1/items` returns paginated workspace-scoped rows
- [x] OpenAPI spec regenerated (74 schemas, 46 paths)
- [x] `npm run build` passes

## Out of scope

- **Backfill of pre-#81 receipts** into `transaction_items` — those rows surface via the metadata fallback. A future maintenance run can `INSERT INTO transaction_items SELECT FROM` over them, or simply re-extract them under v2.6.
- **`products` SSOT** (next PR) — `transaction_items.product_id` FK is the join point for #84 Phase 1; this PR leaves `product_id` off until that table exists.
- **Frontend display** — clients consume `items[]` off the Transaction DTO already; surfacing them visibly is a separate FE issue.

Refs #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)