### PR TITLE
feat(#84): Phase 3 — products merge + recompute endpoints

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1438,6 +1438,52 @@
           }
         }
       },
+      "MergeProductRequest": {
+        "type": "object",
+        "properties": {
+          "target_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          }
+        },
+        "required": [
+          "target_id"
+        ]
+      },
+      "MergeProductResponse": {
+        "type": "object",
+        "properties": {
+          "source_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "target_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "moved_transaction_items": {
+            "type": "integer"
+          },
+          "moved_owned_items": {
+            "type": "integer"
+          },
+          "derivation_event_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          }
+        },
+        "required": [
+          "source_id",
+          "target_id",
+          "moved_transaction_items",
+          "moved_owned_items",
+          "derivation_event_id"
+        ]
+      },
       "OwnedItem": {
         "type": "object",
         "properties": {
@@ -5135,6 +5181,151 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Product"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/products/{id}/merge_into": {
+      "post": {
+        "summary": "Merge this product into the target — re-points transaction_items + owned_items, retires source",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MergeProductRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MergeProductResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (e.g. self-merge)",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Source or target not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Source already retired",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/products/{id}/recompute": {
+      "post": {
+        "summary": "Recompute aggregate stats from the live transaction_items set",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+                    },
+                    "purchase_count": {
+                      "type": "integer"
+                    },
+                    "total_spent_minor": {
+                      "type": "integer"
+                    },
+                    "first_purchased_on": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "last_purchased_on": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "purchase_count",
+                    "total_spent_minor",
+                    "first_purchased_on",
+                    "last_purchased_on"
+                  ]
                 }
               }
             }

--- a/src/generated/build-info.ts
+++ b/src/generated/build-info.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant",
   "version": "1.0.0",
-  "gitSha": "40f6d0be604a8851ffdd8bda036e9b978151d4a9",
-  "gitShortSha": "40f6d0b",
-  "gitBranch": "feat/84-phase2-owned-items",
-  "builtAt": "2026-05-16T08:28:32.031Z"
+  "gitSha": "87358d811633c06d6d1ae39ceee699da491a6309",
+  "gitShortSha": "87358d8",
+  "gitBranch": "feat/84-phase3-products-merge",
+  "builtAt": "2026-05-16T08:33:47.767Z"
 } as const;

--- a/src/routes/products.ts
+++ b/src/routes/products.ts
@@ -12,12 +12,21 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 import { sql, eq, and } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { products } from "../schema/index.js";
+import {
+  products,
+  transactionItems,
+  ownedItems,
+  derivationEvents,
+} from "../schema/index.js";
+import { buildInfo } from "../generated/build-info.js";
+import { PROMPT_VERSION } from "../ingest/prompt.js";
 import { parseOrThrow } from "../http/validate.js";
 import {
   Product,
   UpdateProductRequest,
   ListProductsQuery,
+  MergeProductRequest,
+  MergeProductResponse,
 } from "../schemas/v1/product.js";
 import { ProblemDetails, paginated, Uuid } from "../schemas/v1/common.js";
 import {
@@ -220,11 +229,287 @@ productsRouter.patch(
   },
 );
 
+// ── POST /v1/products/:id/merge_into ───────────────────────────────────
+
+/**
+ * Recompute aggregate stats for one product from its live
+ * transaction_items set. Used by merge_into and the admin endpoint.
+ * Returns `purchase_count` etc. so callers can echo the new state.
+ */
+async function recomputeProductStats(
+  workspaceId: string,
+  productId: string,
+): Promise<{
+  purchase_count: number;
+  total_spent_minor: number;
+  first_purchased_on: string | null;
+  last_purchased_on: string | null;
+}> {
+  const res = await db.execute(
+    sql`
+      WITH stats AS (
+        SELECT
+          MIN(t.occurred_on) AS first_on,
+          MAX(t.occurred_on) AS last_on,
+          COUNT(DISTINCT ti.transaction_id) AS purchases,
+          COALESCE(SUM(ti.effective_total_minor), 0) AS total_minor
+        FROM transaction_items ti
+        JOIN transactions t ON t.id = ti.transaction_id
+        WHERE ti.product_id = ${productId}::uuid
+          AND ti.workspace_id = ${workspaceId}::uuid
+          AND ti.retired_at IS NULL
+          AND ti.line_type = 'product'
+      )
+      UPDATE products p SET
+        first_purchased_on = stats.first_on,
+        last_purchased_on  = stats.last_on,
+        purchase_count     = COALESCE(stats.purchases, 0),
+        total_spent_minor  = stats.total_minor,
+        updated_at         = NOW()
+      FROM stats
+      WHERE p.id = ${productId}::uuid
+        AND p.workspace_id = ${workspaceId}::uuid
+      RETURNING
+        p.purchase_count,
+        p.total_spent_minor,
+        p.first_purchased_on,
+        p.last_purchased_on
+    `,
+  );
+  const r = res.rows[0] as any;
+  return {
+    purchase_count: Number(r?.purchase_count ?? 0),
+    total_spent_minor: Number(r?.total_spent_minor ?? 0),
+    first_purchased_on: r?.first_purchased_on
+      ? toIsoDate(r.first_purchased_on)
+      : null,
+    last_purchased_on: r?.last_purchased_on
+      ? toIsoDate(r.last_purchased_on)
+      : null,
+  };
+}
+
+productsRouter.post(
+  "/:id/merge_into",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const sourceId = String(req.params.id);
+      const body = MergeProductRequest.parse(req.body);
+      if (sourceId === body.target_id) {
+        throw new HttpProblem(
+          400,
+          "self-merge",
+          "Cannot merge a product into itself",
+          "POST /v1/products/:id/merge_into requires target_id != source id.",
+        );
+      }
+
+      const result = await db.transaction(async (tx) => {
+        // Load both rows (workspace-scoped).
+        const both = await tx
+          .select()
+          .from(products)
+          .where(
+            and(
+              eq(products.workspaceId, req.ctx.workspaceId),
+              sql`${products.id} IN (${sql.raw(`'${sourceId}', '${body.target_id}'`)})`,
+            ),
+          );
+        const source = both.find((r) => r.id === sourceId);
+        const target = both.find((r) => r.id === body.target_id);
+        if (!source) throw new NotFoundProblem("Product", sourceId);
+        if (!target) {
+          throw new NotFoundProblem("Product", body.target_id);
+        }
+        if (source.retiredFromCatalogAt) {
+          throw new HttpProblem(
+            409,
+            "already-retired",
+            "Source product is already retired",
+            `Product ${sourceId} was retired at ${source.retiredFromCatalogAt.toISOString()}; cannot re-merge.`,
+          );
+        }
+
+        // Snapshot before for the audit event.
+        const beforeSnap = {
+          source: {
+            id: source.id,
+            product_key: source.productKey,
+            canonical_name: source.canonicalName,
+            purchase_count: Number(source.purchaseCount),
+            total_spent_minor: Number(source.totalSpentMinor),
+            retired_from_catalog_at: source.retiredFromCatalogAt,
+          },
+          target: {
+            id: target.id,
+            product_key: target.productKey,
+            canonical_name: target.canonicalName,
+            purchase_count: Number(target.purchaseCount),
+            total_spent_minor: Number(target.totalSpentMinor),
+          },
+        };
+
+        // Re-point transaction_items.
+        const tiMoved = await tx
+          .update(transactionItems)
+          .set({ productId: body.target_id })
+          .where(
+            and(
+              eq(transactionItems.productId, sourceId),
+              eq(transactionItems.workspaceId, req.ctx.workspaceId),
+            ),
+          )
+          .returning({ id: transactionItems.id });
+
+        // Re-point owned_items.
+        const oiMoved = await tx
+          .update(ownedItems)
+          .set({ productId: body.target_id })
+          .where(
+            and(
+              eq(ownedItems.productId, sourceId),
+              eq(ownedItems.workspaceId, req.ctx.workspaceId),
+            ),
+          )
+          .returning({ id: ownedItems.id });
+
+        // Retire source. Also push the source's product_key into
+        // target's metadata.aliases so a future agent canonicalization
+        // pass can collapse the old key to the new id without human
+        // input.
+        await tx
+          .update(products)
+          .set({
+            retiredFromCatalogAt: new Date(),
+            updatedAt: new Date(),
+            purchaseCount: 0,
+            totalSpentMinor: 0,
+          })
+          .where(eq(products.id, sourceId));
+
+        await tx.execute(
+          sql`UPDATE products SET metadata = jsonb_set(
+                COALESCE(metadata, '{}'::jsonb),
+                '{aliases}',
+                COALESCE(metadata->'aliases', '[]'::jsonb) || ${JSON.stringify([source.productKey])}::jsonb
+              )
+              WHERE id = ${body.target_id}::uuid`,
+        );
+
+        // No `recomputeProductStats` call inside this txn — it uses
+        // db.execute directly which would deadlock against the same
+        // transaction. Compute via raw sql inline:
+        await tx.execute(
+          sql`
+            WITH stats AS (
+              SELECT
+                MIN(t.occurred_on) AS first_on,
+                MAX(t.occurred_on) AS last_on,
+                COUNT(DISTINCT ti.transaction_id) AS purchases,
+                COALESCE(SUM(ti.effective_total_minor), 0) AS total_minor
+              FROM transaction_items ti
+              JOIN transactions t ON t.id = ti.transaction_id
+              WHERE ti.product_id = ${body.target_id}::uuid
+                AND ti.workspace_id = ${req.ctx.workspaceId}::uuid
+                AND ti.retired_at IS NULL
+                AND ti.line_type = 'product'
+            )
+            UPDATE products p SET
+              first_purchased_on = stats.first_on,
+              last_purchased_on  = stats.last_on,
+              purchase_count     = COALESCE(stats.purchases, 0),
+              total_spent_minor  = stats.total_minor,
+              updated_at         = NOW()
+            FROM stats
+            WHERE p.id = ${body.target_id}::uuid
+          `,
+        );
+
+        // Re-read target for the audit snapshot.
+        const [refreshedTarget] = await tx
+          .select()
+          .from(products)
+          .where(eq(products.id, body.target_id));
+
+        const afterSnap = {
+          source: {
+            id: sourceId,
+            retired_from_catalog_at: new Date(),
+          },
+          target: {
+            id: body.target_id,
+            purchase_count: Number(refreshedTarget!.purchaseCount),
+            total_spent_minor: Number(refreshedTarget!.totalSpentMinor),
+          },
+        };
+
+        const [evt] = await tx
+          .insert(derivationEvents)
+          .values({
+            workspaceId: req.ctx.workspaceId,
+            entityType: "product",
+            entityId: body.target_id,
+            promptVersion: PROMPT_VERSION,
+            promptGitSha: buildInfo.gitSha,
+            model: "ts-deterministic",
+            before: beforeSnap,
+            after: afterSnap,
+            changedKeys: ["merged_in", "purchase_count", "total_spent_minor"],
+          })
+          .returning({ id: derivationEvents.id });
+
+        return {
+          source_id: sourceId,
+          target_id: body.target_id,
+          moved_transaction_items: tiMoved.length,
+          moved_owned_items: oiMoved.length,
+          derivation_event_id: evt!.id,
+        };
+      });
+
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── POST /v1/products/:id/recompute ────────────────────────────────────
+//
+// Idempotent: recomputes one product's aggregates from the live
+// transaction_items set. Useful after a manual data fix or if you
+// suspect drift. Returns the new stats.
+
+productsRouter.post(
+  "/:id/recompute",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = String(req.params.id);
+      const exists = await db
+        .select({ id: products.id })
+        .from(products)
+        .where(
+          and(
+            eq(products.id, id),
+            eq(products.workspaceId, req.ctx.workspaceId),
+          ),
+        );
+      if (exists.length === 0) throw new NotFoundProblem("Product", id);
+      const stats = await recomputeProductStats(req.ctx.workspaceId, id);
+      res.json({ id, ...stats });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // ── OpenAPI registration ───────────────────────────────────────────────
 
 export function registerProductsOpenApi(registry: OpenAPIRegistry): void {
   registry.register("Product", Product);
   registry.register("UpdateProductRequest", UpdateProductRequest);
+  registry.register("MergeProductRequest", MergeProductRequest);
+  registry.register("MergeProductResponse", MergeProductResponse);
 
   const problemContent = {
     "application/problem+json": { schema: ProblemDetails },
@@ -277,6 +562,53 @@ export function registerProductsOpenApi(registry: OpenAPIRegistry): void {
       200: {
         description: "OK",
         content: { "application/json": { schema: Product } },
+      },
+      404: { description: "Not Found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/products/{id}/merge_into",
+    summary: "Merge this product into the target — re-points transaction_items + owned_items, retires source",
+    tags: ["products"],
+    request: {
+      params: z.object({ id: Uuid }),
+      body: {
+        content: { "application/json": { schema: MergeProductRequest } },
+      },
+    },
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: MergeProductResponse } },
+      },
+      400: { description: "Bad request (e.g. self-merge)", content: problemContent },
+      404: { description: "Source or target not found", content: problemContent },
+      409: { description: "Source already retired", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/products/{id}/recompute",
+    summary: "Recompute aggregate stats from the live transaction_items set",
+    tags: ["products"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: {
+        description: "OK",
+        content: {
+          "application/json": {
+            schema: z.object({
+              id: Uuid,
+              purchase_count: z.number().int(),
+              total_spent_minor: z.number().int(),
+              first_purchased_on: z.string().nullable(),
+              last_purchased_on: z.string().nullable(),
+            }),
+          },
+        },
       },
       404: { description: "Not Found", content: problemContent },
     },

--- a/src/schemas/v1/product.ts
+++ b/src/schemas/v1/product.ts
@@ -74,3 +74,26 @@ export const ListProductsQuery = z.object({
   cursor: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(500).optional(),
 });
+
+/**
+ * `POST /v1/products/:id/merge_into` body. Collapses two products
+ * into one: all `transaction_items` and `owned_items` re-point to
+ * `target_id`; the source product is retired and its aggregates
+ * zeroed. The target's aggregates are recomputed from the live
+ * `transaction_items` set.
+ */
+export const MergeProductRequest = z
+  .object({
+    target_id: Uuid,
+  })
+  .openapi("MergeProductRequest");
+
+export const MergeProductResponse = z
+  .object({
+    source_id: Uuid,
+    target_id: Uuid,
+    moved_transaction_items: z.number().int(),
+    moved_owned_items: z.number().int(),
+    derivation_event_id: Uuid,
+  })
+  .openapi("MergeProductResponse");


### PR DESCRIPTION
## Summary

Closes the products SSOT story with the two admin endpoints from #84's Phase 3:

- `POST /v1/products/:id/merge_into` — collapse a duplicate product into the surviving canonical row
- `POST /v1/products/:id/recompute` — idempotent stats refresh from the live `transaction_items` set

The merge endpoint inherits the audit pattern from Wave 0 — every merge writes one `derivation_events` row keyed `entity_type='product'`, `entity_id=<target_id>`, with `before` / `after` snapshots and `changed_keys`.

## Merge semantics

Inside one transaction:
1. `UPDATE transaction_items SET product_id = $target WHERE product_id = $source`
2. `UPDATE owned_items SET product_id = $target WHERE product_id = $source`
3. `UPDATE products SET retired_from_catalog_at = NOW(), purchase_count = 0, total_spent_minor = 0 WHERE id = $source`
4. Push `$source.product_key` into `$target.metadata.aliases` (future agent canonicalization runs see the alias and collapse the old key with no human input — same "agent learns from human override" pattern as #79)
5. Recompute `$target` aggregates from the live `transaction_items` set (now sees the moved rows)
6. Insert one `derivation_events` row with the before/after snapshot

## Recompute

Idempotent stats recomputation — useful after a manual data fix or if drift is suspected. Same query the merge uses internally, but standalone and outside a txn.

## Error handling

- Self-merge (`source == target`) → 400 `self-merge`
- Re-merging a previously-retired product → 409 `already-retired`
- Source or target not in workspace → 404

## Smoke

Seeded two products manually (`merge-src`, `merge-tgt`), neither linked to any transaction_items / owned_items.

```
POST /v1/products/{src}/merge_into  { target_id: {tgt} }
  → 200 { moved_transaction_items: 0, moved_owned_items: 0,
          derivation_event_id: ... }

SELECT id, retired_from_catalog_at IS NULL AS live,
       purchase_count, metadata->'aliases'
FROM products WHERE id IN (src, tgt);
  src → live=f, count=0, aliases=null
  tgt → live=t, count=0, aliases=["merge-src"]

POST /v1/products/{tgt}/recompute
  → 200 { purchase_count: 0, total_spent_minor: 0, ...}

POST /v1/products/{src}/merge_into  { target_id: {tgt} }  (retry)
  → 409 already-retired   ✅
```

## Acceptance criteria

- [x] `POST /v1/products/:id/merge_into` moves transaction_items + owned_items + retires source
- [x] Target aggregates recomputed (not incremented) from live set
- [x] Source's `product_key` pushed into target's `metadata.aliases`
- [x] One `derivation_events` row per merge
- [x] `POST /v1/products/:id/recompute` is idempotent
- [x] Self-merge → 400; double-merge → 409
- [x] OpenAPI regenerated (52 paths / 81 schemas)
- [x] `npm run build` passes

## Out of scope

- **Frontend "merge these two" UI** — admin-only for now; the issue (#84) explicitly framed merge as the "user's kill switch" for agent canonicalization mistakes, so it's reachable via curl/admin tools today
- **Bulk recompute** (`POST /v1/admin/recompute-products` over the whole workspace) — the per-id endpoint is sufficient until we see scale-driven drift; can be added later as a one-liner that iterates over `products.id`
- **#101 brand_assets work** — separate PR, the last in this backlog

After this PR merges, #85 (the brand-aware SSOT epic tracker) can be closed referencing #84 Phase 1-3 + the upcoming #101.

Refs #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)