### PR TITLE
feat(sandbox): side-by-side test stack for frontend-test-runner

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,70 @@
+# Sandbox stack for frontend-test-runner.
+#
+#   docker compose -p receipts-test -f docker-compose.test.yml up -d --build
+#
+# Side-by-side with the production stack — different ports, different
+# postgres volume, different uploads dir, different container names.
+# Production stack stays running on 3000/5432 while this one runs on
+# 3001/5433. Synthetic test receipts uploaded here never touch the
+# iCloud-synced production uploads dir or the production DB.
+#
+# What's SEPARATE from prod (the whole point of the sandbox):
+#   • Postgres binary: ~/Developer/receipt-assistant-data/test-postgres/
+#   • Uploads dir:     ~/Developer/receipt-assistant-data/test-uploads/
+#     ↑ both are sibling dirs — NOT in any git repo, NOT in iCloud
+#   • Container names: receipts-test-postgres, receipt-assistant-test
+#   • Ports:           3001 (backend), 5433 (postgres) on the host
+#   • No Langfuse — sandbox runs don't pollute prod traces
+#
+# What's SHARED with prod (intentional, avoids running `claude /login` twice):
+#   • Claude OAuth credentials → ~/Developer/receipt-assistant-data/claude/
+#   • Brand assets cache       → ~/Developer/receipt-assistant-data/brand-assets/
+#     (icons are content-addressable, safe to share across stacks)
+#
+# Reset script: scripts/sandbox-reset.sh — TRUNCATEs all test tables and
+# nukes test-uploads/, fast (~1s) versus a full down/up cycle.
+
+services:
+  receipts-postgres:
+    image: docker.io/postgres:17
+    container_name: receipts-test-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: receipts
+      TZ: UTC
+      PGTZ: UTC
+    ports:
+      - "5433:5432"
+    volumes:
+      - ${HOME}/Developer/receipt-assistant-data/test-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d receipts"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+
+  receipt-assistant:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: receipt-assistant:local
+    container_name: receipt-assistant-test
+    depends_on:
+      receipts-postgres:
+        condition: service_healthy
+    ports:
+      - "3001:3000"
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@receipts-postgres:5432/receipts
+      CLAUDE_CONFIG_DIR: /home/node/.claude
+      GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY:-}
+      MAX_CLAUDE_CONCURRENCY: ${MAX_CLAUDE_CONCURRENCY:-6}
+      LOGODEV_PUBLISHABLE_KEY: ${LOGODEV_PUBLISHABLE_KEY:-}
+      LOGODEV_SECRET_KEY: ${LOGODEV_SECRET_KEY:-}
+    volumes:
+      - ${HOME}/Developer/receipt-assistant-data/test-uploads:/data
+      - ${HOME}/Developer/receipt-assistant-data/claude:/home/node/.claude
+      - ${HOME}/Developer/receipt-assistant-data/brand-assets:/data/brand-assets
+    restart: unless-stopped

--- a/scripts/sandbox-reset.sh
+++ b/scripts/sandbox-reset.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# sandbox-reset.sh — wipe all test data without restarting the stack.
+#
+# Run this at the START of every frontend-test-runner session against the
+# sandbox. ~1 second versus the ~30s a full `docker compose down -v && up -d`
+# would take. The sandbox stack stays up between runs; only the data resets.
+#
+# What this clears:
+#   • All rows in transactions / receipts / batches / jobs / brand_assets /
+#     brands / merchants / products / documents (anything user-data-shaped)
+#   • Everything under ~/Developer/receipt-assistant-data/test-uploads/
+#
+# What this leaves alone:
+#   • The postgres schema (drizzle migrations stay applied)
+#   • The container itself, its env vars, the OAuth credentials mount
+#   • Brand-assets cache (icons are content-addressable, safe to keep
+#     between runs — re-fetching every run wastes Anthropic API calls)
+#
+# Usage (from anywhere; paths are absolute):
+#   ./scripts/sandbox-reset.sh                 # full reset
+#   ./scripts/sandbox-reset.sh --keep-uploads  # just truncate DB, leave files
+
+set -euo pipefail
+
+CONTAINER="${SANDBOX_PG_CONTAINER:-receipts-test-postgres}"
+UPLOADS_DIR="${SANDBOX_UPLOADS_DIR:-$HOME/Developer/receipt-assistant-data/test-uploads}"
+KEEP_UPLOADS=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --keep-uploads) KEEP_UPLOADS=1 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0"
+      exit 0
+      ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Safety check: refuse to run against the production container even if
+# someone hand-overrides SANDBOX_PG_CONTAINER. The whole point is isolation.
+if [[ "$CONTAINER" == "receipts-postgres" ]]; then
+  echo "REFUSING: container name 'receipts-postgres' looks like the production stack." >&2
+  echo "         set SANDBOX_PG_CONTAINER to the sandbox container (default: receipts-test-postgres)." >&2
+  exit 1
+fi
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+  echo "sandbox container '$CONTAINER' is not running." >&2
+  echo "bring it up first:" >&2
+  echo "  docker compose -p receipts-test -f docker-compose.test.yml up -d" >&2
+  exit 1
+fi
+
+echo "[sandbox-reset] truncating tables in ${CONTAINER}…"
+
+# TRUNCATE every user-data table. CASCADE follows FKs so order doesn't matter.
+# RESTART IDENTITY resets sequences too.
+docker exec "$CONTAINER" psql -U postgres -d receipts -v ON_ERROR_STOP=1 <<'SQL'
+DO $$
+DECLARE
+  tbl text;
+  tables text[] := ARRAY[
+    'transactions',
+    'receipts',
+    'documents',
+    'batches',
+    'jobs',
+    'brand_assets',
+    'brands',
+    'merchants',
+    'products'
+  ];
+BEGIN
+  FOREACH tbl IN ARRAY tables LOOP
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name=tbl) THEN
+      EXECUTE format('TRUNCATE TABLE public.%I RESTART IDENTITY CASCADE', tbl);
+      RAISE NOTICE 'truncated %', tbl;
+    ELSE
+      RAISE NOTICE 'skipped % (table not present)', tbl;
+    END IF;
+  END LOOP;
+END $$;
+SQL
+
+if [[ $KEEP_UPLOADS -eq 0 ]]; then
+  echo "[sandbox-reset] clearing ${UPLOADS_DIR}…"
+  if [[ -d "$UPLOADS_DIR" ]]; then
+    # Project rule: never `rm -rf`. Move contents to Trash so they're recoverable.
+    STAMP=$(date +%Y%m%d-%H%M%S)
+    TRASH_BUCKET="$HOME/.Trash/sandbox-uploads-$STAMP"
+    mkdir -p "$TRASH_BUCKET"
+    # Handle empty dir (no files to move) without erroring.
+    if compgen -G "$UPLOADS_DIR/*" >/dev/null; then
+      mv "$UPLOADS_DIR"/* "$TRASH_BUCKET/"
+    fi
+    if compgen -G "$UPLOADS_DIR/.*" >/dev/null 2>&1; then
+      find "$UPLOADS_DIR" -mindepth 1 -maxdepth 1 -name '.*' -exec mv {} "$TRASH_BUCKET/" \; 2>/dev/null || true
+    fi
+    echo "[sandbox-reset] (moved old uploads to $TRASH_BUCKET)"
+  else
+    mkdir -p "$UPLOADS_DIR"
+    echo "[sandbox-reset] (created $UPLOADS_DIR)"
+  fi
+else
+  echo "[sandbox-reset] (skipped uploads dir per --keep-uploads)"
+fi
+
+echo "[sandbox-reset] done."


### PR DESCRIPTION
## Summary

Adds a parallel Docker stack (project name `receipts-test`) that the `frontend-test-runner` skill targets for its mandatory upload-smoke section. Without this, the new "≥5 synthetic receipts per run" rule would land fake transactions in the iCloud-synced production DB on every test run.

## What's separate from prod

- **Postgres**: `receipts-test-postgres` @ host port 5433; bind-mount `~/Developer/receipt-assistant-data/test-postgres/`
- **Backend**: `receipt-assistant-test` @ host port 3001
- **Uploads**: bind-mount `~/Developer/receipt-assistant-data/test-uploads/` (sibling dir — non-iCloud, non-git)
- **No Langfuse \`include:\`** — sandbox runs don't pollute prod traces

## What's shared

- **OAuth credentials** at `~/Developer/receipt-assistant-data/claude/` — intentional, avoids running `claude /login` twice
- **Brand-assets cache** — content-addressable, safe to share

## Reset script

`scripts/sandbox-reset.sh` TRUNCATEs all user-data tables + clears `test-uploads/` in ~1s (vs ~30s for full `down/up`). Hard safety check refuses to run against the production container. Uses `mv ~/.Trash/` not `rm -rf`.

## Test plan

Smoke-tested 2026-05-16:

- [x] Sandbox stack comes up clean alongside running prod stack
- [x] Sandbox postgres applies all 20 drizzle migrations (25 tables present)
- [x] \`curl POST :3001/v1/ingest/batch\` accepts a synthetic JPEG and returns a \`batchId\`
- [x] Transaction lands in \`receipts-test-postgres.transactions\` with correct payee/date/amount (verified against ground-truth.json)
- [x] Production tx count (\`receipts-postgres\`) unchanged across two sandbox upload smoke runs
- [x] \`sandbox-reset.sh\` truncates cleanly + moves uploads to ~/.Trash/sandbox-uploads-<ts>/
- [x] Safety check refuses \`SANDBOX_PG_CONTAINER=receipts-postgres\` (exit 1)

## Related

Backend half of a two-repo change. Frontend-test-runner skill + setup skill update + gen_receipts.py fixture generator land in the outer project repo in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)