### PR TITLE
feat(#101): Phase 2 — brand discovery + 4-tier acquisition + agent visual judgment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,12 @@
 # HTTP server port. Default 3000. Also update the `ports:` mapping in
 # docker-compose.yml if you change this.
 # PORT=3000
+
+# logo.dev API keys (#101 Phase 2 brand-icon acquisition). Obtain both
+# from the logo.dev dashboard. The publishable key (pk_…) goes into
+# img.logo.dev URLs; the secret key (sk_…) authorizes api.logo.dev/search.
+# Phase 4b uses search-first against api.logo.dev to avoid the "any
+# unknown domain returns a generated first-letter PNG" bug. The agent
+# skips the logo.dev tier when either key is unset.
+# LOGODEV_PUBLISHABLE_KEY=
+# LOGODEV_SECRET_KEY=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,15 @@ services:
       # ~10% even at concurrency 3 — host has headroom. Bumped to 6 to
       # halve eval wall-clock without straining Anthropic API rate limits.
       MAX_CLAUDE_CONCURRENCY: ${MAX_CLAUDE_CONCURRENCY:-6}
+      # logo.dev API keys for #101 Phase 2 brand-icon acquisition. The
+      # publishable key (pk_…) is embedded in img.logo.dev URLs the agent
+      # follows; the secret key (sk_…) authorizes api.logo.dev/search,
+      # which Phase 4b uses search-first to avoid the letter-fallback bug
+      # (blind GET against img.logo.dev/<anydomain> returns a generated
+      # first-letter PNG for unknown domains — silent wrong-icon). Empty
+      # is fine — the agent skips the logo.dev tier when unset.
+      LOGODEV_PUBLISHABLE_KEY: ${LOGODEV_PUBLISHABLE_KEY:-}
+      LOGODEV_SECRET_KEY: ${LOGODEV_SECRET_KEY:-}
     volumes:
       # Uploaded receipt images = user content (PII). Lives in the outer
       # project's iCloud-synced docs root, so the user's own receipt corpus
@@ -98,4 +107,13 @@ services:
       # claude /login`; the CLI self-refreshes and writes back here.
       # Survives compose down/up and OrbStack resets. See `setup` skill.
       - ${HOME}/Developer/receipt-assistant-data/claude:/home/node/.claude
+      # Brand icon assets cache (#101 Phase 2). Each brand_assets row's
+      # `local_path` is relative to /data/brand-assets/, structure:
+      #   <brand_id>/<tier>/<origin-token>.<ext>
+      # SIBLING dir same as postgres / claude — outside git (PII-adjacent
+      # via the brands they identify) and outside iCloud (continuous
+      # block reupload undermines `UNIQUE (brand_id, content_hash)`
+      # dedup semantics on byte-equal re-fetch). On a fresh machine:
+      #   mkdir -p ~/Developer/receipt-assistant-data/brand-assets
+      - ${HOME}/Developer/receipt-assistant-data/brand-assets:/data/brand-assets
     restart: unless-stopped

--- a/drizzle/0019_tricky_korvac.sql
+++ b/drizzle/0019_tricky_korvac.sql
@@ -1,0 +1,42 @@
+-- #101 Phase 2 — promote merchants.brand_id and products.brand_id to FK
+-- on the global brands registry (the #86 schema-cleanup residual), add a
+-- per-brand metadata jsonb for icon-resolution outcomes, and document
+-- the transactions.merchant_id nullable decision.
+--
+-- The ALTER ADD CONSTRAINT statements only succeed if every existing
+-- text value in merchants.brand_id / products.brand_id corresponds to
+-- a row in brands. The two INSERT … SELECT statements below backfill
+-- stub brands rows (name = brand_id verbatim, domain NULL) for any
+-- referenced brand_id that doesn't yet exist. Phase 2.6 of the ingest
+-- prompt enriches name/domain on future ingest passes via WebSearch.
+
+ALTER TABLE "brands" ADD COLUMN "metadata" jsonb DEFAULT '{}'::jsonb NOT NULL;--> statement-breakpoint
+
+-- Backfill stub brands rows for any merchants.brand_id text value that
+-- doesn't yet have a brands row. Existing merchants.brand_id is already
+-- constrained to ^[a-z0-9-]+$ (see merchants_brand_id_format CHECK),
+-- so every value is a valid PK candidate.
+INSERT INTO "brands" ("brand_id", "name")
+SELECT DISTINCT m."brand_id", m."brand_id"
+  FROM "merchants" m
+  LEFT JOIN "brands" b ON b."brand_id" = m."brand_id"
+ WHERE b."brand_id" IS NULL
+   AND m."brand_id" IS NOT NULL;--> statement-breakpoint
+
+-- Same for products.brand_id (nullable; only backfill non-NULL rows).
+INSERT INTO "brands" ("brand_id", "name")
+SELECT DISTINCT p."brand_id", p."brand_id"
+  FROM "products" p
+  LEFT JOIN "brands" b ON b."brand_id" = p."brand_id"
+ WHERE b."brand_id" IS NULL
+   AND p."brand_id" IS NOT NULL;--> statement-breakpoint
+
+ALTER TABLE "products" ADD CONSTRAINT "products_brand_id_brands_brand_id_fk" FOREIGN KEY ("brand_id") REFERENCES "public"."brands"("brand_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "merchants" ADD CONSTRAINT "merchants_brand_id_brands_brand_id_fk" FOREIGN KEY ("brand_id") REFERENCES "public"."brands"("brand_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+
+-- transactions.merchant_id stays nullable per #101 default option (b).
+-- Voided rows, statement-line aggregates, and `unsupported` classified
+-- documents all need a no-merchant affordance; NULL is the honest
+-- representation. See #101 / #64 for the decision rationale.
+COMMENT ON COLUMN "transactions"."merchant_id" IS
+  'Nullable: voided rows, statement-line aggregates, and unsupported-classified docs need a no-merchant affordance. See #101 / #64 for the decision rationale.';

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,3870 @@
+{
+  "id": "07a8b857-8f65-4574-b496-7de0f4631d7a",
+  "prevId": "2dd7b973-ad0d-406a-8ab3-4867e22481ba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_uniq": {
+          "name": "users_email_lower_uniq",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_users_id_fk": {
+          "name": "workspace_members_user_id_users_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_workspace_id_user_id_pk": {
+          "name": "workspace_members_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_owner_id_users_id_fk": {
+          "name": "workspaces_owner_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_balance_minor": {
+          "name": "opening_balance_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "accounts_workspace_idx": {
+          "name": "accounts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_parent_idx": {
+          "name": "accounts_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_workspace_type_idx": {
+          "name": "accounts_workspace_type_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_workspace_id_workspaces_id_fk": {
+          "name": "accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_parent_id_accounts_id_fk": {
+          "name": "accounts_parent_id_accounts_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narration": {
+          "name": "narration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "txn_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "voided_by_id": {
+          "name": "voided_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transactions_keyset_idx": {
+          "name": "transactions_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_created_at_keyset_idx": {
+          "name": "transactions_created_at_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_source_ingest_idx": {
+          "name": "transactions_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_trip_idx": {
+          "name": "transactions_trip_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_place_idx": {
+          "name": "transactions_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_merchant_idx": {
+          "name": "transactions_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_workspace_id_workspaces_id_fk": {
+          "name": "transactions_workspace_id_workspaces_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_voided_by_id_transactions_id_fk": {
+          "name": "transactions_voided_by_id_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "voided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_source_ingest_id_ingests_id_fk": {
+          "name": "transactions_source_ingest_id_ingests_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_place_id_places_id_fk": {
+          "name": "transactions_place_id_places_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_merchant_id_merchants_id_fk": {
+          "name": "transactions_merchant_id_merchants_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_created_by_users_id_fk": {
+          "name": "transactions_created_by_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_purchased_on": {
+          "name": "first_purchased_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_purchased_on": {
+          "name": "last_purchased_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_spent_minor": {
+          "name": "total_spent_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_from_catalog_at": {
+          "name": "retired_from_catalog_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "products_workspace_merchant_key_uq": {
+          "name": "products_workspace_merchant_key_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_class_idx": {
+          "name": "products_workspace_class_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_brand_idx": {
+          "name": "products_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_merchant_idx": {
+          "name": "products_workspace_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_workspace_id_workspaces_id_fk": {
+          "name": "products_workspace_id_workspaces_id_fk",
+          "tableFrom": "products",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "products_merchant_id_merchants_id_fk": {
+          "name": "products_merchant_id_merchants_id_fk",
+          "tableFrom": "products",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "products_brand_id_brands_brand_id_fk": {
+          "name": "products_brand_id_brands_brand_id_fk",
+          "tableFrom": "products",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "products_item_class_ck": {
+          "name": "products_item_class_ck",
+          "value": "\"products\".\"item_class\" IN ('durable','consumable','food_drink','service','other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transaction_items": {
+      "name": "transaction_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price_minor": {
+          "name": "unit_price_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_total_minor": {
+          "name": "line_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability_tier": {
+          "name": "durability_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_kind": {
+          "name": "food_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'product'"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_minor": {
+          "name": "tax_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tip_share_minor": {
+          "name": "tip_share_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_share_minor": {
+          "name": "discount_share_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_total_minor": {
+          "name": "effective_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "line_total_minor + COALESCE(tax_minor, 0) + COALESCE(tip_share_minor, 0) - COALESCE(discount_share_minor, 0)",
+            "type": "stored"
+          }
+        },
+        "extraction_run": {
+          "name": "extraction_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transaction_items_line_no_run_uq": {
+          "name": "transaction_items_line_no_run_uq",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "extraction_run",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_items_tx_idx": {
+          "name": "transaction_items_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_items_workspace_class_created_idx": {
+          "name": "transaction_items_workspace_class_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_items_workspace_id_workspaces_id_fk": {
+          "name": "transaction_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_items_transaction_id_transactions_id_fk": {
+          "name": "transaction_items_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_items_product_id_products_id_fk": {
+          "name": "transaction_items_product_id_products_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.owned_items": {
+      "name": "owned_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_item_id": {
+          "name": "transaction_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_index": {
+          "name": "instance_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_on": {
+          "name": "acquired_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warranty_until": {
+          "name": "warranty_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "owned_items_tx_item_instance_uq": {
+          "name": "owned_items_tx_item_instance_uq",
+          "columns": [
+            {
+              "expression": "transaction_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instance_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "owned_items_workspace_product_idx": {
+          "name": "owned_items_workspace_product_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "owned_items_workspace_id_workspaces_id_fk": {
+          "name": "owned_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "owned_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "owned_items_product_id_products_id_fk": {
+          "name": "owned_items_product_id_products_id_fk",
+          "tableFrom": "owned_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "owned_items_transaction_item_id_transaction_items_id_fk": {
+          "name": "owned_items_transaction_item_id_transaction_items_id_fk",
+          "tableFrom": "owned_items",
+          "tableTo": "transaction_items",
+          "columnsFrom": [
+            "transaction_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_assets": {
+      "name": "brand_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "agent_relevance": {
+          "name": "agent_relevance",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_notes": {
+          "name": "agent_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uploaded": {
+          "name": "user_uploaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "brand_assets_brand_hash_uq": {
+          "name": "brand_assets_brand_hash_uq",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brand_assets_brand_idx": {
+          "name": "brand_assets_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brand_assets_brand_tier_idx": {
+          "name": "brand_assets_brand_tier_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_assets_brand_id_brands_brand_id_fk": {
+          "name": "brand_assets_brand_id_brands_brand_id_fk",
+          "tableFrom": "brand_assets",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "brand_assets_tier_ck": {
+          "name": "brand_assets_tier_ck",
+          "value": "\"brand_assets\".\"tier\" IN ('itunes','svgl','logo_dev','simple_icons','user_upload','manual_url')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.brands": {
+      "name": "brands",
+      "schema": "",
+      "columns": {
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_asset_id": {
+          "name": "preferred_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_chose_at": {
+          "name": "user_chose_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "brands_parent_id_brands_brand_id_fk": {
+          "name": "brands_parent_id_brands_brand_id_fk",
+          "tableFrom": "brands",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.postings": {
+      "name": "postings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fx_rate": {
+          "name": "fx_rate",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_base_minor": {
+          "name": "amount_base_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "postings_transaction_idx": {
+          "name": "postings_transaction_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_account_idx": {
+          "name": "postings_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_workspace_idx": {
+          "name": "postings_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "postings_workspace_id_workspaces_id_fk": {
+          "name": "postings_workspace_id_workspaces_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_transaction_id_transactions_id_fk": {
+          "name": "postings_transaction_id_transactions_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_account_id_accounts_id_fk": {
+          "name": "postings_account_id_accounts_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_links": {
+      "name": "document_links",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "document_links_txn_idx": {
+          "name": "document_links_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_links_document_id_documents_id_fk": {
+          "name": "document_links_document_id_documents_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_links_transaction_id_transactions_id_fk": {
+          "name": "document_links_transaction_id_transactions_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_links_document_id_transaction_id_pk": {
+          "name": "document_links_document_id_transaction_id_pk",
+          "columns": [
+            "document_id",
+            "transaction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocr_text": {
+          "name": "ocr_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_model_version": {
+          "name": "ocr_model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_meta": {
+          "name": "extraction_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "documents_workspace_sha_uniq": {
+          "name": "documents_workspace_sha_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_kind_idx": {
+          "name": "documents_kind_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_source_ingest_idx": {
+          "name": "documents_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_workspace_live_idx": {
+          "name": "documents_workspace_live_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"documents\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_workspace_id_workspaces_id_fk": {
+          "name": "documents_workspace_id_workspaces_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_source_ingest_id_ingests_id_fk": {
+          "name": "documents_source_ingest_id_ingests_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_events": {
+      "name": "transaction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "txn_events_txn_idx": {
+          "name": "txn_events_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_events_workspace_id_workspaces_id_fk": {
+          "name": "transaction_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_transaction_id_transactions_id_fk": {
+          "name": "transaction_events_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_actor_id_users_id_fk": {
+          "name": "transaction_events_actor_id_users_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "idempotency_keys_uniq": {
+          "name": "idempotency_keys_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_workspace_id_workspaces_id_fk": {
+          "name": "idempotency_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reconcile": {
+          "name": "auto_reconcile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "batches_workspace_created_idx": {
+          "name": "batches_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_status_idx": {
+          "name": "batches_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batches_workspace_id_workspaces_id_fk": {
+          "name": "batches_workspace_id_workspaces_id_fk",
+          "tableFrom": "batches",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingests": {
+      "name": "ingests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ingest_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "produced": {
+          "name": "produced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingests_batch_idx": {
+          "name": "ingests_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_workspace_created_idx": {
+          "name": "ingests_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_status_idx": {
+          "name": "ingests_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingests_workspace_id_workspaces_id_fk": {
+          "name": "ingests_workspace_id_workspaces_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingests_batch_id_batches_id_fk": {
+          "name": "ingests_batch_id_batches_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconcile_proposals": {
+      "name": "reconcile_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconcile_proposals_batch_idx": {
+          "name": "reconcile_proposals_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconcile_proposals_kind_idx": {
+          "name": "reconcile_proposals_kind_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconcile_proposals_batch_id_batches_id_fk": {
+          "name": "reconcile_proposals_batch_id_batches_id_fk",
+          "tableFrom": "reconcile_proposals",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_photos": {
+      "name": "place_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_photo_name": {
+          "name": "google_photo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width_px": {
+          "name": "width_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_px": {
+          "name": "height_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_attributions": {
+          "name": "author_attributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_extracted": {
+          "name": "ocr_extracted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_reviews": {
+      "name": "place_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_review_name": {
+          "name": "google_review_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_language": {
+          "name": "text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_text": {
+          "name": "original_text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_language": {
+          "name": "original_text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relative_publish_time": {
+          "name": "relative_publish_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_time": {
+          "name": "publish_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_uri": {
+          "name": "author_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_photo_uri": {
+          "name": "author_photo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_taken_at": {
+          "name": "snapshot_taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "google_place_id": {
+          "name": "google_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_name_en": {
+          "name": "display_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh": {
+          "name": "display_name_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_locale": {
+          "name": "display_name_zh_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_source": {
+          "name": "display_name_zh_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_is_native": {
+          "name": "display_name_zh_is_native",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type_display_zh": {
+          "name": "primary_type_display_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maps_type_label_zh": {
+          "name": "maps_type_label_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "types": {
+          "name": "types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_en": {
+          "name": "formatted_address_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_zh": {
+          "name": "formatted_address_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_status": {
+          "name": "business_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_hours": {
+          "name": "business_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_rating_count": {
+          "name": "user_rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "national_phone_number": {
+          "name": "national_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_uri": {
+          "name": "website_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_maps_uri": {
+          "name": "google_maps_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_business_id": {
+          "name": "yelp_business_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_alias": {
+          "name": "yelp_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_price_level": {
+          "name": "yelp_price_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_categories": {
+          "name": "yelp_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_raw_response": {
+          "name": "yelp_raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "places_lat_lng_idx": {
+          "name": "places_lat_lng_idx",
+          "columns": [
+            {
+              "expression": "lat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lng",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "places_google_place_id_unique": {
+          "name": "places_google_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_place_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_snapshots": {
+      "name": "place_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "fetched_by_sha": {
+          "name": "fetched_by_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "place_snapshots_place_idx": {
+          "name": "place_snapshots_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "place_snapshots_place_id_places_id_fk": {
+          "name": "place_snapshots_place_id_places_id_fk",
+          "tableFrom": "place_snapshots",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merchants": {
+      "name": "merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_attribution": {
+          "name": "photo_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_status": {
+          "name": "enrichment_status",
+          "type": "merchant_enrichment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enrichment_attempted_at": {
+          "name": "enrichment_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "merchants_workspace_brand_idx": {
+          "name": "merchants_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merchants_workspace_idx": {
+          "name": "merchants_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merchants_enrichment_pending_idx": {
+          "name": "merchants_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "merchants_workspace_id_workspaces_id_fk": {
+          "name": "merchants_workspace_id_workspaces_id_fk",
+          "tableFrom": "merchants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "merchants_brand_id_brands_brand_id_fk": {
+          "name": "merchants_brand_id_brands_brand_id_fk",
+          "tableFrom": "merchants",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "merchants_brand_id_format": {
+          "name": "merchants_brand_id_format",
+          "value": "\"merchants\".\"brand_id\" ~ '^[a-z0-9-]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.derivation_events": {
+      "name": "derivation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_git_sha": {
+          "name": "prompt_git_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_keys": {
+          "name": "changed_keys",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "derivation_events_entity_idx": {
+          "name": "derivation_events_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "derivation_events_version_idx": {
+          "name": "derivation_events_version_idx",
+          "columns": [
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "derivation_events_workspace_id_workspaces_id_fk": {
+          "name": "derivation_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "derivation_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "asset",
+        "liability",
+        "equity",
+        "income",
+        "expense"
+      ]
+    },
+    "public.batch_status": {
+      "name": "batch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "extracted",
+        "reconciling",
+        "reconciled",
+        "failed",
+        "reconcile_error"
+      ]
+    },
+    "public.document_kind": {
+      "name": "document_kind",
+      "schema": "public",
+      "values": [
+        "receipt_image",
+        "receipt_email",
+        "receipt_pdf",
+        "statement_pdf",
+        "other"
+      ]
+    },
+    "public.ingest_status": {
+      "name": "ingest_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "done",
+        "error",
+        "unsupported"
+      ]
+    },
+    "public.merchant_enrichment_status": {
+      "name": "merchant_enrichment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "not_found",
+        "failed"
+      ]
+    },
+    "public.txn_status": {
+      "name": "txn_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided",
+        "reconciled",
+        "error"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1778920670679,
       "tag": "0018_zippy_gateway",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1778927292094,
+      "tag": "0019_tricky_korvac",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -6000,7 +6000,8 @@
     },
     "/v1/brands/{brandId}/icon": {
       "get": {
-        "summary": "Resolve the preferred icon and stream it (501 until #101 Phase 2)",
+        "summary": "Stream the brand's preferred icon bytes",
+        "description": "Resolves preferred_asset_id and streams the file. 404 when the brand is missing, no asset is preferred, the asset is retired, or the file is missing on disk. Frontend falls back to CategoryIcon on 404 — never to a different candidate.",
         "tags": [
           "brands"
         ],
@@ -6019,17 +6020,7 @@
             "description": "Icon bytes"
           },
           "404": {
-            "description": "Brand or preferred asset missing",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "501": {
-            "description": "Streaming not implemented yet",
+            "description": "Brand or icon unavailable",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/src/ingest/brand-icon-prompt.ts
+++ b/src/ingest/brand-icon-prompt.ts
@@ -1,0 +1,267 @@
+/**
+ * Shared brand-icon acquisition + judgment phases for the extraction
+ * and re-extraction prompts (#101).
+ *
+ * Both prompts inline these phases verbatim so the agent — which runs
+ * inside a container that doesn't have the source files — gets the
+ * full instructions in its prompt window. Don't reference these phases
+ * by source-file path from the prompt; the agent will go looking for
+ * `src/ingest/prompt.ts` and waste turns when it can't find it.
+ */
+
+/**
+ * Phase 2.6 — Brand discovery & registry upsert.
+ *
+ * Per merchant brand_id: ensure a `brands` row exists with a canonical
+ * name and (when discoverable) an official domain. WebSearch for CJK /
+ * regional names; recognize obvious English brands without searching.
+ * Skip silently to `metadata.icon_resolution='discovery_failed'` when
+ * no domain can be found.
+ */
+export const PHASE_2_6_BRAND_DISCOVERY = String.raw`── Phase 2.6 — Brand discovery & registry upsert (#101) ───────────────
+
+Goal: ensure every brand_id you emitted has a row in the global
+\`brands\` registry, with a canonical English name and (when
+discoverable) an official domain. The downstream Phase 4b uses the
+domain to query logo.dev; without it that tier is skipped.
+
+Steps (run once per unique merchant brand_id in this document):
+
+  1. Cache check — read the registry first:
+       psql "\$DATABASE_URL" -c "SELECT brand_id, name, domain, metadata->>'icon_resolution' AS icon_resolution FROM brands WHERE brand_id = '<bid>';"
+
+     - Row exists with non-null domain → done. Move on.
+     - Row exists with null domain AND metadata.icon_resolution =
+       'discovery_failed' → already tried, don't re-try. Move on.
+     - Row exists with null domain → proceed to discover.
+     - Row missing → proceed to discover, then INSERT.
+
+  2. Discover canonical name + domain:
+     - If the brand_id is a recognizable English token with an
+       obvious domain (starbucks → starbucks.com, apple-store →
+       apple.com, costco → costco.com, target → target.com), use it
+       directly — no web search needed.
+     - Otherwise (CJK names, ambiguous abbreviations, regional brands):
+       call the WebSearch tool with a query like
+         "<canonical_name> 官网"
+       or, if you have an address from the receipt text:
+         "<canonical_name> <city or state> official website"
+       Look for an official site in the top 3 results. Prefer the
+       brand's own .com / regional TLD over directories
+       (Yelp/Tripadvisor/etc).
+     - If the LA-region check applies (CJK merchant, US receipt
+       address), the LA-region brand often differs from the
+       mainland: e.g. 三喵奶茶 in LA → 3catea.com, not the
+       mainland chain. Geo from receipt printed address helps
+       disambiguate.
+
+  3. UPSERT:
+       psql "\$DATABASE_URL" <<'SQL'
+         INSERT INTO brands (brand_id, name, domain)
+         VALUES ('<bid>', '<canonical_name>', '<domain or NULL>')
+         ON CONFLICT (brand_id) DO UPDATE
+           SET name   = EXCLUDED.name,
+               domain = COALESCE(brands.domain, EXCLUDED.domain),
+               updated_at = NOW();
+       SQL
+
+  4. Discovery failure:
+     - If no usable domain can be found, INSERT/UPDATE with
+       metadata = jsonb_build_object('icon_resolution', 'discovery_failed').
+       Phase 4b will see this and skip mechanical acquisition for
+       this brand. The frontend falls back to CategoryIcon — this
+       is a first-class outcome, not an error.
+
+Token cost: discovery dominated by WebSearch (1 call per unseen brand).
+Already-cached brands cost only one SELECT. Most receipts hit cache.`;
+
+/**
+ * Phase 4b — Mechanical icon acquisition (4 tiers, retain all).
+ * Phase 4c — Agent visual judgment (Read tool, pick winner).
+ *
+ * Both inlined as one block because they share the same per-brand
+ * loop and the cache pre-check naturally flows from 4b's classification
+ * into 4c's input set.
+ */
+export const PHASE_4B_4C_ICON_PIPELINE = String.raw`── Phase 4b — Mechanical icon acquisition (#101) ──────────────────────
+
+For each unique merchant brand_id this run touched. Skip for
+\`unsupported\` and statement-row aggregates with no merchant.
+
+This phase saves every icon candidate it finds. It does NOT pick a
+winner — that's Phase 4c. The goal here is mechanical retention:
+"every external source that has a plausible match for this brand,
+saved to disk, recorded in \`brand_assets\`". Tier is provenance, not
+priority.
+
+Cache pre-check (token saver — read before fetching anything):
+
+  psql "\$DATABASE_URL" -c "SELECT b.preferred_asset_id, b.user_chose_at, b.domain, b.metadata->>'icon_resolution' AS icon_resolution, (SELECT count(*) FROM brand_assets WHERE brand_id = '<bid>' AND retired_at IS NULL) AS live_count FROM brands b WHERE brand_id = '<bid>';"
+
+  Case A — preferred_asset_id IS NOT NULL:
+    Already resolved. Skip Phase 4b AND 4c for this brand. Move on.
+
+  Case B — preferred_asset_id IS NULL AND live_count > 0:
+    Candidates exist but no winner picked yet. Skip mechanical fetch;
+    go straight to Phase 4c judgment on the existing rows.
+
+  Case C — live_count = 0 AND icon_resolution = 'discovery_failed':
+    No domain to query against, no point fetching. Skip 4b and 4c.
+
+  Case D — live_count = 0 AND domain IS NOT NULL:
+    Run the mechanical fetch below.
+
+Mechanical fetch (Case D only). Run each tier independently — partial
+failure of one tier doesn't block others. Cap at 3 candidates per
+tier to bound the cost. All four tiers can be fetched in parallel
+via separate Bash tool calls if you want.
+
+  Tier itunes — Apple iTunes Search API (always free, no auth):
+
+    curl -sS "https://itunes.apple.com/search?term=<urlencoded canonical_name>&entity=software&country=us&limit=3" | jq -r '.results[] | [.trackName, .bundleId, .artworkUrl512] | @tsv'
+
+    For each row (cap 3): download the artwork512 URL with curl,
+    save to /data/brand-assets/<bid>/itunes/<bundleId>_512.jpg
+    (mkdir -p the parent first). Compute the sha256 of the bytes —
+    that's content_hash. Detect image dimensions if you can
+    (\`identify -format "%wx%h" <file>\` if ImageMagick is available;
+    skip if not — width/height are optional). Then:
+
+      psql "\$DATABASE_URL" <<SQL
+        INSERT INTO brand_assets (brand_id, tier, source_url, local_path,
+          content_hash, content_type, width, height, bytes)
+        VALUES ('<bid>', 'itunes', '<artworkUrl512>',
+          '<bid>/itunes/<bundleId>_512.jpg',
+          '<sha256>', 'image/jpeg', <w or NULL>, <h or NULL>, <bytes>)
+        ON CONFLICT (brand_id, content_hash) DO UPDATE
+          SET last_seen_at = NOW();
+      SQL
+
+    Do not filter by trackName here — keep all 3 results.
+    Phase 4c will judge them visually.
+
+  Tier svgl — clean colored SVGs:
+
+    curl -sS "https://api.svgl.app/?search=<urlencoded canonical_name>" | jq -c '.'
+
+    The response is a JSON array OR an error object. Skip on error.
+    Iterate: accept results where \`title\` equals the brand name or
+    its parent walked up via \`brands.parent_id\` (max 2 hops). For
+    each, download the light variant (\`.route\` is typically the
+    light URL). Save to /data/brand-assets/<bid>/svgl/<id>_light.svg
+    and INSERT with tier='svgl', content_type='image/svg+xml'.
+
+  Tier logo_dev — search-first, never blind GET:
+
+    Two-step. Step 1 verifies the brand is in the registry (avoids
+    the "any unknown domain returns a generated first-letter PNG"
+    bug). Step 2 follows the response's pre-signed logo_url.
+
+    Skip this tier entirely if LOGODEV_SECRET_KEY is unset.
+
+    curl -sS -H "Authorization: Bearer \$LOGODEV_SECRET_KEY" \
+      "https://api.logo.dev/search?q=<urlencoded canonical_name>" | jq -c '.'
+
+    Iterate matches with plausible name/domain (cap 3). For each:
+    follow its \`logo_url\` field (already includes pk_… key). Save
+    to /data/brand-assets/<bid>/logo-dev/<domain>.png. INSERT with
+    tier='logo_dev'. If the search response is an empty array OR a
+    401/403, skip this tier silently — do NOT fall back to a blind
+    img.logo.dev/<domain> GET.
+
+  Tier simple_icons — monochrome SVGs (often inferior, but free):
+
+    Compute the slug: lowercase, drop non-alphanumeric. E.g.
+    "Best Buy" → "bestbuy".
+
+    curl -sS -o /tmp/si.svg -w '%{http_code} %{content_type}\n' \
+      "https://cdn.simpleicons.org/<slug>"
+
+    Only save if HTTP 200 AND content_type starts with "image/svg".
+    Save to /data/brand-assets/<bid>/simple-icons/<slug>.svg.
+    INSERT with tier='simple_icons'.
+
+After mechanical fetch, brand_assets now has 0..N rows for this brand
+with agent_relevance and agent_notes still NULL. Proceed to Phase 4c.
+
+── Phase 4c — Agent visual judgment (#101) ────────────────────────────
+
+For every brand_id that went through Phase 4b — including Case B
+where you skipped mechanical fetch but still need to score existing
+candidates. Skip for Case A (already-resolved) and Case C
+(discovery_failed) brands.
+
+Step 1: list the live candidates:
+
+  psql "\$DATABASE_URL" -c "SELECT id, tier, local_path FROM brand_assets WHERE brand_id = '<bid>' AND retired_at IS NULL ORDER BY acquired_at;"
+
+Step 2: for each row, use the Read tool to open the file at
+\`/data/brand-assets/<local_path>\`. Form a one-line visual judgment
+and score on 0..100. The judgment is visual — don't rely on tier,
+source URL, or filename. Score axes:
+
+  - Brand mark vs. auxiliary app icon. iTunes returns the App Store
+    shopping bag for "Apple", a purple Dashboard tile for "Stripe".
+    Those are the App Store app's icon and Stripe's Dashboard
+    product's icon, not the brand mark. agent_relevance ≤ 20.
+  - Generated letter-fallback placeholder. Single capital letter,
+    generic sans-serif, white background → 0; also retire the asset
+    so future re-acquisition skips it.
+  - Monochrome vs. brand-color logo. Simple Icons SVGs are
+    monochrome; unless the brand IS monochrome (Apple, NYT) prefer
+    a colored variant. Penalize monochrome ~15.
+  - Regional or limited variant. CHAGEE HK&MO badge on a US receipt
+    → mild penalty vs. a clean variant.
+  - Wordmark-on-square vs. symbol. Both acceptable — neutral.
+  - Quality: dimensions (bigger is better for raster), padding
+    (over-cropped is bad), transparency present, color accuracy.
+
+Step 3: write the judgment back per candidate:
+
+  psql "\$DATABASE_URL" <<SQL
+    UPDATE brand_assets
+       SET agent_relevance    = <0..100>,
+           agent_notes        = '<one-line judgment>',
+           extraction_version = extraction_version + 1
+           <, retired_at = NOW() if letter-fallback or otherwise unusable>
+     WHERE id = '<candidate_id>';
+  SQL
+
+Step 4: pick the winner (Layer-3-safe):
+
+  psql "\$DATABASE_URL" <<SQL
+    UPDATE brands
+       SET preferred_asset_id = (
+             SELECT id FROM brand_assets
+              WHERE brand_id = '<bid>'
+                AND retired_at IS NULL
+                AND agent_relevance >= 30
+              ORDER BY agent_relevance DESC, acquired_at ASC
+              LIMIT 1
+           ),
+           updated_at = NOW()
+     WHERE brand_id = '<bid>'
+       AND user_chose_at IS NULL;
+  SQL
+
+The \`user_chose_at IS NULL\` clause is the Layer-3 lock — if the
+user has manually picked an icon via PATCH /v1/brands/:id, never
+overwrite it.
+
+Step 5: if no candidate scored ≥ 30, the agent rejected every
+candidate. Record that:
+
+  psql "\$DATABASE_URL" <<SQL
+    UPDATE brands
+       SET preferred_asset_id = NULL,
+           metadata = metadata || jsonb_build_object(
+             'icon_resolution', 'all_candidates_rejected'
+           ),
+           updated_at = NOW()
+     WHERE brand_id = '<bid>'
+       AND user_chose_at IS NULL;
+  SQL
+
+The frontend falls back to CategoryIcon in this case — a first-class
+outcome. Layer-1 retention is preserved (the candidates stay in
+brand_assets so re-extract can revisit them later).`;

--- a/src/ingest/extractor.ts
+++ b/src/ingest/extractor.ts
@@ -14,7 +14,12 @@ import {
   type ReExtractPromptContext,
 } from "./reextract-prompt.js";
 
-const CLAUDE_TIMEOUT_MS = Number(process.env.CLAUDE_TIMEOUT_MS ?? 300_000);
+// Bumped 300s → 900s in #101 Phase 2 to accommodate the new Phase 2.6
+// (WebSearch for CJK domains), Phase 4b (4-tier mechanical fetch with
+// curl downloads), and Phase 4c (Read tool per candidate + visual
+// scoring). First-time brand resolution legitimately needs the budget;
+// cached brands return in seconds via the Case A early-out.
+const CLAUDE_TIMEOUT_MS = Number(process.env.CLAUDE_TIMEOUT_MS ?? 900_000);
 
 export interface ExtractorInput {
   /** Absolute path on disk — sha256-named, written by the documents service. */

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -8,6 +8,10 @@
  * (Node-side coerce + service-layer writes) to Phase 2.
  */
 import { buildInfo } from "../generated/build-info.js";
+import {
+  PHASE_2_6_BRAND_DISCOVERY,
+  PHASE_4B_4C_ICON_PIPELINE,
+} from "./brand-icon-prompt.js";
 
 /**
  * Manual prompt-version stamp written into `transactions.metadata.extraction`
@@ -17,7 +21,7 @@ import { buildInfo } from "../generated/build-info.js";
  * `extraction.prompt_version` ≠ `PROMPT_VERSION` are eligible to be
  * re-derived. See #80 / #88 for the 3-layer data model rationale.
  */
-export const PROMPT_VERSION = "2.8";
+export const PROMPT_VERSION = "2.9";
 
 export interface ExtractorPromptContext {
   /** Absolute path inside the container where the file was staged. */
@@ -364,6 +368,11 @@ the most attention-sensitive new ask in the prompt; keep it terse.
 
 The merchant block goes into the transaction's \`metadata.merchant\` JSON
 key (see the Phase 4 template).
+
+${PHASE_2_6_BRAND_DISCOVERY}
+
+For receipt_image / receipt_email / receipt_pdf only. Skip for
+\`statement_pdf\` (handled per-row in Phase 4b) and \`unsupported\`.
 
 ── Phase 3 — Resolve place + fetch multilingual record (#74) ──────────
 
@@ -773,6 +782,28 @@ Invariants you MUST honor:
 
 ### 4a. receipt_image / receipt_email / receipt_pdf
 
+**Pre-step — brand FK guard.** Phase 2.6 ensured the merchant's
+brand_id is in \`brands\`. Items may also carry \`product_brand_id\`
+(e.g. Apple-branded products at Best Buy → product brand = "apple",
+merchant brand = "best-buy"). \`products.brand_id\` is FK into
+\`brands\`, so before the BEGIN below, run one defensive UPSERT for
+every distinct product_brand_id present in items[]:
+
+  psql "\$DATABASE_URL" <<'SQL'
+    INSERT INTO brands (brand_id, name)
+    SELECT DISTINCT product_brand_id, product_brand_id
+      FROM jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb)
+        AS item(product_brand_id text)
+     WHERE product_brand_id IS NOT NULL
+    ON CONFLICT (brand_id) DO NOTHING;
+  SQL
+
+This is a stub row (domain NULL); we don't run Phase 2.6 discovery
+for product brand_ids in v1. Phase 4b will skip them at the
+discovery_failed check, so they cost nothing extra at ingest. They
+become eligible for discovery + icon acquisition if a future ingest
+sees the same brand as a merchant.
+
 Write one balanced transaction. The expense account name is **exactly
 the \`merchant.category\` value you emitted in Phase 2.5** — one of the
 seven canonical accounts:
@@ -1154,6 +1185,9 @@ in the final ingest close-out (Phase 5).
 ### 4c. unsupported
 
 Skip every insert above. Go directly to Phase 5.
+
+${PHASE_4B_4C_ICON_PIPELINE}
+
 
 ── Phase 5 — Close the ingest row ─────────────────────────────────────
 

--- a/src/ingest/reextract-prompt.ts
+++ b/src/ingest/reextract-prompt.ts
@@ -29,6 +29,10 @@
  * `src/ingest/prompt.ts`'s ~800.
  */
 import { buildInfo } from "../generated/build-info.js";
+import {
+  PHASE_2_6_BRAND_DISCOVERY,
+  PHASE_4B_4C_ICON_PIPELINE,
+} from "./brand-icon-prompt.js";
 
 /**
  * Bumped on meaningful re-extract prompt edits. Separate from
@@ -37,7 +41,7 @@ import { buildInfo } from "../generated/build-info.js";
  * into `transactions.metadata.extraction.prompt_version` on every run
  * (overwriting the prior value), and into `derivation_events.prompt_version`.
  */
-export const REEXTRACT_PROMPT_VERSION = "1.3";
+export const REEXTRACT_PROMPT_VERSION = "1.5";
 
 /**
  * The model identifier we stamp into `documents.ocr_model_version`.
@@ -144,6 +148,19 @@ also OUT OF SCOPE — re-extract does not rewrite them. Do NOT touch
 \`postings\` or \`document_links\`.
 
 ── Phase 2 — Write ────────────────────────────────────────────────────
+
+**Brand FK guard (#101).** Items may carry product_brand_id, which is
+FK into \`brands\`. Re-extract products UPSERT below would fail if the
+brand row doesn't exist. Run this defensively BEFORE the main block:
+
+  psql "\$DATABASE_URL" <<'SQL'
+    INSERT INTO brands (brand_id, name)
+    SELECT DISTINCT product_brand_id, product_brand_id
+      FROM jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb)
+        AS item(product_brand_id text)
+     WHERE product_brand_id IS NOT NULL
+    ON CONFLICT (brand_id) DO NOTHING;
+  SQL
 
 Run exactly ONE psql block. Substitute your extracted values for the
 placeholders; the CASE statements consult \`metadata.user_edited\` so a
@@ -328,6 +345,38 @@ user override survives this re-extract.
 IMPORTANT escaping rule: SQL single quotes inside values must be
 doubled (\`O''Brien\`). Newlines inside \`raw_text\` are fine inside a
 single-quoted SQL literal as long as no single quote is unescaped.
+
+── Phase 3 — Refresh brand identity & icons (#101) ────────────────────
+
+Re-extract refreshes the merchant's brand registry entry AND its
+icons. Apply both sub-phases below to the merchant.brand_id of the
+transaction (NOT to product brand_ids — those are stub-only in v1).
+
+Layer-3 protection is mandatory: never overwrite a user's choice.
+The Phase 4c winner-pick UPDATE is gated on
+\`user_chose_at IS NULL\`; user ratings
+(\`brand_assets.user_rating\`) and uploads
+(\`brand_assets.user_uploaded\`) are not touched by re-extract at all.
+
+Step 1: identify the merchant's brand_id and canonical_name from the
+transaction's merchant row:
+
+  psql "\$DATABASE_URL" -c "SELECT m.brand_id, m.canonical_name FROM transactions t JOIN merchants m ON m.id = t.merchant_id WHERE t.id = '${ctx.transactionId}';"
+
+If the SELECT returns NULL (voided / orphaned tx), skip Phase 3.
+
+Step 2: substitute the returned brand_id for <bid> and the
+canonical_name for <canonical_name> in the inlined phases that
+follow, then execute them verbatim:
+
+${PHASE_2_6_BRAND_DISCOVERY}
+
+${PHASE_4B_4C_ICON_PIPELINE}
+
+Most re-extracts hit Case A (already-resolved) on the cache pre-check
+and complete in one SELECT. Case B (re-judge existing candidates with
+no new fetch) is the next most common; full Case D (mechanical fetch
++ judgment) only runs when the brand has never been resolved.
 
 ── Done ────────────────────────────────────────────────────────────────
 

--- a/src/routes/brands.ts
+++ b/src/routes/brands.ts
@@ -12,6 +12,9 @@ import express, { Router, type Request, type Response, type NextFunction } from 
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 import { sql, eq, and, isNull } from "drizzle-orm";
+import { createReadStream } from "fs";
+import { stat } from "fs/promises";
+import { join, isAbsolute } from "path";
 import { db } from "../db/client.js";
 import { brands, brandAssets } from "../schema/index.js";
 import { parseOrThrow } from "../http/validate.js";
@@ -20,11 +23,17 @@ import {
   BrandAsset,
   UpdateBrandRequest,
 } from "../schemas/v1/brand.js";
-import { ProblemDetails, Uuid } from "../schemas/v1/common.js";
+import { ProblemDetails } from "../schemas/v1/common.js";
 import {
   HttpProblem,
   NotFoundProblem,
 } from "../http/problem.js";
+
+// Where the bind-mount lands inside the container. Phase 4b writes each
+// candidate to `<BRAND_ASSETS_ROOT>/<brand_id>/<tier>/<token>.<ext>` and
+// stores the relative path (everything after the root) in
+// `brand_assets.local_path`. Streaming joins root + local_path.
+const BRAND_ASSETS_ROOT = process.env.BRAND_ASSETS_ROOT || "/data/brand-assets";
 
 export const brandsRouter: Router = Router();
 
@@ -169,8 +178,12 @@ brandsRouter.get(
 
 // ── GET /v1/brands/:brandId/icon ───────────────────────────────────────
 //
-// Resolves the preferred asset and streams its bytes. Stub for now —
-// returns 404 until #101 Phase 2 starts populating brand_assets.
+// Resolves the brand's preferred_asset_id and streams the bytes from
+// `${BRAND_ASSETS_ROOT}/<local_path>`. Returns 404 if the brand is
+// missing, no asset is preferred, the asset row is retired, or the
+// file is missing on disk. The frontend falls back to CategoryIcon on
+// any 404; never to a different candidate (per #101 spec: no inter-
+// candidate cascade — the agent already picked the winner at ingest).
 
 brandsRouter.get(
   "/:brandId/icon",
@@ -191,17 +204,43 @@ brandsRouter.get(
           `No preferred_asset_id for brand=${brandId}`,
         );
       }
-      // Placeholder until Phase 2 wires the streaming path:
-      // - Look up `brand_assets.local_path` (relative)
-      // - Stream from `/data/brand-assets/<local_path>` with the right
-      //   Content-Type header and an immutable Cache-Control.
-      // For now we 501 so callers know it's not wired yet.
-      throw new HttpProblem(
-        501,
-        "icon-streaming-not-implemented",
-        "Brand icon streaming lands in #101 Phase 2",
-        `Phase 1 establishes brands + brand_assets schema. Streaming of the resolved asset (id=${preferredId}) is wired by the follow-up PR that adds Phase 5a/5b agent acquisition.`,
-      );
+      const assetRows = await db
+        .select({
+          localPath: brandAssets.localPath,
+          contentType: brandAssets.contentType,
+          retiredAt: brandAssets.retiredAt,
+        })
+        .from(brandAssets)
+        .where(eq(brandAssets.id, preferredId));
+      if (assetRows.length === 0) {
+        throw new NotFoundProblem(
+          "Brand icon",
+          `preferred_asset_id=${preferredId} not found for brand=${brandId}`,
+        );
+      }
+      const asset = assetRows[0]!;
+      if (asset.retiredAt !== null) {
+        // Stale pointer — UI fallback. Re-extract should clear this.
+        throw new NotFoundProblem(
+          "Brand icon",
+          `preferred_asset_id=${preferredId} is retired for brand=${brandId}`,
+        );
+      }
+      const absPath = isAbsolute(asset.localPath)
+        ? asset.localPath
+        : join(BRAND_ASSETS_ROOT, asset.localPath);
+      try {
+        const st = await stat(absPath);
+        if (!st.isFile()) throw new Error("not a file");
+      } catch {
+        throw new NotFoundProblem(
+          "Brand icon",
+          `File missing on disk: ${absPath}`,
+        );
+      }
+      res.setHeader("Content-Type", asset.contentType);
+      res.setHeader("Cache-Control", "public, max-age=86400, immutable");
+      createReadStream(absPath).pipe(res);
     } catch (err) {
       next(err);
     }
@@ -323,13 +362,14 @@ export function registerBrandsOpenApi(registry: OpenAPIRegistry): void {
   registry.registerPath({
     method: "get",
     path: "/v1/brands/{brandId}/icon",
-    summary: "Resolve the preferred icon and stream it (501 until #101 Phase 2)",
+    summary: "Stream the brand's preferred icon bytes",
+    description:
+      "Resolves preferred_asset_id and streams the file. 404 when the brand is missing, no asset is preferred, the asset is retired, or the file is missing on disk. Frontend falls back to CategoryIcon on 404 — never to a different candidate.",
     tags: ["brands"],
     request: { params: z.object({ brandId: z.string() }) },
     responses: {
       200: { description: "Icon bytes" },
-      404: { description: "Brand or preferred asset missing", content: problemContent },
-      501: { description: "Streaming not implemented yet", content: problemContent },
+      404: { description: "Brand or icon unavailable", content: problemContent },
     },
   });
 

--- a/src/schema/brands.ts
+++ b/src/schema/brands.ts
@@ -48,6 +48,15 @@ export const brands = pgTable("brands", {
   /** Layer-3 lock — when NOT NULL, re-extract leaves
    *  `preferred_asset_id` alone (user has chosen). */
   userChoseAt: timestamp("user_chose_at", { withTimezone: true }),
+  /**
+   * Free-form per-brand state. Currently used by Phase 2.6 / 4c to
+   * record icon-resolution outcomes:
+   *   - {"icon_resolution": "discovery_failed"} — Phase 2.6 couldn't
+   *     find a canonical domain, so Phase 4b is skipped.
+   *   - {"icon_resolution": "all_candidates_rejected"} — Phase 4c
+   *     scored every candidate below the acceptance threshold.
+   */
+  metadata: jsonb("metadata").notNull().default({}),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .default(sql`NOW()`),

--- a/src/schema/merchants.ts
+++ b/src/schema/merchants.ts
@@ -12,6 +12,7 @@ import { sql } from "drizzle-orm";
 import { merchantEnrichmentStatusEnum } from "./enums.js";
 import { createdAt, updatedAt } from "./common.js";
 import { workspaces } from "./workspaces.js";
+import { brands } from "./brands.js";
 
 /**
  * Canonicalized merchants, the aggregation root behind the merchant page
@@ -39,8 +40,14 @@ export const merchants = pgTable(
      * Kebab-case stable identifier emitted by the extractor — same brand
      * should always collapse to the same id (e.g. `starbucks`, `apple-store`).
      * Used in frontend URLs as the path segment for the merchant page.
+     * FK into the global `brands` registry (#101) — every merchant row's
+     * `brand_id` must correspond to a `brands.brand_id` PK. Phase 2.6
+     * of the ingest prompt upserts the brand row before the merchant
+     * UPSERT in Phase 4.
      */
-    brandId: text("brand_id").notNull(),
+    brandId: text("brand_id")
+      .notNull()
+      .references(() => brands.brandId),
     /** Display name (e.g. "Starbucks", "Apple Store"). */
     canonicalName: text("canonical_name").notNull(),
     /**

--- a/src/schema/products.ts
+++ b/src/schema/products.ts
@@ -33,6 +33,7 @@ import {
 import { sql } from "drizzle-orm";
 import { workspaces } from "./workspaces.js";
 import { merchants } from "./merchants.js";
+import { brands } from "./brands.js";
 
 export const products = pgTable(
   "products",
@@ -48,10 +49,12 @@ export const products = pgTable(
     merchantId: uuid("merchant_id").references(() => merchants.id, {
       onDelete: "set null",
     }),
-    /** Text, not FK — the manufacturer (`apple`) can differ from the
-     *  seller (`best-buy`). A soft join against `merchants.brand_id`
-     *  covers cases where the brand is itself a known merchant. */
-    brandId: text("brand_id"),
+    /** FK into the global `brands` registry (#101). Manufacturer brand,
+     *  may differ from the seller (Crunchwrap branded `taco-bell` sold
+     *  at a Best Buy → `brand_id='taco-bell'` here, merchant separately
+     *  identifies Best Buy). Nullable: line items without a recognizable
+     *  brand (raw groceries, services) leave it NULL. */
+    brandId: text("brand_id").references(() => brands.brandId),
     itemClass: text("item_class").notNull(),
 
     // Product-level attribute facets — each variant gets its own row.


### PR DESCRIPTION
## Summary

Finishes the brand-icon pipeline left after PR #110 by adding agent-driven discovery + acquisition + visual judgment. The architecture is the one from #101 with one extension (cache-first pre-check) plus the #86 schema-cleanup residual.

Closes #101.

## What changes

### Migration `0019_tricky_korvac`

- **`brands` adds `metadata jsonb`** — Phase 2.6 / 4c record icon-resolution outcomes (`discovery_failed`, `all_candidates_rejected`) here, first-class no-icon states the frontend maps to `CategoryIcon`.
- **`merchants.brand_id` and `products.brand_id` promoted to FK** on `brands.brand_id` — the #86 residual. Backfilled stub `brands` rows (`name = brand_id` verbatim, `domain` NULL) for every existing referenced value before `ADD CONSTRAINT`. 73 rows backfilled in dev (72 merchant brands + 1 product-only brand).
- **`transactions.merchant_id` stays nullable** with a column comment documenting why — voided rows, statement-line aggregates, and `unsupported` classification all need a no-merchant affordance. The #101 spec proposed this default option (b); kept as-is.

### Runtime plumbing

- `docker-compose.yml` adds the `brand-assets/` bind-mount at `${HOME}/Developer/receipt-assistant-data/brand-assets:/data/brand-assets` (SIBLING dir, not in git or iCloud — matches postgres + claude sibling pattern), plus `LOGODEV_PUBLISHABLE_KEY` / `LOGODEV_SECRET_KEY` env vars (empty-default like `GOOGLE_MAPS_API_KEY`).
- `.env.example` documents both keys.

### `GET /v1/brands/:id/icon` — replaces 501 stub

Resolves `brands.preferred_asset_id` → `brand_assets.local_path`, streams via `createReadStream` from `/data/brand-assets/<local_path>` with `Cache-Control: public, max-age=86400, immutable`. 404 on missing brand / NULL preferred / retired asset / file ENOENT (frontend always falls to `CategoryIcon` — no inter-candidate cascade per spec). Mirrors the place-photo pattern in `src/routes/merchants.ts:238–288`.

### Prompt: Phase 2.6 + Phase 4b + Phase 4c (shared)

The icon-pipeline prompt blocks are now exported from `src/ingest/brand-icon-prompt.ts` and inlined verbatim into both `src/ingest/prompt.ts` (PROMPT_VERSION → `2.9`) and `src/ingest/reextract-prompt.ts` (REEXTRACT_PROMPT_VERSION → `1.5`). They cannot be referenced by source-file path — the agent runs in the container without the source tree and wastes turns hunting for files that aren't there. Lesson learned during the first re-extract smoke test.

**Phase 2.6 — Brand discovery & registry upsert.** Per merchant `brand_id`: SELECT brands; if no domain, `WebSearch` for canonical domain (with LA-region disambiguation for CJK merchants). UPSERT `brands(brand_id, name, domain)`. Failure → `metadata.icon_resolution='discovery_failed'`, Phase 4b skips this brand cleanly.

**Phase 4b — Mechanical icon acquisition (4 tiers, retain all).** Cache pre-check classifies the brand into one of four cases:
- **Case A** — `preferred_asset_id NOT NULL` → skip 4b AND 4c (O(new brand), not O(every receipt)).
- **Case B** — `live_count > 0` but no preferred → re-judge existing only.
- **Case C** — `discovery_failed` → skip.
- **Case D** — full fetch from `itunes`, `svgl`, `logo_dev` (search-first via `api.logo.dev/search` — never blind `img.logo.dev/<domain>` GET because that returns letter-fallback PNGs for unknown domains), `simple_icons`. Saved to `<brand>/<tier>/<token>.<ext>` with `ON CONFLICT (brand_id, content_hash) DO UPDATE SET last_seen_at` dedup.

**Phase 4c — Agent visual judgment.** Agent uses the `Read` tool on each candidate file, scores 0–100 on visual axes (brand-mark vs auxiliary app icon, letter-fallback, monochrome penalty, regional badge, quality). Winner pick gated on `WHERE user_chose_at IS NULL` — Layer-3 lock honored. No candidate ≥ 30 → `preferred_asset_id = NULL` + `metadata.icon_resolution='all_candidates_rejected'`.

### Re-extract integration

`reextract-prompt.ts` gains a Phase 3 section that runs the same Phase 2.6 + 4b/4c blocks against the transaction's merchant `brand_id`. Cache-first guarantees most re-extracts hit Case A (free SELECT) or Case B (re-judge only). Layer-3 protections (`user_chose_at`, `user_rating = -1` retired assets) survive untouched.

## Smoke test (real receipts)

Hand-tested by re-extracting a Starbucks transaction in dev. Result:

```
brand_id  | name      | domain        | preferred_asset_id
starbucks | Starbucks | starbucks.com | logo_dev/starbucks.com.png (score 92)

5 candidates retained, scored:
  92  logo_dev    starbucks.com    — canonical siren in official green
  80  itunes      mystarbucks_512  — Starbucks Siren brand mark on green
  60  simple_icons starbucks.svg   — single-color #006241 outline (monochrome penalty)
  55  logo_dev    starbucks.tt     — TT variant
  50  logo_dev    starbucks.ca     — monochrome regional
```

`GET /v1/brands/starbucks/icon` returns 200 with image bytes. 2nd re-extract: 0 new assets fetched, `preferred_asset_id` unchanged (cache pre-check working).

## Acceptance criteria (#101 Phase 2)

- [x] `0019` migration: FK promotion + `brands.metadata` column + tx.merchant_id comment
- [x] `LOGODEV_*` env wiring + `brand-assets/` bind-mount in compose
- [x] Icon streaming endpoint replaces 501 stub
- [x] Phase 2.6 brand discovery implemented
- [x] Phase 4b mechanical acquisition with cache-first early-outs
- [x] Phase 4c agent visual judgment, Layer-3-safe winner pick
- [x] Re-extract prompt mirrors the new phases (`REEXTRACT_PROMPT_VERSION` 1.3 → 1.5)
- [x] OpenAPI regenerated (501 → 404 on `/v1/brands/:id/icon`)
- [x] `grep -n "override" src/ingest/prompt.ts` yields no curated brand→tier map — agent picks visually
- [x] Smoke test on Starbucks passes end-to-end (full pipeline; 5 candidates, correct winner)

## Out of scope (per #101)

Wordmark/banner slot · per-merchant icon override · automatic re-acquisition cron · CV-based scoring · the `MerchantIcon` frontend component (handled separately by TINKPA/receipt-assistant-frontend#48 — this PR unblocks it by populating `brand.icon_url`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)