### PR TITLE
Log JSONL transcript path at claude -p spawn for live mid-run debugging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,62 @@ Local dev defaults:
 - Public key: `pk-receipt-local`
 - Secret key: `sk-receipt-local`
 
+### Live trace: tail the JSONL while the extractor is running (recommended for debugging hangs / errors)
+
+Langfuse only ingests the trace **after** `claude -p` exits — so if an extraction hangs, times out, or crashes mid-loop, Langfuse never sees it and you have nothing to inspect. **This is the right tool when something looks stuck.**
+
+`src/ingest/extractor.ts` (both `defaultClaudeExtractor` and `defaultClaudeReExtractor`) logs the live transcript path to stdout the instant it spawns the subprocess. Grep `docker logs` for the spawn line, then `tail -f` the JSONL on the host — it's bind-mounted, so no `docker exec` needed and the file is being written in real time by the in-container `claude` CLI:
+
+```bash
+# 1. Find the spawn line for the most recent extraction (or grep by ingestId).
+docker logs receipt-assistant --since 5m 2>&1 | grep '\[claude\] extract' | tail -3
+# → [claude] extract ingestId=<id> sessionId=<uuid> jsonl=/home/node/.claude/projects/-app/<uuid>.jsonl
+
+# 2. Translate the container path to the host bind-mount and tail it.
+#    /home/node/.claude/  ←→  ~/Developer/receipt-assistant-data/claude/
+SID=<uuid-from-spawn-line>
+tail -f ~/Developer/receipt-assistant-data/claude/projects/-app/$SID.jsonl
+
+# 3. To pretty-print as the agent runs (one event per line, type + tool + short payload):
+tail -f ~/Developer/receipt-assistant-data/claude/projects/-app/$SID.jsonl \
+  | python3 -c "
+import json, sys
+for line in sys.stdin:
+    e = json.loads(line)
+    t = e.get('type')
+    if t == 'assistant':
+        for b in e.get('message', {}).get('content', []) or []:
+            if b.get('type') == 'tool_use':
+                cmd = b.get('input', {}).get('command') or b.get('input', {}).get('file_path') or ''
+                print(f'  tool: {b[\"name\"]:>10}  {str(cmd)[:120]}')
+            elif b.get('type') == 'thinking' and b.get('thinking'):
+                print(f'  think: {b[\"thinking\"][:140]}')
+            elif b.get('type') == 'text' and b.get('text'):
+                print(f'  text : {b[\"text\"][:140]}')
+    elif t == 'user':
+        c = e.get('message', {}).get('content', [])
+        if isinstance(c, list):
+            for b in c:
+                if b.get('type') == 'tool_result':
+                    inner = b.get('content', '')
+                    if isinstance(inner, list):
+                        inner = ' '.join(x.get('text','') for x in inner if x.get('type')=='text')
+                    print(f'  result: {str(inner)[:120]}')
+"
+```
+
+When to reach for this vs. Langfuse:
+
+| Symptom | Use |
+|---|---|
+| Extraction is stuck in `processing` for >2 min | **Tail the JSONL** — Langfuse hasn't seen anything yet |
+| `claude -p` timed out / hit `CLAUDE_TIMEOUT_MS` | **Tail the JSONL** — Langfuse's trace will be missing or partial; the JSONL has the last events the agent emitted |
+| Agent exited with a SQL error, want to see what it tried to write | **Tail the JSONL** for the `tool_use:Bash` blocks; Langfuse compresses these |
+| Reviewing a past, completed extraction | **Langfuse REST API** — that's its job |
+| Comparing date-OCR accuracy across many receipts | **Langfuse REST API** + the app's `/v1/transactions` |
+
+The JSONL is the source of truth Langfuse ingests from — when the two ever disagree, the JSONL is right.
+
 ### Manual Verification Flow
 
 No verify script. Three curl calls are the contract:

--- a/src/ingest/extractor.ts
+++ b/src/ingest/extractor.ts
@@ -8,6 +8,7 @@
  */
 import { spawn } from "child_process";
 import { randomUUID } from "crypto";
+import { getSessionJsonlPath } from "../langfuse.js";
 import { buildExtractorPrompt, type ExtractorPromptContext } from "./prompt.js";
 import {
   buildReExtractPrompt,
@@ -118,6 +119,13 @@ export const defaultClaudeExtractor: Extractor = async (input) => {
     userId: input.userId,
   };
   const prompt = buildExtractorPrompt(ctx);
+  // Log the live-transcript path BEFORE spawn so an operator can
+  // `tail -f` it mid-run. The agent loop can take 30-900s and may hang;
+  // Langfuse only ingests on exit, so without this line there is no
+  // way to see what the agent is doing in real time.
+  console.log(
+    `[claude] extract ingestId=${input.ingestId} sessionId=${sessionId} jsonl=${getSessionJsonlPath(sessionId)}`,
+  );
   const stdout = await runClaude(prompt, sessionId, CLAUDE_TIMEOUT_MS);
   return { sessionId, stdout };
 };
@@ -159,6 +167,9 @@ export const defaultClaudeReExtractor: ReExtractor = async (input) => {
     userId: input.userId,
   };
   const prompt = buildReExtractPrompt(ctx);
+  console.log(
+    `[claude] re-extract txId=${input.transactionId} sessionId=${sessionId} jsonl=${getSessionJsonlPath(sessionId)}`,
+  );
   const stdout = await runClaude(prompt, sessionId, CLAUDE_TIMEOUT_MS);
   return { sessionId, stdout };
 };


### PR DESCRIPTION
## Summary

`src/ingest/extractor.ts` (both `defaultClaudeExtractor` and `defaultClaudeReExtractor`) now logs the live transcript path to stdout the instant `claude -p` is spawned:

```
[claude] extract ingestId=<id> sessionId=<uuid> jsonl=/home/node/.claude/projects/-app/<uuid>.jsonl
```

This closes a visibility gap I hit while diagnosing a stuck extraction: Langfuse only ingests after the subprocess exits, so for the full 30–900 s the agent is running, `docker logs` was silent and there was no way to see what the agent was actually doing. If the subprocess hung or timed out, the trace was lost entirely.

The JSONL file is being live-written by the in-container `claude` CLI and is exposed on the host via the existing `~/Developer/receipt-assistant-data/claude/` bind-mount — so an operator can `tail -f` it directly without `docker exec`.

## Scope

- `src/ingest/extractor.ts` — two `console.log` lines, one per code path (extract + re-extract). No behavior change.
- `CLAUDE.md` — new "Live trace: tail the JSONL while the extractor is running" subsection under Langfuse Observability, with a pretty-printer for the JSONL stream and a when-to-reach-for-this table contrasting the live tail (mid-run, partial traces, hangs, timeouts) with the Langfuse REST API (post-mortem, completed runs).

## Verification

Smoke-tested locally: re-encoded a real receipt fixture, uploaded via `POST /v1/ingest/batch`, and confirmed end-to-end:

- The `[claude] extract ingestId=… sessionId=… jsonl=…` line appeared in `docker logs receipt-assistant` immediately after upload.
- `wc -l` on the printed host-side JSONL path grew live during processing (12 → 17 → 23 → 30 → … → 70 over ~2 min).
- Pretty-printer surfaced the agent's actual tool sequence mid-run: `Read` image → query `brands` → `geocode` lookup → query `places` → query `accounts` → `INSERT brands` → `Write` icon, 15 tool calls total.
- Batch reached `status=reconciled` with `{done: 1, error: 0}`. The new log line does not change extraction behavior.

## Acceptance criteria

- [x] `docker logs receipt-assistant` shows a `[claude] extract …` line within seconds of an ingest hitting the worker.
- [x] The printed `jsonl=…` path resolves to a file on disk (host side via the bind-mount) while the agent is still running.
- [x] Pretty-printer recipe in CLAUDE.md runs against a real mid-extraction JSONL and prints human-readable tool calls.
- [x] Re-extract path (`defaultClaudeReExtractor`) logs the same shape with `txId=` instead of `ingestId=`.
- [x] Existing extraction smoke test passes: receipt → reconciled, transaction row written, Langfuse trace still ingested post-exit.

## Impact / Relation

- Pure observability change. No DB schema, no API change, no client-visible behavior.
- Pairs with the existing Langfuse REST flow rather than replacing it — the CLAUDE.md table explicitly carves the boundary (live tail for "stuck / timed out / SQL error mid-run", Langfuse for "review a past completed run").

🤖 Generated with [Claude Code](https://claude.com/claude-code)