### PR TITLE
feat(#84): Phase 1 — products SSOT + per-line allocation + versioning

### DIFF
--- a/drizzle/0016_complete_gateway.sql
+++ b/drizzle/0016_complete_gateway.sql
@@ -1,0 +1,70 @@
+-- #84 Phase 1: products SSOT + transaction_items allocation & versioning.
+--
+-- Three things land together because they only make sense together:
+--   1. `products` table — canonical catalog ("what is this thing")
+--   2. `transaction_items` extensions — per-line tax/tip/discount
+--      allocation columns + product_id FK + soft-delete versioning
+--   3. `transaction_items_live` view — filter convenience for callers
+--
+-- See issue #84 for the full motivation. Carbon-copy values to
+-- watch: `item_class` is the ONLY enumerated CHECK column on this
+-- migration — every other taxonomy is free text per the user's
+-- explicit "越少 hard-code" principle.
+
+CREATE TABLE "products" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"product_key" text NOT NULL,
+	"canonical_name" text NOT NULL,
+	"merchant_id" uuid,
+	"brand_id" text,
+	"item_class" text NOT NULL,
+	"model" text,
+	"color" text,
+	"size" text,
+	"variant" text,
+	"sku" text,
+	"manufacturer" text,
+	"first_purchased_on" date,
+	"last_purchased_on" date,
+	"purchase_count" integer DEFAULT 0 NOT NULL,
+	"total_spent_minor" bigint DEFAULT 0 NOT NULL,
+	"custom_name" text,
+	"notes" text,
+	"retired_from_catalog_at" timestamp with time zone,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	CONSTRAINT "products_item_class_ck" CHECK ("products"."item_class" IN ('durable','consumable','food_drink','service','other'))
+);
+--> statement-breakpoint
+DROP INDEX "transaction_items_line_no_uq";--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD COLUMN "line_type" text DEFAULT 'product' NOT NULL;--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD COLUMN "product_id" uuid;--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD COLUMN "tax_minor" bigint;--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD COLUMN "tip_share_minor" bigint;--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD COLUMN "discount_share_minor" bigint;--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD COLUMN "effective_total_minor" bigint GENERATED ALWAYS AS (line_total_minor + COALESCE(tax_minor, 0) + COALESCE(tip_share_minor, 0) - COALESCE(discount_share_minor, 0)) STORED;--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD COLUMN "extraction_run" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD COLUMN "retired_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "products" ADD CONSTRAINT "products_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "products" ADD CONSTRAINT "products_merchant_id_merchants_id_fk" FOREIGN KEY ("merchant_id") REFERENCES "public"."merchants"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+-- NULLS NOT DISTINCT (PG 15+) so merchant_id=NULL (portable products
+-- like iPhone) participates in the unique constraint. Without this,
+-- two iPhone rows could be inserted because PG treats NULL as
+-- distinct from NULL by default.
+CREATE UNIQUE INDEX "products_workspace_merchant_key_uq" ON "products" USING btree ("workspace_id","merchant_id","product_key") NULLS NOT DISTINCT;--> statement-breakpoint
+CREATE INDEX "products_workspace_class_idx" ON "products" USING btree ("workspace_id","item_class");--> statement-breakpoint
+CREATE INDEX "products_workspace_brand_idx" ON "products" USING btree ("workspace_id","brand_id");--> statement-breakpoint
+CREATE INDEX "products_workspace_merchant_idx" ON "products" USING btree ("workspace_id","merchant_id");--> statement-breakpoint
+ALTER TABLE "transaction_items" ADD CONSTRAINT "transaction_items_product_id_products_id_fk" FOREIGN KEY ("product_id") REFERENCES "public"."products"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "transaction_items_line_no_run_uq" ON "transaction_items" USING btree ("transaction_id","line_no","extraction_run");--> statement-breakpoint
+-- Partial indexes: only over LIVE rows. Re-extract soft-deletes
+-- prior runs via `retired_at`; every query must filter
+-- `retired_at IS NULL` to skip them.
+CREATE INDEX "transaction_items_workspace_line_type_live_idx" ON "transaction_items" USING btree ("workspace_id","line_type") WHERE retired_at IS NULL;--> statement-breakpoint
+CREATE INDEX "transaction_items_workspace_product_live_idx" ON "transaction_items" USING btree ("workspace_id","product_id") WHERE retired_at IS NULL;--> statement-breakpoint
+CREATE INDEX "transaction_items_tx_extraction_run_idx" ON "transaction_items" USING btree ("transaction_id","extraction_run");--> statement-breakpoint
+-- Ergonomic view so callers don't forget the retired filter.
+CREATE VIEW "transaction_items_live" AS
+  SELECT * FROM "transaction_items" WHERE retired_at IS NULL;

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,3353 @@
+{
+  "id": "e750f876-37fe-4dbd-a0db-1f8efdc08000",
+  "prevId": "e64c1107-892e-4811-b95c-f6a015c84e44",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_uniq": {
+          "name": "users_email_lower_uniq",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_users_id_fk": {
+          "name": "workspace_members_user_id_users_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_workspace_id_user_id_pk": {
+          "name": "workspace_members_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_owner_id_users_id_fk": {
+          "name": "workspaces_owner_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_balance_minor": {
+          "name": "opening_balance_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "accounts_workspace_idx": {
+          "name": "accounts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_parent_idx": {
+          "name": "accounts_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_workspace_type_idx": {
+          "name": "accounts_workspace_type_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_workspace_id_workspaces_id_fk": {
+          "name": "accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_parent_id_accounts_id_fk": {
+          "name": "accounts_parent_id_accounts_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narration": {
+          "name": "narration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "txn_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "voided_by_id": {
+          "name": "voided_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transactions_keyset_idx": {
+          "name": "transactions_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_created_at_keyset_idx": {
+          "name": "transactions_created_at_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_source_ingest_idx": {
+          "name": "transactions_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_trip_idx": {
+          "name": "transactions_trip_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_place_idx": {
+          "name": "transactions_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_merchant_idx": {
+          "name": "transactions_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_workspace_id_workspaces_id_fk": {
+          "name": "transactions_workspace_id_workspaces_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_voided_by_id_transactions_id_fk": {
+          "name": "transactions_voided_by_id_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "voided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_source_ingest_id_ingests_id_fk": {
+          "name": "transactions_source_ingest_id_ingests_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_place_id_places_id_fk": {
+          "name": "transactions_place_id_places_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_merchant_id_merchants_id_fk": {
+          "name": "transactions_merchant_id_merchants_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_created_by_users_id_fk": {
+          "name": "transactions_created_by_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_purchased_on": {
+          "name": "first_purchased_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_purchased_on": {
+          "name": "last_purchased_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_spent_minor": {
+          "name": "total_spent_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_from_catalog_at": {
+          "name": "retired_from_catalog_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "products_workspace_merchant_key_uq": {
+          "name": "products_workspace_merchant_key_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_class_idx": {
+          "name": "products_workspace_class_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_brand_idx": {
+          "name": "products_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_merchant_idx": {
+          "name": "products_workspace_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_workspace_id_workspaces_id_fk": {
+          "name": "products_workspace_id_workspaces_id_fk",
+          "tableFrom": "products",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "products_merchant_id_merchants_id_fk": {
+          "name": "products_merchant_id_merchants_id_fk",
+          "tableFrom": "products",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "products_item_class_ck": {
+          "name": "products_item_class_ck",
+          "value": "\"products\".\"item_class\" IN ('durable','consumable','food_drink','service','other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transaction_items": {
+      "name": "transaction_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price_minor": {
+          "name": "unit_price_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_total_minor": {
+          "name": "line_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability_tier": {
+          "name": "durability_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_kind": {
+          "name": "food_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'product'"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_minor": {
+          "name": "tax_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tip_share_minor": {
+          "name": "tip_share_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_share_minor": {
+          "name": "discount_share_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_total_minor": {
+          "name": "effective_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "line_total_minor + COALESCE(tax_minor, 0) + COALESCE(tip_share_minor, 0) - COALESCE(discount_share_minor, 0)",
+            "type": "stored"
+          }
+        },
+        "extraction_run": {
+          "name": "extraction_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transaction_items_line_no_run_uq": {
+          "name": "transaction_items_line_no_run_uq",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "extraction_run",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_items_tx_idx": {
+          "name": "transaction_items_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_items_workspace_class_created_idx": {
+          "name": "transaction_items_workspace_class_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_items_workspace_id_workspaces_id_fk": {
+          "name": "transaction_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_items_transaction_id_transactions_id_fk": {
+          "name": "transaction_items_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_items_product_id_products_id_fk": {
+          "name": "transaction_items_product_id_products_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.postings": {
+      "name": "postings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fx_rate": {
+          "name": "fx_rate",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_base_minor": {
+          "name": "amount_base_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "postings_transaction_idx": {
+          "name": "postings_transaction_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_account_idx": {
+          "name": "postings_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_workspace_idx": {
+          "name": "postings_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "postings_workspace_id_workspaces_id_fk": {
+          "name": "postings_workspace_id_workspaces_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_transaction_id_transactions_id_fk": {
+          "name": "postings_transaction_id_transactions_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_account_id_accounts_id_fk": {
+          "name": "postings_account_id_accounts_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_links": {
+      "name": "document_links",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "document_links_txn_idx": {
+          "name": "document_links_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_links_document_id_documents_id_fk": {
+          "name": "document_links_document_id_documents_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_links_transaction_id_transactions_id_fk": {
+          "name": "document_links_transaction_id_transactions_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_links_document_id_transaction_id_pk": {
+          "name": "document_links_document_id_transaction_id_pk",
+          "columns": [
+            "document_id",
+            "transaction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocr_text": {
+          "name": "ocr_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_model_version": {
+          "name": "ocr_model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_meta": {
+          "name": "extraction_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "documents_workspace_sha_uniq": {
+          "name": "documents_workspace_sha_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_kind_idx": {
+          "name": "documents_kind_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_source_ingest_idx": {
+          "name": "documents_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_workspace_live_idx": {
+          "name": "documents_workspace_live_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"documents\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_workspace_id_workspaces_id_fk": {
+          "name": "documents_workspace_id_workspaces_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_source_ingest_id_ingests_id_fk": {
+          "name": "documents_source_ingest_id_ingests_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_events": {
+      "name": "transaction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "txn_events_txn_idx": {
+          "name": "txn_events_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_events_workspace_id_workspaces_id_fk": {
+          "name": "transaction_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_transaction_id_transactions_id_fk": {
+          "name": "transaction_events_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_actor_id_users_id_fk": {
+          "name": "transaction_events_actor_id_users_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "idempotency_keys_uniq": {
+          "name": "idempotency_keys_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_workspace_id_workspaces_id_fk": {
+          "name": "idempotency_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reconcile": {
+          "name": "auto_reconcile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "batches_workspace_created_idx": {
+          "name": "batches_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_status_idx": {
+          "name": "batches_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batches_workspace_id_workspaces_id_fk": {
+          "name": "batches_workspace_id_workspaces_id_fk",
+          "tableFrom": "batches",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingests": {
+      "name": "ingests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ingest_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "produced": {
+          "name": "produced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingests_batch_idx": {
+          "name": "ingests_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_workspace_created_idx": {
+          "name": "ingests_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_status_idx": {
+          "name": "ingests_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingests_workspace_id_workspaces_id_fk": {
+          "name": "ingests_workspace_id_workspaces_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingests_batch_id_batches_id_fk": {
+          "name": "ingests_batch_id_batches_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconcile_proposals": {
+      "name": "reconcile_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconcile_proposals_batch_idx": {
+          "name": "reconcile_proposals_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconcile_proposals_kind_idx": {
+          "name": "reconcile_proposals_kind_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconcile_proposals_batch_id_batches_id_fk": {
+          "name": "reconcile_proposals_batch_id_batches_id_fk",
+          "tableFrom": "reconcile_proposals",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_photos": {
+      "name": "place_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_photo_name": {
+          "name": "google_photo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width_px": {
+          "name": "width_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_px": {
+          "name": "height_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_attributions": {
+          "name": "author_attributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_extracted": {
+          "name": "ocr_extracted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_reviews": {
+      "name": "place_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_review_name": {
+          "name": "google_review_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_language": {
+          "name": "text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_text": {
+          "name": "original_text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_language": {
+          "name": "original_text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relative_publish_time": {
+          "name": "relative_publish_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_time": {
+          "name": "publish_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_uri": {
+          "name": "author_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_photo_uri": {
+          "name": "author_photo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_taken_at": {
+          "name": "snapshot_taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "google_place_id": {
+          "name": "google_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_name_en": {
+          "name": "display_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh": {
+          "name": "display_name_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_locale": {
+          "name": "display_name_zh_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_source": {
+          "name": "display_name_zh_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_is_native": {
+          "name": "display_name_zh_is_native",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type_display_zh": {
+          "name": "primary_type_display_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maps_type_label_zh": {
+          "name": "maps_type_label_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "types": {
+          "name": "types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_en": {
+          "name": "formatted_address_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_zh": {
+          "name": "formatted_address_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_status": {
+          "name": "business_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_hours": {
+          "name": "business_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_rating_count": {
+          "name": "user_rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "national_phone_number": {
+          "name": "national_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_uri": {
+          "name": "website_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_maps_uri": {
+          "name": "google_maps_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_business_id": {
+          "name": "yelp_business_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_alias": {
+          "name": "yelp_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_price_level": {
+          "name": "yelp_price_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_categories": {
+          "name": "yelp_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_raw_response": {
+          "name": "yelp_raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "places_lat_lng_idx": {
+          "name": "places_lat_lng_idx",
+          "columns": [
+            {
+              "expression": "lat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lng",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "places_google_place_id_unique": {
+          "name": "places_google_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_place_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_snapshots": {
+      "name": "place_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "fetched_by_sha": {
+          "name": "fetched_by_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "place_snapshots_place_idx": {
+          "name": "place_snapshots_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "place_snapshots_place_id_places_id_fk": {
+          "name": "place_snapshots_place_id_places_id_fk",
+          "tableFrom": "place_snapshots",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merchants": {
+      "name": "merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_attribution": {
+          "name": "photo_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_status": {
+          "name": "enrichment_status",
+          "type": "merchant_enrichment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enrichment_attempted_at": {
+          "name": "enrichment_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "merchants_workspace_brand_idx": {
+          "name": "merchants_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merchants_workspace_idx": {
+          "name": "merchants_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merchants_enrichment_pending_idx": {
+          "name": "merchants_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "merchants_workspace_id_workspaces_id_fk": {
+          "name": "merchants_workspace_id_workspaces_id_fk",
+          "tableFrom": "merchants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "merchants_brand_id_format": {
+          "name": "merchants_brand_id_format",
+          "value": "\"merchants\".\"brand_id\" ~ '^[a-z0-9-]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.derivation_events": {
+      "name": "derivation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_git_sha": {
+          "name": "prompt_git_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_keys": {
+          "name": "changed_keys",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "derivation_events_entity_idx": {
+          "name": "derivation_events_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "derivation_events_version_idx": {
+          "name": "derivation_events_version_idx",
+          "columns": [
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "derivation_events_workspace_id_workspaces_id_fk": {
+          "name": "derivation_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "derivation_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "asset",
+        "liability",
+        "equity",
+        "income",
+        "expense"
+      ]
+    },
+    "public.batch_status": {
+      "name": "batch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "extracted",
+        "reconciling",
+        "reconciled",
+        "failed",
+        "reconcile_error"
+      ]
+    },
+    "public.document_kind": {
+      "name": "document_kind",
+      "schema": "public",
+      "values": [
+        "receipt_image",
+        "receipt_email",
+        "receipt_pdf",
+        "statement_pdf",
+        "other"
+      ]
+    },
+    "public.ingest_status": {
+      "name": "ingest_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "done",
+        "error",
+        "unsupported"
+      ]
+    },
+    "public.merchant_enrichment_status": {
+      "name": "merchant_enrichment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "not_found",
+        "failed"
+      ]
+    },
+    "public.txn_status": {
+      "name": "txn_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided",
+        "reconciled",
+        "error"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1778911497324,
       "tag": "0015_natural_ezekiel_stane",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1778913979897,
+      "tag": "0016_complete_gateway",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -996,6 +996,43 @@
               "medium",
               "low"
             ]
+          },
+          "line_type": {
+            "type": "string",
+            "default": "product"
+          },
+          "product_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "default": null,
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "tax_minor": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "default": null
+          },
+          "tip_share_minor": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "default": null
+          },
+          "discount_share_minor": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "default": null
+          },
+          "effective_total_minor": {
+            "type": "integer"
           }
         },
         "required": [
@@ -1008,7 +1045,8 @@
           "line_total_minor",
           "currency",
           "item_class",
-          "confidence"
+          "confidence",
+          "effective_total_minor"
         ]
       },
       "Transaction": {
@@ -1199,6 +1237,206 @@
             ]
           }
         ]
+      },
+      "Product": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "workspace_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "product_key": {
+            "type": "string"
+          },
+          "canonical_name": {
+            "type": "string"
+          },
+          "merchant_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "brand_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "item_class": {
+            "type": "string",
+            "enum": [
+              "durable",
+              "consumable",
+              "food_drink",
+              "service",
+              "other"
+            ]
+          },
+          "model": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "color": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "size": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "variant": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sku": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "manufacturer": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "first_purchased_on": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "last_purchased_on": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "example": "2026-04-19"
+          },
+          "purchase_count": {
+            "type": "integer"
+          },
+          "total_spent_minor": {
+            "type": "integer"
+          },
+          "custom_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "retired_from_catalog_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {},
+            "description": "User-defined JSON object; not schema-validated."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "workspace_id",
+          "product_key",
+          "canonical_name",
+          "merchant_id",
+          "brand_id",
+          "item_class",
+          "model",
+          "color",
+          "size",
+          "variant",
+          "sku",
+          "manufacturer",
+          "first_purchased_on",
+          "last_purchased_on",
+          "purchase_count",
+          "total_spent_minor",
+          "custom_name",
+          "notes",
+          "retired_from_catalog_at",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "UpdateProductRequest": {
+        "type": "object",
+        "properties": {
+          "custom_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "brand_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "merchant_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "retired_from_catalog_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        }
       },
       "Document": {
         "type": "object",
@@ -4474,6 +4712,212 @@
           },
           "400": {
             "description": "Bad request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/products": {
+      "get": {
+        "summary": "List products in the workspace catalog",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "durable",
+                "consumable",
+                "food_drink",
+                "service",
+                "other"
+              ]
+            },
+            "required": false,
+            "name": "class",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "brand_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": false,
+            "name": "merchant_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "required": false,
+            "name": "include_retired",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Product"
+                      }
+                    },
+                    "next_cursor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "next_cursor"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/products/{id}": {
+      "get": {
+        "summary": "Fetch a single product",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Patch product user-truth fields",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ import { problemHandler } from "./http/problem.js";
 import { accountsRouter } from "./routes/accounts.js";
 import { transactionsRouter } from "./routes/transactions.js";
 import { itemsRouter } from "./routes/items.js";
+import { productsRouter } from "./routes/products.js";
 import { postingsRouter } from "./routes/postings.js";
 import { documentsRouter } from "./routes/documents.js";
 import {
@@ -73,6 +74,7 @@ export function buildApp(): Express {
   app.use("/v1/accounts", accountsRouter);
   app.use("/v1/transactions", transactionsRouter);
   app.use("/v1/items", itemsRouter);
+  app.use("/v1/products", productsRouter);
   app.use("/v1/postings", postingsRouter);
   app.use("/v1/documents", documentsRouter);
   app.use("/v1/ingest", ingestRouter);

--- a/src/generated/build-info.ts
+++ b/src/generated/build-info.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant",
   "version": "1.0.0",
-  "gitSha": "ed41b9b8144bee6f0aa3e4b831b848b9630b852e",
-  "gitShortSha": "ed41b9b",
-  "gitBranch": "feat/81-phase2-transaction-items",
-  "builtAt": "2026-05-16T06:09:18.217Z"
+  "gitSha": "92e24dda5d92baa95fe76b232b75484743aa8b6d",
+  "gitShortSha": "92e24dd",
+  "gitBranch": "feat/84-phase1-products-allocation",
+  "builtAt": "2026-05-16T08:16:22.818Z"
 } as const;

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -17,7 +17,7 @@ import { buildInfo } from "../generated/build-info.js";
  * `extraction.prompt_version` ≠ `PROMPT_VERSION` are eligible to be
  * re-derived. See #80 / #88 for the 3-layer data model rationale.
  */
-export const PROMPT_VERSION = "2.6";
+export const PROMPT_VERSION = "2.7";
 
 export interface ExtractorPromptContext {
   /** Absolute path inside the container where the file was staged. */
@@ -163,6 +163,72 @@ Each \`item\` object has these fields:
                                  low    — thermal-paper smudge,
                                           ink fade, partial occlusion
 
+  ── Phase 1 of #84: products SSOT + allocation fields ──
+
+  line_type          text       prompt-recommended values:
+                                 product  — the default, an actual line
+                                 tax      — printed tax aggregate row
+                                 tip      — printed tip aggregate row
+                                 discount — store discount aggregate row
+                                 shipping | surcharge | service_fee |
+                                 gift_card | …
+                                Invent a snake_case label when none fit.
+                                tax/tip/discount rows MUST appear if
+                                printed — they're the audit baseline
+                                against the per-line allocations below.
+
+  product_key        text|null  kebab-case canonical key. REQUIRED for
+                                line_type='product'; NULL for tax/tip/
+                                discount rows. Format: ^[a-z0-9-]+\$.
+                                Same product → same key forever.
+                                Variants get distinct keys:
+                                  iphone-15-pro-natural-titanium-256
+                                  iphone-15-pro-blue-titanium-256
+                                  kirkland-paper-towels-12ct
+                                  starbucks-grande-latte
+                                  costco-gas-regular   (NOT just "gas")
+                                Don't include the merchant id in the key
+                                — merchant scoping lives on a separate
+                                column.
+
+  product_brand_id   text|null  the manufacturer brand, NOT the seller.
+                                "apple" for iPhone, "kirkland" for KS
+                                products, "starbucks" for in-store
+                                espresso. Mirror the merchant block's
+                                brand_id rules.
+
+  product_merchant_exclusive bool|null
+                                true  → this product only exists at
+                                        this merchant (Crunchwrap @
+                                        Taco Bell, AYCE @ Sichuan Spicy
+                                        Bay, in-store private label).
+                                        Phase 4 binds product.merchant_id
+                                        to this receipt's merchant.
+                                false → portable / cross-merchant
+                                        (iPhone, Coke, brand-name goods).
+                                        product.merchant_id stays NULL
+                                        and the row shares across stores.
+
+  product_model      text|null   "M3 13\\" 256GB", "iPad Pro 11\\""
+  product_color      text|null   "Natural Titanium", "Black", "Red"
+  product_size       text|null   "L", "12 ct", "750 ml"
+  product_variant    text|null   free-text catch-all (flavor, fit, finish)
+  product_sku        text|null   when printed on the receipt
+  product_manufacturer text|null when the brand and the manufacturer
+                                differ ("kirkland" brand made by
+                                "georgia-pacific" manufacturer); leave
+                                NULL when they match.
+
+  tax_minor          int|null    per-line tax share allocated from the
+                                printed tax aggregate. See Phase 2.7
+                                allocation logic. NULL on tax/tip/
+                                discount rows themselves and on lines
+                                you decide are non-taxable.
+  tip_share_minor    int|null    per-line tip share from printed tip.
+  discount_share_minor int|null  per-line discount share. Signed
+                                positive (always reduces). NULL when
+                                no discount applies.
+
 Arithmetic invariant — Σ line_total_minor across all items SHOULD
 approximate the receipt's printed subtotal (within \$0.01 rounding;
 tax/tip/discount lines are themselves items or excluded — see
@@ -209,6 +275,47 @@ Best Buy laptop ($1,599):
 For statement_pdf, pull rows: { date, payee, amount_minor }.
 
 For unsupported, record a short reason.
+
+── Phase 2.7 — Per-line tax / tip / discount allocation (#84) ─────────
+
+Receipts print aggregate tax / tip / discount; users want "what did
+this specific line cost me, all-in." Allocate per-line at ingest.
+Recommended logic (apply real arithmetic; do NOT hard-code rates):
+
+Tax allocation:
+  1. Look for per-line taxability markers ("T", "T1/T2", asterisks
+     next to specific lines, "Taxable" labels).
+  2. If markers present: \`tax_minor\` for each taxable line =
+     ROUND(printed-tax-total × line_total_minor / Σ taxable lines).
+     Non-taxable lines → tax_minor = NULL.
+  3. If no markers: treat all line_type='product' rows as equally
+     taxable and allocate proportionally.
+  4. Make Σ tax_minor exactly match the printed tax (absorb the
+     rounding remainder on the largest line).
+
+Tip allocation (dining receipts):
+  Split the printed tip total proportionally across product lines
+  by \`line_total_minor\`. Tips are for the whole meal.
+
+Discount allocation:
+  Receipt names the target ("20% off Item X") → put it all on that
+  line. Whole-order ("\$5 off subtotal") → split proportionally.
+  BOGO / "buy 2 get 1 free" / promo edge cases → use judgment;
+  record the reasoning in transactions.metadata.allocation_audit.
+
+Always emit the printed tax / tip / discount rows themselves as
+items with line_type ∈ ('tax','tip','discount') and product_key=NULL.
+Their tax_minor / tip_share_minor / discount_share_minor stay NULL
+— a tax line is not itself taxed.
+
+Final self-check before COMMIT:
+  Σ effective_total_minor (line_type='product') ≈ transactions.total
+  Σ tax_minor      ≈ items where line_type='tax'
+  Σ tip_share_minor ≈ items where line_type='tip'
+  Σ discount_share_minor ≈ items where line_type='discount'
+Discrepancies > 1¢ → record in transactions.metadata.allocation_audit
+(structured object: \`{kind, expected, got, delta}\`). Don't block
+ingest — just log.
 
 ── Phase 2.5 — Merchant canonicalization (#64) ────────────────────────
 
@@ -748,41 +855,125 @@ them first):
       ON CONFLICT DO NOTHING
       RETURNING transaction_id
     ),
-    -- #81 Phase 2: relational line-items. One INSERT per item from
-    -- your Phase 2 items[] array. The shape is identical to the
-    -- jsonb_build_object's 'items' key — both stay in sync this
-    -- release; clients read items off the table, the metadata copy
-    -- is the on-the-wire archive of the agent's exact emission.
-    -- Use ARRAY[]::text[] when tags is empty / NULL.
-    -- Re-extract on the same tx clears + reinserts via the (tx_id,
-    -- line_no) unique constraint; ingest only ever inserts (the
-    -- transaction is brand new here, so no conflicts possible).
+    -- #84 Phase 1: products SSOT upsert. The agent emits a
+    -- product_key per item; this CTE upserts the catalog row keyed by
+    -- (workspace_id, merchant_id, product_key) and returns its id.
+    -- merchant_id is NULL when product_merchant_exclusive=false (the
+    -- product is portable across stores) and the receipt's
+    -- merchant_id when true (in-store private label / dish).
+    -- Non-product lines (line_type ∈ tax/tip/discount/shipping/…) get
+    -- product_key=NULL and skip this step entirely (filtered by the
+    -- WHERE clause). NULLS NOT DISTINCT in the unique index makes
+    -- merchant_id=NULL participate.
+    p_upsert AS (
+      INSERT INTO products (
+        workspace_id, merchant_id, product_key, canonical_name,
+        item_class, brand_id, model, color, size, variant, sku,
+        manufacturer
+      )
+      SELECT '${ctx.workspaceId}',
+             CASE WHEN item.product_merchant_exclusive THEN (SELECT id FROM m) ELSE NULL END,
+             item.product_key,
+             COALESCE(item.normalized_name, item.raw_name),
+             item.item_class, item.product_brand_id,
+             item.product_model, item.product_color, item.product_size,
+             item.product_variant, item.product_sku, item.product_manufacturer
+      FROM jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb) AS item(
+        line_no int, raw_name text, normalized_name text,
+        quantity numeric, unit text,
+        unit_price_minor bigint, line_total_minor bigint, currency text,
+        item_class text, durability_tier text, food_kind text,
+        tags text[], confidence text,
+        line_type text, product_key text, product_brand_id text,
+        product_merchant_exclusive boolean, product_model text,
+        product_color text, product_size text, product_variant text,
+        product_sku text, product_manufacturer text,
+        tax_minor bigint, tip_share_minor bigint, discount_share_minor bigint
+      )
+      WHERE COALESCE(item.line_type, 'product') = 'product' AND item.product_key IS NOT NULL
+      ON CONFLICT (workspace_id, merchant_id, product_key) DO UPDATE
+        SET updated_at = NOW(),
+            canonical_name = COALESCE(EXCLUDED.canonical_name, products.canonical_name),
+            brand_id       = COALESCE(EXCLUDED.brand_id,       products.brand_id),
+            item_class     = COALESCE(EXCLUDED.item_class,     products.item_class)
+      RETURNING id, product_key, merchant_id
+    ),
+    -- #81 Phase 2 + #84: relational line-items with product_id link
+    -- and per-line allocation columns. Re-extract on the same tx
+    -- bumps extraction_run and soft-deletes the prior run; this
+    -- ingest path always writes the first run (run=1, retired_at=NULL).
     ti AS (
       INSERT INTO transaction_items (
         id, workspace_id, transaction_id, line_no,
         raw_name, normalized_name, quantity, unit,
         unit_price_minor, line_total_minor, currency,
         item_class, durability_tier, food_kind, tags, confidence,
-        extraction_version
+        line_type, product_id, tax_minor, tip_share_minor,
+        discount_share_minor, extraction_run, extraction_version
       )
       SELECT gen_random_uuid(), '${ctx.workspaceId}', tx.id, item.line_no,
              item.raw_name, item.normalized_name, item.quantity, item.unit,
              item.unit_price_minor, item.line_total_minor, item.currency,
              item.item_class, item.durability_tier, item.food_kind,
              item.tags, item.confidence,
-             '${PROMPT_VERSION}'
+             COALESCE(item.line_type, 'product'),
+             (SELECT pu.id FROM p_upsert pu
+                WHERE pu.product_key = item.product_key
+                  AND pu.merchant_id IS NOT DISTINCT FROM
+                      (CASE WHEN item.product_merchant_exclusive THEN (SELECT id FROM m) ELSE NULL END)
+                LIMIT 1),
+             item.tax_minor, item.tip_share_minor, item.discount_share_minor,
+             1, '${PROMPT_VERSION}'
       FROM tx,
         jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb) AS item(
           line_no int, raw_name text, normalized_name text,
           quantity numeric, unit text,
           unit_price_minor bigint, line_total_minor bigint, currency text,
           item_class text, durability_tier text, food_kind text,
-          tags text[], confidence text
+          tags text[], confidence text,
+          line_type text, product_key text, product_brand_id text,
+          product_merchant_exclusive boolean, product_model text,
+          product_color text, product_size text, product_variant text,
+          product_sku text, product_manufacturer text,
+          tax_minor bigint, tip_share_minor bigint, discount_share_minor bigint
         )
-      RETURNING id
+      RETURNING id, product_id
     )
   SELECT tx.id AS tx_id FROM tx;
   COMMIT;
+  SQL
+
+After the main block commits, run the products aggregate recomputation
+for every product touched by this ingest. The agent runs this so
+the stats reflect THE LIVE set of transaction_items immediately —
+this is the recompute-not-increment rule from #84. \`from_dt\` is
+optional; use the workspace base currency snapshot already on
+\`postings.amount_base_minor\` for total_spent_minor:
+
+  psql "\$DATABASE_URL" <<'SQL'
+  WITH stats AS (
+    SELECT ti.product_id,
+           MIN(t.occurred_on)          AS first_on,
+           MAX(t.occurred_on)          AS last_on,
+           COUNT(DISTINCT ti.transaction_id) AS purchases,
+           SUM(ti.effective_total_minor)    AS total_minor
+    FROM transaction_items ti
+    JOIN transactions t ON t.id = ti.transaction_id
+    WHERE ti.workspace_id = '${ctx.workspaceId}'
+      AND ti.product_id IS NOT NULL
+      AND ti.retired_at IS NULL
+      AND ti.line_type = 'product'
+    GROUP BY ti.product_id
+  )
+  UPDATE products p SET
+    first_purchased_on = stats.first_on,
+    last_purchased_on  = stats.last_on,
+    purchase_count     = stats.purchases,
+    total_spent_minor  = stats.total_minor,
+    updated_at         = NOW()
+  FROM stats
+  WHERE p.id = stats.product_id
+    AND p.workspace_id = '${ctx.workspaceId}';
   SQL
 
 If you have a geocode result, run this AFTER the main transaction

--- a/src/ingest/reextract-prompt.ts
+++ b/src/ingest/reextract-prompt.ts
@@ -37,7 +37,7 @@ import { buildInfo } from "../generated/build-info.js";
  * into `transactions.metadata.extraction.prompt_version` on every run
  * (overwriting the prior value), and into `derivation_events.prompt_version`.
  */
-export const REEXTRACT_PROMPT_VERSION = "1.2";
+export const REEXTRACT_PROMPT_VERSION = "1.3";
 
 /**
  * The model identifier we stamp into `documents.ocr_model_version`.
@@ -193,34 +193,123 @@ user override survives this re-extract.
     updated_at        = NOW()
   WHERE id = '${ctx.documentId}' AND workspace_id = '${ctx.workspaceId}';
 
-  -- #81 Phase 2: refresh relational items in lockstep with metadata.
-  -- DELETE-then-INSERT inside the same txn is idempotent because the
-  -- UNIQUE (transaction_id, line_no) constraint would otherwise reject
-  -- a second pass. Always reset, even on a no-item receipt (the agent
-  -- emits the 'TOTAL ONLY' fallback row in that case).
-  DELETE FROM transaction_items
-  WHERE transaction_id = '${ctx.transactionId}';
+  -- #84 Phase 1: re-extract is now versioned (extraction_run counter
+  -- bumps; old run rows soft-deleted via retired_at). Live aggregates
+  -- read WHERE retired_at IS NULL, so old purchases drop out and new
+  -- ones count immediately — purchase_count stays correct, no drift.
+  -- Soft-delete every live item belonging to this tx.
+  UPDATE transaction_items
+  SET retired_at = NOW()
+  WHERE transaction_id = '${ctx.transactionId}'
+    AND retired_at IS NULL;
 
+  -- Insert the freshly extracted rows under run = MAX(prev)+1.
+  -- Capture the run number in a temp var via WITH ... SELECT, then
+  -- INSERT. The agent computes this run number inline below.
+  WITH next_run AS (
+    SELECT COALESCE(MAX(extraction_run), 0) + 1 AS run
+    FROM transaction_items
+    WHERE transaction_id = '${ctx.transactionId}'
+  ),
+  p_upsert AS (
+    INSERT INTO products (
+      workspace_id, merchant_id, product_key, canonical_name,
+      item_class, brand_id, model, color, size, variant, sku,
+      manufacturer
+    )
+    SELECT '${ctx.workspaceId}',
+           CASE WHEN item.product_merchant_exclusive THEN
+             (SELECT merchant_id FROM transactions WHERE id = '${ctx.transactionId}')
+           ELSE NULL END,
+           item.product_key,
+           COALESCE(item.normalized_name, item.raw_name),
+           item.item_class, item.product_brand_id,
+           item.product_model, item.product_color, item.product_size,
+           item.product_variant, item.product_sku, item.product_manufacturer
+    FROM jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb) AS item(
+      line_no int, raw_name text, normalized_name text,
+      quantity numeric, unit text,
+      unit_price_minor bigint, line_total_minor bigint, currency text,
+      item_class text, durability_tier text, food_kind text,
+      tags text[], confidence text,
+      line_type text, product_key text, product_brand_id text,
+      product_merchant_exclusive boolean, product_model text,
+      product_color text, product_size text, product_variant text,
+      product_sku text, product_manufacturer text,
+      tax_minor bigint, tip_share_minor bigint, discount_share_minor bigint
+    )
+    WHERE COALESCE(item.line_type, 'product') = 'product' AND item.product_key IS NOT NULL
+    ON CONFLICT (workspace_id, merchant_id, product_key) DO UPDATE
+      SET updated_at = NOW(),
+          canonical_name = COALESCE(EXCLUDED.canonical_name, products.canonical_name),
+          brand_id       = COALESCE(EXCLUDED.brand_id,       products.brand_id),
+          item_class     = COALESCE(EXCLUDED.item_class,     products.item_class)
+    RETURNING id, product_key, merchant_id
+  )
   INSERT INTO transaction_items (
     id, workspace_id, transaction_id, line_no,
     raw_name, normalized_name, quantity, unit,
     unit_price_minor, line_total_minor, currency,
     item_class, durability_tier, food_kind, tags, confidence,
-    extraction_version
+    line_type, product_id, tax_minor, tip_share_minor,
+    discount_share_minor, extraction_run, extraction_version
   )
   SELECT gen_random_uuid(), '${ctx.workspaceId}', '${ctx.transactionId}', item.line_no,
          item.raw_name, item.normalized_name, item.quantity, item.unit,
          item.unit_price_minor, item.line_total_minor, item.currency,
          item.item_class, item.durability_tier, item.food_kind,
          item.tags, item.confidence,
+         COALESCE(item.line_type, 'product'),
+         (SELECT pu.id FROM p_upsert pu
+            WHERE pu.product_key = item.product_key
+              AND pu.merchant_id IS NOT DISTINCT FROM
+                  (CASE WHEN item.product_merchant_exclusive THEN
+                     (SELECT merchant_id FROM transactions WHERE id = '${ctx.transactionId}')
+                   ELSE NULL END)
+            LIMIT 1),
+         item.tax_minor, item.tip_share_minor, item.discount_share_minor,
+         (SELECT run FROM next_run),
          '${REEXTRACT_PROMPT_VERSION}'
   FROM jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb) AS item(
     line_no int, raw_name text, normalized_name text,
     quantity numeric, unit text,
     unit_price_minor bigint, line_total_minor bigint, currency text,
     item_class text, durability_tier text, food_kind text,
-    tags text[], confidence text
+    tags text[], confidence text,
+    line_type text, product_key text, product_brand_id text,
+    product_merchant_exclusive boolean, product_model text,
+    product_color text, product_size text, product_variant text,
+    product_sku text, product_manufacturer text,
+    tax_minor bigint, tip_share_minor bigint, discount_share_minor bigint
   );
+
+  -- #84: recompute aggregate stats for every product whose live
+  -- transaction_items set just changed. The WHERE clause unions
+  -- old-touched + new-touched products by reading the live set,
+  -- which now reflects the post-soft-delete state.
+  WITH stats AS (
+    SELECT ti.product_id,
+           MIN(t.occurred_on) AS first_on,
+           MAX(t.occurred_on) AS last_on,
+           COUNT(DISTINCT ti.transaction_id) AS purchases,
+           SUM(ti.effective_total_minor) AS total_minor
+    FROM transaction_items ti
+    JOIN transactions t ON t.id = ti.transaction_id
+    WHERE ti.workspace_id = '${ctx.workspaceId}'
+      AND ti.product_id IS NOT NULL
+      AND ti.retired_at IS NULL
+      AND ti.line_type = 'product'
+    GROUP BY ti.product_id
+  )
+  UPDATE products p SET
+    first_purchased_on = stats.first_on,
+    last_purchased_on  = stats.last_on,
+    purchase_count     = stats.purchases,
+    total_spent_minor  = stats.total_minor,
+    updated_at         = NOW()
+  FROM stats
+  WHERE p.id = stats.product_id
+    AND p.workspace_id = '${ctx.workspaceId}';
 
   INSERT INTO transaction_events (
     id, workspace_id, transaction_id, event_type, actor_id, payload

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -23,6 +23,7 @@ import { ProblemDetails } from "./schemas/v1/common.js";
 import { registerAccountsOpenApi } from "./routes/accounts.js";
 import { registerTransactionsOpenApi } from "./routes/transactions.js";
 import { registerItemsOpenApi } from "./routes/items.js";
+import { registerProductsOpenApi } from "./routes/products.js";
 import { registerPostingsOpenApi } from "./routes/postings.js";
 import { registerDocumentsOpenApi } from "./routes/documents.js";
 import { registerIngestOpenApi } from "./routes/ingest.js";
@@ -77,6 +78,7 @@ export function buildRegistry(): OpenAPIRegistry {
   registerAccountsOpenApi(registry);
   registerTransactionsOpenApi(registry);
   registerItemsOpenApi(registry);
+  registerProductsOpenApi(registry);
   registerPostingsOpenApi(registry);
   registerDocumentsOpenApi(registry);
   registerIngestOpenApi(registry);

--- a/src/routes/items.ts
+++ b/src/routes/items.ts
@@ -71,6 +71,8 @@ itemsRouter.get(
 
       const conditions: ReturnType<typeof sql>[] = [];
       conditions.push(sql`ti.workspace_id = ${req.ctx.workspaceId}::uuid`);
+      // #84: only live items. Re-extract soft-deletes the prior run.
+      conditions.push(sql`ti.retired_at IS NULL`);
       if (query.class) conditions.push(sql`ti.item_class = ${query.class}`);
       if (query.transaction_id) {
         conditions.push(sql`ti.transaction_id = ${query.transaction_id}::uuid`);

--- a/src/routes/products.ts
+++ b/src/routes/products.ts
@@ -1,0 +1,279 @@
+/**
+ * `/v1/products` — catalog browse + edit.
+ *
+ * The catalog is the canonical "what is this thing" registry; ingest
+ * writes rows here via `ON CONFLICT (workspace_id, merchant_id,
+ * product_key) DO UPDATE` and re-points `transaction_items.product_id`
+ * at the surviving row. This router only exposes read + user-truth
+ * edits. The merge endpoint and admin recompute land in #84 Phase 3.
+ */
+import { Router, type Request, type Response, type NextFunction } from "express";
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+import { sql, eq, and } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { products } from "../schema/index.js";
+import { parseOrThrow } from "../http/validate.js";
+import {
+  Product,
+  UpdateProductRequest,
+  ListProductsQuery,
+} from "../schemas/v1/product.js";
+import { ProblemDetails, paginated, Uuid } from "../schemas/v1/common.js";
+import {
+  HttpProblem,
+  NotFoundProblem,
+} from "../http/problem.js";
+import {
+  clampLimit,
+  encodeCursor,
+  decodeCursor,
+  DEFAULT_PAGE_LIMIT,
+  emitNextLink,
+} from "../http/pagination.js";
+
+export const productsRouter: Router = Router();
+
+interface ProductsCursor {
+  updated_at: string;
+  id: string;
+}
+
+function rowToProductDto(row: any) {
+  return {
+    id: row.id,
+    workspace_id: row.workspaceId ?? row.workspace_id,
+    product_key: row.productKey ?? row.product_key,
+    canonical_name: row.canonicalName ?? row.canonical_name,
+    merchant_id: row.merchantId ?? row.merchant_id ?? null,
+    brand_id: row.brandId ?? row.brand_id ?? null,
+    item_class: row.itemClass ?? row.item_class,
+    model: row.model ?? null,
+    color: row.color ?? null,
+    size: row.size ?? null,
+    variant: row.variant ?? null,
+    sku: row.sku ?? null,
+    manufacturer: row.manufacturer ?? null,
+    first_purchased_on:
+      (row.firstPurchasedOn ?? row.first_purchased_on) === null ||
+      (row.firstPurchasedOn ?? row.first_purchased_on) === undefined
+        ? null
+        : toIsoDate(row.firstPurchasedOn ?? row.first_purchased_on),
+    last_purchased_on:
+      (row.lastPurchasedOn ?? row.last_purchased_on) === null ||
+      (row.lastPurchasedOn ?? row.last_purchased_on) === undefined
+        ? null
+        : toIsoDate(row.lastPurchasedOn ?? row.last_purchased_on),
+    purchase_count: Number(row.purchaseCount ?? row.purchase_count ?? 0),
+    total_spent_minor: Number(row.totalSpentMinor ?? row.total_spent_minor ?? 0),
+    custom_name: row.customName ?? row.custom_name ?? null,
+    notes: row.notes ?? null,
+    retired_from_catalog_at:
+      (row.retiredFromCatalogAt ?? row.retired_from_catalog_at) === null ||
+      (row.retiredFromCatalogAt ?? row.retired_from_catalog_at) === undefined
+        ? null
+        : toIsoString(row.retiredFromCatalogAt ?? row.retired_from_catalog_at),
+    metadata: row.metadata ?? {},
+    created_at: toIsoString(row.createdAt ?? row.created_at),
+    updated_at: toIsoString(row.updatedAt ?? row.updated_at),
+  };
+}
+
+function toIsoString(v: unknown): string {
+  if (v instanceof Date) return v.toISOString();
+  return String(v);
+}
+
+function toIsoDate(v: unknown): string {
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  if (typeof v === "string") return v.length >= 10 ? v.slice(0, 10) : v;
+  return String(v);
+}
+
+// ── GET /v1/products ───────────────────────────────────────────────────
+
+productsRouter.get(
+  "/",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const query = parseOrThrow(ListProductsQuery, req.query);
+      const limit = clampLimit(query.limit ?? DEFAULT_PAGE_LIMIT);
+      const cursor = decodeCursor<ProductsCursor>(query.cursor ?? undefined);
+
+      const conditions: ReturnType<typeof sql>[] = [];
+      conditions.push(sql`p.workspace_id = ${req.ctx.workspaceId}::uuid`);
+      if (!query.include_retired) {
+        conditions.push(sql`p.retired_from_catalog_at IS NULL`);
+      }
+      if (query.class) conditions.push(sql`p.item_class = ${query.class}`);
+      if (query.brand_id) conditions.push(sql`p.brand_id = ${query.brand_id}`);
+      if (query.merchant_id) {
+        conditions.push(sql`p.merchant_id = ${query.merchant_id}::uuid`);
+      }
+      if (query.q) {
+        const needle = `%${query.q}%`;
+        conditions.push(
+          sql`(p.canonical_name ILIKE ${needle} OR COALESCE(p.custom_name, '') ILIKE ${needle} OR p.product_key ILIKE ${needle})`,
+        );
+      }
+      if (cursor) {
+        conditions.push(
+          sql`(p.updated_at, p.id) < (${cursor.updated_at}::timestamptz, ${cursor.id}::uuid)`,
+        );
+      }
+
+      const where = sql.join(conditions, sql` AND `);
+      const rowsRes = await db.execute(
+        sql`SELECT * FROM products p WHERE ${where} ORDER BY p.updated_at DESC, p.id DESC LIMIT ${limit + 1}`,
+      );
+      const rows = rowsRes.rows as any[];
+      const hasMore = rows.length > limit;
+      const page = hasMore ? rows.slice(0, limit) : rows;
+
+      const items = page.map(rowToProductDto);
+      const nextCursor = hasMore
+        ? encodeCursor({
+            updated_at: toIsoString(page[page.length - 1]!.updated_at),
+            id: page[page.length - 1]!.id,
+          })
+        : null;
+
+      emitNextLink(req, res, nextCursor);
+      res.json({ items, next_cursor: nextCursor });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── GET /v1/products/:id ───────────────────────────────────────────────
+
+productsRouter.get(
+  "/:id",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = String(req.params.id);
+      const rows = await db
+        .select()
+        .from(products)
+        .where(
+          and(
+            eq(products.id, id),
+            eq(products.workspaceId, req.ctx.workspaceId),
+          ),
+        );
+      if (rows.length === 0) throw new NotFoundProblem("Product", id);
+      res.json(rowToProductDto(rows[0]!));
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── PATCH /v1/products/:id ─────────────────────────────────────────────
+
+productsRouter.patch(
+  "/:id",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = String(req.params.id);
+      const body = parseOrThrow(UpdateProductRequest, req.body);
+      const updates: Record<string, unknown> = {};
+      if (body.custom_name !== undefined) updates["customName"] = body.custom_name;
+      if (body.notes !== undefined) updates["notes"] = body.notes;
+      if (body.brand_id !== undefined) updates["brandId"] = body.brand_id;
+      if (body.merchant_id !== undefined) updates["merchantId"] = body.merchant_id;
+      if (body.retired_from_catalog_at !== undefined) {
+        updates["retiredFromCatalogAt"] = body.retired_from_catalog_at
+          ? new Date(body.retired_from_catalog_at)
+          : null;
+      }
+      if (Object.keys(updates).length === 0) {
+        throw new HttpProblem(
+          400,
+          "no-fields",
+          "No editable fields supplied",
+          "PATCH /v1/products/:id needs at least one field to update.",
+        );
+      }
+      updates["updatedAt"] = new Date();
+      const updated = await db
+        .update(products)
+        .set(updates)
+        .where(
+          and(
+            eq(products.id, id),
+            eq(products.workspaceId, req.ctx.workspaceId),
+          ),
+        )
+        .returning();
+      if (updated.length === 0) throw new NotFoundProblem("Product", id);
+      res.json(rowToProductDto(updated[0]!));
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── OpenAPI registration ───────────────────────────────────────────────
+
+export function registerProductsOpenApi(registry: OpenAPIRegistry): void {
+  registry.register("Product", Product);
+  registry.register("UpdateProductRequest", UpdateProductRequest);
+
+  const problemContent = {
+    "application/problem+json": { schema: ProblemDetails },
+  };
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/products",
+    summary: "List products in the workspace catalog",
+    tags: ["products"],
+    request: { query: ListProductsQuery },
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: paginated(Product) } },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/products/{id}",
+    summary: "Fetch a single product",
+    tags: ["products"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: Product } },
+      },
+      404: { description: "Not Found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "patch",
+    path: "/v1/products/{id}",
+    summary: "Patch product user-truth fields",
+    tags: ["products"],
+    request: {
+      params: z.object({ id: Uuid }),
+      body: {
+        content: {
+          "application/merge-patch+json": { schema: UpdateProductRequest },
+          "application/json": { schema: UpdateProductRequest },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: Product } },
+      },
+      404: { description: "Not Found", content: problemContent },
+    },
+  });
+}

--- a/src/routes/transactions.service.ts
+++ b/src/routes/transactions.service.ts
@@ -11,7 +11,7 @@
  * translated to `PostingsImbalanceProblem` (422) so clients see a
  * structured 7807 error rather than an opaque 500.
  */
-import { sql, eq, and, inArray } from "drizzle-orm";
+import { sql, eq, and, inArray, isNull } from "drizzle-orm";
 import { db } from "../db/client.js";
 import {
   transactions,
@@ -89,6 +89,16 @@ export interface TransactionItemRow {
   food_kind: "restaurant_dish" | "grocery_food" | "beverage" | null;
   tags: string[] | null;
   confidence: "high" | "medium" | "low";
+  /** #84 — recommended labels: product / tax / tip / discount / shipping. */
+  line_type: string;
+  /** #84 — catalog linkage; NULL on non-product rows. */
+  product_id: string | null;
+  /** #84 — per-line tax allocated from the printed aggregate. */
+  tax_minor: number | null;
+  tip_share_minor: number | null;
+  discount_share_minor: number | null;
+  /** #84 — generated column: line_total + tax + tip - discount. */
+  effective_total_minor: number;
 }
 
 export interface TransactionRow {
@@ -217,6 +227,13 @@ function mapPostingRow(row: any): PostingRow {
  * field-for-field so this can swallow either shape.
  */
 function mapTransactionItem(row: any): TransactionItemRow {
+  const unitPrice = row.unitPriceMinor ?? row.unit_price_minor;
+  const taxMinor = row.taxMinor ?? row.tax_minor;
+  const tipShare = row.tipShareMinor ?? row.tip_share_minor;
+  const discShare = row.discountShareMinor ?? row.discount_share_minor;
+  const lineTotal = Number(row.lineTotalMinor ?? row.line_total_minor);
+  const effective =
+    row.effectiveTotalMinor ?? row.effective_total_minor ?? null;
   return {
     line_no: Number(row.lineNo ?? row.line_no),
     raw_name: row.rawName ?? row.raw_name,
@@ -227,17 +244,30 @@ function mapTransactionItem(row: any): TransactionItemRow {
         : Number(row.quantity),
     unit: row.unit ?? null,
     unit_price_minor:
-      (row.unitPriceMinor ?? row.unit_price_minor) === null ||
-      (row.unitPriceMinor ?? row.unit_price_minor) === undefined
-        ? null
-        : Number(row.unitPriceMinor ?? row.unit_price_minor),
-    line_total_minor: Number(row.lineTotalMinor ?? row.line_total_minor),
+      unitPrice === null || unitPrice === undefined ? null : Number(unitPrice),
+    line_total_minor: lineTotal,
     currency: row.currency,
     item_class: row.itemClass ?? row.item_class,
     durability_tier: row.durabilityTier ?? row.durability_tier ?? null,
     food_kind: row.foodKind ?? row.food_kind ?? null,
     tags: Array.isArray(row.tags) ? row.tags : null,
     confidence: row.confidence,
+    line_type: row.lineType ?? row.line_type ?? "product",
+    product_id: row.productId ?? row.product_id ?? null,
+    tax_minor: taxMinor === null || taxMinor === undefined ? null : Number(taxMinor),
+    tip_share_minor:
+      tipShare === null || tipShare === undefined ? null : Number(tipShare),
+    discount_share_minor:
+      discShare === null || discShare === undefined ? null : Number(discShare),
+    // For fallback rows (pre-#84) the generated column doesn't exist;
+    // synthesize it from the components so clients always get a number.
+    effective_total_minor:
+      effective === null
+        ? lineTotal +
+          (Number(taxMinor) || 0) +
+          (Number(tipShare) || 0) -
+          (Number(discShare) || 0)
+        : Number(effective),
   };
 }
 
@@ -317,10 +347,18 @@ async function loadTransactionFull(
     .where(eq(documentLinks.transactionId, id));
   const placeMap = t.placeId ? await loadPlacesByIds([t.placeId]) : null;
   const place = placeMap?.get(t.placeId!) ?? null;
+  // #84: only show LIVE items (retired_at IS NULL). Re-extract soft-
+  // deletes the prior run; old rows are kept for history but must not
+  // surface in the response.
   const itemRows = await runner
     .select()
     .from(transactionItems)
-    .where(eq(transactionItems.transactionId, id))
+    .where(
+      and(
+        eq(transactionItems.transactionId, id),
+        isNull(transactionItems.retiredAt),
+      ),
+    )
     .orderBy(transactionItems.lineNo);
   return mapTransactionRow(t, posts, docLinks, place, itemRows);
 }
@@ -656,8 +694,10 @@ export async function listTransactions(
 
   // Bulk-load relational line-items for this page. Empty → fallback
   // path in mapTransactionRow reads metadata.items for pre-#81 rows.
+  // #84: filter retired_at IS NULL — re-extract soft-deletes the
+  // prior run; only the current run is live.
   const itemRes = await db.execute(
-    sql`SELECT * FROM transaction_items WHERE transaction_id = ANY(${sql.raw(`ARRAY[${ids.map((i) => `'${i}'`).join(",")}]::uuid[]`)}) ORDER BY transaction_id, line_no ASC`,
+    sql`SELECT * FROM transaction_items WHERE transaction_id = ANY(${sql.raw(`ARRAY[${ids.map((i) => `'${i}'`).join(",")}]::uuid[]`)}) AND retired_at IS NULL ORDER BY transaction_id, line_no ASC`,
   );
   const itemsByTx = new Map<string, any[]>();
   for (const it of itemRes.rows as any[]) {

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -3,6 +3,7 @@ export * from "./users.js";
 export * from "./workspaces.js";
 export * from "./accounts.js";
 export * from "./transactions.js";
+export * from "./products.js";
 export * from "./transaction_items.js";
 export * from "./postings.js";
 export * from "./documents.js";

--- a/src/schema/products.ts
+++ b/src/schema/products.ts
@@ -1,0 +1,107 @@
+/**
+ * #84 Phase 1 — canonical product catalog.
+ *
+ * Variant granularity is per-row: iPhone-Black-256 and iPhone-White-256
+ * are two distinct products. color / model / size / variant live on
+ * the row, so each variant is its own catalog entry.
+ *
+ * Multi-currency: the same product bought in different currencies stays
+ * one row. Aggregate stats (`purchase_count`, `total_spent_minor`,
+ * `first_purchased_on`, `last_purchased_on`) are recomputed from the
+ * live (`retired_at IS NULL`) set of `transaction_items` pointing at
+ * the product — never incremented, no drift under re-extract / merge.
+ *
+ * Hard-coding budget: only `item_class` carries a CHECK constraint
+ * because it's the primary downstream filter. Everything else
+ * (`condition`, `line_type`, free-text variant fields) is recommended
+ * via the prompt but stored as plain text so the agent can invent a
+ * snake_case label when the recommended set doesn't fit.
+ */
+import {
+  pgTable,
+  uuid,
+  text,
+  integer,
+  bigint,
+  date,
+  timestamp,
+  jsonb,
+  index,
+  uniqueIndex,
+  check,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { workspaces } from "./workspaces.js";
+import { merchants } from "./merchants.js";
+
+export const products = pgTable(
+  "products",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    workspaceId: uuid("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    productKey: text("product_key").notNull(),
+    canonicalName: text("canonical_name").notNull(),
+    /** NULL → portable across merchants (iPhone); NOT NULL → exclusive
+     *  to that merchant (Crunchwrap @ Taco Bell). User-editable. */
+    merchantId: uuid("merchant_id").references(() => merchants.id, {
+      onDelete: "set null",
+    }),
+    /** Text, not FK — the manufacturer (`apple`) can differ from the
+     *  seller (`best-buy`). A soft join against `merchants.brand_id`
+     *  covers cases where the brand is itself a known merchant. */
+    brandId: text("brand_id"),
+    itemClass: text("item_class").notNull(),
+
+    // Product-level attribute facets — each variant gets its own row.
+    model: text("model"),
+    color: text("color"),
+    size: text("size"),
+    variant: text("variant"),
+    sku: text("sku"),
+    manufacturer: text("manufacturer"),
+
+    // Aggregate stats — recomputed from live transaction_items, never
+    // incremented. All money in workspace base currency.
+    firstPurchasedOn: date("first_purchased_on"),
+    lastPurchasedOn: date("last_purchased_on"),
+    purchaseCount: integer("purchase_count").notNull().default(0),
+    totalSpentMinor: bigint("total_spent_minor", { mode: "number" })
+      .notNull()
+      .default(0),
+
+    // Layer-3 (user truth) — never overwritten by re-extract.
+    customName: text("custom_name"),
+    notes: text("notes"),
+    retiredFromCatalogAt: timestamp("retired_from_catalog_at", {
+      withTimezone: true,
+    }),
+
+    metadata: jsonb("metadata").notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .default(sql`NOW()`),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .default(sql`NOW()`),
+  },
+  (t) => [
+    // Aggregation key — NULLS NOT DISTINCT so merchant_id=NULL
+    // (portable products) participate. Drizzle's unique index doesn't
+    // expose nulls-not-distinct directly; the migration SQL adds the
+    // clause manually.
+    uniqueIndex("products_workspace_merchant_key_uq").on(
+      t.workspaceId,
+      t.merchantId,
+      t.productKey,
+    ),
+    index("products_workspace_class_idx").on(t.workspaceId, t.itemClass),
+    index("products_workspace_brand_idx").on(t.workspaceId, t.brandId),
+    index("products_workspace_merchant_idx").on(t.workspaceId, t.merchantId),
+    check(
+      "products_item_class_ck",
+      sql`${t.itemClass} IN ('durable','consumable','food_drink','service','other')`,
+    ),
+  ],
+);

--- a/src/schema/transaction_items.ts
+++ b/src/schema/transaction_items.ts
@@ -22,6 +22,7 @@ import {
 import { sql } from "drizzle-orm";
 import { workspaces } from "./workspaces.js";
 import { transactions } from "./transactions.js";
+import { products } from "./products.js";
 
 export const transactionItems = pgTable(
   "transaction_items",
@@ -46,6 +47,43 @@ export const transactionItems = pgTable(
     foodKind: text("food_kind"),
     tags: text("tags").array(),
     confidence: text("confidence").notNull(),
+    /** Free-text but the prompt recommends `product`, `tax`, `tip`,
+     *  `discount`, `shipping`, `surcharge`, `service_fee`,
+     *  `gift_card`. Non-product rows audit-balance the totals; the
+     *  agent invents a snake_case label for novel cases. */
+    lineType: text("line_type").notNull().default("product"),
+    /** Catalog linkage (#84). Nullable when line_type is non-product
+     *  (tax/tip/discount rows have no product) or when the agent
+     *  judges the line not worth canonicalizing (generic produce,
+     *  unbranded fuel). */
+    productId: uuid("product_id").references(() => products.id, {
+      onDelete: "set null",
+    }),
+    /** Per-line allocation of the receipt's printed tax total.
+     *  Agent computes from line-level taxability markers or, in
+     *  their absence, proportionally to `line_total_minor`. NULL on
+     *  non-taxable lines and on the tax/tip/discount rows themselves. */
+    taxMinor: bigint("tax_minor", { mode: "number" }),
+    tipShareMinor: bigint("tip_share_minor", { mode: "number" }),
+    discountShareMinor: bigint("discount_share_minor", { mode: "number" }),
+    /** All-in cost the user effectively paid for this line.
+     *  `effective_total_minor = line_total + tax + tip - discount`.
+     *  Stored generated column for index-friendliness. */
+    effectiveTotalMinor: bigint("effective_total_minor", {
+      mode: "number",
+    }).generatedAlwaysAs(
+      sql`line_total_minor + COALESCE(tax_minor, 0) + COALESCE(tip_share_minor, 0) - COALESCE(discount_share_minor, 0)`,
+    ),
+    /** Monotonic counter per re-extract of the parent transaction.
+     *  Stays 1 for first ingest; bumped on every `POST
+     *  /v1/documents/:id/re-extract`. Old rows soft-deleted via
+     *  `retired_at`; aggregates read from `retired_at IS NULL`. */
+    extractionRun: integer("extraction_run").notNull().default(1),
+    /** Soft-delete cursor — supersedes the row on re-extract. */
+    retiredAt: timestamp("retired_at", { withTimezone: true }),
+    /** Prompt version stamp (text). #105/#106 used this column;
+     *  retained as semantic audit ("which prompt produced this row")
+     *  alongside the numeric `extractionRun` counter (#84). */
     extractionVersion: text("extraction_version").notNull(),
     metadata: jsonb("metadata").notNull().default({}),
     createdAt: timestamp("created_at", { withTimezone: true })
@@ -53,7 +91,15 @@ export const transactionItems = pgTable(
       .default(sql`NOW()`),
   },
   (t) => [
-    uniqueIndex("transaction_items_line_no_uq").on(t.transactionId, t.lineNo),
+    // (transaction_id, line_no, extraction_run) — re-extract appends
+    // a new run rather than colliding with the live row of the same
+    // line_no. Replaces the (transaction_id, line_no) unique from
+    // #81 Phase 2 which would have made versioning impossible.
+    uniqueIndex("transaction_items_line_no_run_uq").on(
+      t.transactionId,
+      t.lineNo,
+      t.extractionRun,
+    ),
     index("transaction_items_tx_idx").on(t.transactionId),
     index("transaction_items_workspace_class_created_idx").on(
       t.workspaceId,

--- a/src/schemas/v1/product.ts
+++ b/src/schemas/v1/product.ts
@@ -1,0 +1,76 @@
+/**
+ * `products` SSOT zod schema (#84 Phase 1). The catalog row is shared
+ * across all transactions that link to it; aggregate stats are
+ * recomputed from the live `transaction_items` set, never incremented.
+ */
+import { z } from "zod";
+import { IsoDate, IsoDateTime, Metadata, Uuid } from "./common.js";
+
+export const ProductItemClass = z.enum([
+  "durable",
+  "consumable",
+  "food_drink",
+  "service",
+  "other",
+]);
+
+export const Product = z
+  .object({
+    id: Uuid,
+    workspace_id: Uuid,
+    /** Kebab-case canonical key, scoped under (workspace, merchant). */
+    product_key: z.string(),
+    canonical_name: z.string(),
+    /** NULL → portable across merchants (iPhone, Coke). NOT NULL →
+     *  exclusive to one merchant (Crunchwrap @ Taco Bell, AYCE set). */
+    merchant_id: Uuid.nullable(),
+    /** Manufacturer brand id, NOT the seller's. Text, not FK. */
+    brand_id: z.string().nullable(),
+    item_class: ProductItemClass,
+
+    model: z.string().nullable(),
+    color: z.string().nullable(),
+    size: z.string().nullable(),
+    variant: z.string().nullable(),
+    sku: z.string().nullable(),
+    manufacturer: z.string().nullable(),
+
+    first_purchased_on: IsoDate.nullable(),
+    last_purchased_on: IsoDate.nullable(),
+    purchase_count: z.number().int(),
+    total_spent_minor: z.number().int(),
+
+    custom_name: z.string().nullable(),
+    notes: z.string().nullable(),
+    retired_from_catalog_at: IsoDateTime.nullable(),
+
+    metadata: Metadata,
+    created_at: IsoDateTime,
+    updated_at: IsoDateTime,
+  })
+  .openapi("Product");
+
+export const UpdateProductRequest = z
+  .object({
+    custom_name: z.string().nullable().optional(),
+    notes: z.string().nullable().optional(),
+    /** PATCH the manufacturer brand id. The user can correct the
+     *  agent's initial judgment (Costco Kirkland gray-area, etc). */
+    brand_id: z.string().nullable().optional(),
+    /** Move portable ↔ merchant-exclusive. NULL → portable.
+     *  Setting NOT NULL collapses the row's scope to one merchant. */
+    merchant_id: Uuid.nullable().optional(),
+    /** Soft-archive the row. */
+    retired_from_catalog_at: IsoDateTime.nullable().optional(),
+  })
+  .openapi("UpdateProductRequest");
+
+export const ListProductsQuery = z.object({
+  class: ProductItemClass.optional(),
+  brand_id: z.string().optional(),
+  merchant_id: Uuid.optional(),
+  q: z.string().optional(),
+  include_retired: z.coerce.boolean().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+});

--- a/src/schemas/v1/transaction.ts
+++ b/src/schemas/v1/transaction.ts
@@ -94,6 +94,20 @@ export const TransactionItem = z
       .optional(),
     tags: z.array(z.string()).nullable().optional(),
     confidence: z.enum(["high", "medium", "low"]),
+    /** #84 — recommended values product / tax / tip / discount /
+     *  shipping / surcharge / service_fee / gift_card. Free text
+     *  so the agent can invent labels for novel cases. */
+    line_type: z.string().default("product"),
+    /** #84 — catalog linkage; null on non-product rows and on lines
+     *  the agent judged not worth canonicalizing. */
+    product_id: Uuid.nullable().default(null),
+    /** #84 — per-line tax allocated from the printed aggregate. */
+    tax_minor: z.number().int().nullable().default(null),
+    tip_share_minor: z.number().int().nullable().default(null),
+    discount_share_minor: z.number().int().nullable().default(null),
+    /** #84 — generated column on `transaction_items`:
+     *  `line_total + tax + tip - discount`. */
+    effective_total_minor: z.number().int(),
   })
   .openapi("TransactionItem");
 


### PR DESCRIPTION
## Summary

Closes the SSOT layer beneath line items. Adds the `products` catalog (the "what is this thing"), the per-line tax/tip/discount allocation columns on `transaction_items`, and a versioned soft-delete pattern so re-extract doesn't double-count.

Owns the bulk of #84's Phase 1 scope. Phase 2 (`owned_items` register) and Phase 3 (`merge_into` + admin recompute) ship separately.

## What changes

### Migration `0016_complete_gateway`

```sql
CREATE TABLE products (...);
ALTER TABLE transaction_items
  ADD COLUMN line_type text DEFAULT 'product' NOT NULL,
  ADD COLUMN product_id uuid REFERENCES products(id),
  ADD COLUMN tax_minor bigint,
  ADD COLUMN tip_share_minor bigint,
  ADD COLUMN discount_share_minor bigint,
  ADD COLUMN effective_total_minor bigint GENERATED ALWAYS AS (...) STORED,
  ADD COLUMN extraction_run int DEFAULT 1 NOT NULL,
  ADD COLUMN retired_at timestamptz;
DROP INDEX transaction_items_line_no_uq;
CREATE UNIQUE INDEX transaction_items_line_no_run_uq
  ON transaction_items (transaction_id, line_no, extraction_run);
CREATE VIEW transaction_items_live AS
  SELECT * FROM transaction_items WHERE retired_at IS NULL;
-- partial indexes on (workspace, line_type) / (workspace, product_id) WHERE retired_at IS NULL
```

Only `item_class` carries a CHECK; `line_type`, `condition`, etc. are free text per the user's "越少 hard-code" rule.

### Prompts

- **PROMPT_VERSION 2.6 → 2.7.** Items[] gains: `line_type`, `product_key` (kebab-case canonical), `product_brand_id`, `product_merchant_exclusive` (drives `products.merchant_id`), `product_model`/`color`/`size`/`variant`/`sku`/`manufacturer`, `tax_minor`, `tip_share_minor`, `discount_share_minor`.
- **New Phase 2.7** in `prompt.ts`: per-line tax / tip / discount allocation logic. Proportional by `line_total_minor` when no taxability markers; per-line when `T`/`T1`/`*`/`Taxable` markers are present. Σ tax_minor exactly matches printed tax (rounding absorbed on largest line).
- **Phase 4 SQL** in `prompt.ts`: new `p_upsert` CTE keyed on `(workspace_id, merchant_id, product_key)` with `NULLS NOT DISTINCT` so portable products (one row across stores) and merchant-exclusive products (one row per merchant) coexist. After commit, an aggregate-recompute UPDATE runs over every product touched by this ingest.
- **REEXTRACT_PROMPT_VERSION 1.2 → 1.3.** SQL block: UPDATE retired_at=NOW(); compute next_run via WITH CTE; p_upsert products; INSERT new transaction_items with `extraction_run = next_run`; UPDATE products aggregates from the live set.

### Read path

- `loadTransactionFull` + `listTransactions` filter `retired_at IS NULL` so callers never see retired rows.
- `Transaction.items[]` grows: `line_type`, `product_id`, `tax_minor`, `tip_share_minor`, `discount_share_minor`, `effective_total_minor`.
- `/v1/items` listing also filters `retired_at IS NULL`.

### New routes

- `GET /v1/products` — workspace-scoped catalog browse. Filters: `class`, `brand_id`, `merchant_id`, `q`, `include_retired`. Keyset paginated on `(updated_at, id)`.
- `GET /v1/products/:id` — single fetch.
- `PATCH /v1/products/:id` — Layer-3 edits: `custom_name`, `notes`, `brand_id`, `merchant_id` (move portable ↔ merchant-exclusive), `retired_from_catalog_at`.

## Smoke

Re-extracted Sichuan Spicy Bay (`bda79c9a-47f6-4559-ae69-72342e89c5a7`) — a TOTAL-ONLY receipt, perfect for exercising the soft-delete + versioning path without product canonicalization.

```
SELECT line_no, line_type, line_total_minor, tax_minor, tip_share_minor,
       discount_share_minor, effective_total_minor, extraction_run,
       retired_at IS NULL AS live
FROM transaction_items
WHERE transaction_id = 'bda79c9a...';

 line_no | line_type | line_total | tax | tip | disc | effective | run | live
---------+-----------+------------+-----+-----+------+-----------+-----+------
       1 | product   |       8281 |     |     |      |      8281 |   1 | f
       1 | product   |       8281 |     | 990 |      |      9271 |   2 | t
```

`GET /v1/transactions/:id` returns only the live (run=2) row with `tip_share_minor=990`, `effective_total_minor=9271`. `GET /v1/products` correctly returns empty (TOTAL-ONLY fallback emits no canonicalizable lines).

## Acceptance criteria

- [x] `products` table with full attribute set + recomputed aggregate stats
- [x] `transaction_items` extended with allocation + versioning columns
- [x] `transaction_items_live` view created
- [x] `UNIQUE (transaction_id, line_no, extraction_run)` replaces old line_no unique
- [x] NULLS NOT DISTINCT on products unique index — portable + merchant-exclusive coexist
- [x] Ingest prompt emits new fields; Phase 4 SQL upserts products + writes per-line allocation
- [x] Re-extract prompt soft-deletes prior run + bumps `extraction_run`
- [x] Read paths filter `retired_at IS NULL`
- [x] `Transaction.items[]` includes new fields
- [x] `/v1/products` CRUD endpoints live
- [x] OpenAPI spec regenerated (76 schemas / 48 paths)
- [x] `npm run build` passes
- [x] Soft-delete + versioning verified via smoke

## Out of scope

- **Phase 2 (`owned_items` register)** — next PR. The schema's columns are designed but the table doesn't exist yet.
- **Phase 3 (`POST /v1/products/:id/merge_into` + admin recompute endpoint)** — PR after that.
- **Frontend display** — clients consume new `items[]` fields off the existing transactions endpoint already.
- **Backfill** of pre-#106 receipts into the new schema — those rows surface via the existing `metadata.items` fallback (Phase 2 design); re-extract under v2.7 to populate the relational fields.

Refs #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)