### PR TITLE
fix(ingest): force error on zero-transaction done for receipt ingests (#125)

### DIFF
--- a/src/ingest/worker.ts
+++ b/src/ingest/worker.ts
@@ -342,6 +342,39 @@ async function runOne(item: QueueItem): Promise<void> {
     return;
   }
 
+  // #125 — don't trust the agent's self-reported `done`. For a receipt
+  // classification, `done` with zero transactions is silent data loss
+  // (the user/mail-ingest skill sees success and discards the source
+  // email). The only legitimate zero-transaction `done` is the email
+  // dedup skip (error sentinel below). `unsupported` has its own
+  // status, and the L1 byte-dedup path (#124) never enters the worker.
+  const RECEIPT_KINDS = ["receipt_image", "receipt_email", "receipt_pdf"];
+  if (
+    terminal.status === "done" &&
+    terminal.classification !== null &&
+    RECEIPT_KINDS.includes(terminal.classification) &&
+    terminal.produced.transaction_ids.length === 0 &&
+    !(terminal.error ?? "").startsWith("duplicate Message-ID")
+  ) {
+    const msg =
+      "receipt classified but no transaction written — forcing error (agent self-reported done; see #125)";
+    // Not markError(): that helper wipes `produced`, and the agent may
+    // have legitimately written document_ids worth keeping for triage.
+    await db
+      .update(ingests)
+      .set({
+        status: "error",
+        error: msg,
+        completedAt: new Date(),
+      })
+      .where(
+        and(eq(ingests.id, ingestId), eq(ingests.workspaceId, workspaceId)),
+      );
+    busEmit("job.error", { batchId, ingestId, error: msg });
+    await onBatchChildTerminated(batchId, workspaceId);
+    return;
+  }
+
   if (terminal.status === "error") {
     busEmit("job.error", {
       batchId,


### PR DESCRIPTION
## Summary
Fixes #125. Backend-side guard so the worker no longer trusts the agent's self-reported `done`: for `classification ∈ {receipt_image, receipt_email, receipt_pdf}`, a terminal `done` with `transaction_ids=[]` whose `error` is not the email-dedup sentinel (`duplicate Message-ID…`) is forced to `status='error'` with message `"receipt classified but no transaction written — forcing error (agent self-reported done; see #125)"`, and `job.error` is emitted instead of `job.done`.

## Exempt zero-write terminal states (per updated issue AC)
- `unsupported` — own status, untouched.
- L1 `dedup` (#124) — born terminal in the service, never enters the worker.
- Email dedup-skip — `done` + `error` starting with `duplicate Message-ID`, untouched.

## Notes
- The forced-error UPDATE intentionally does **not** reuse `markError()` (it wipes `produced`); agent-written `document_ids` are preserved for triage.
- `startsWith('duplicate Message-ID')` rather than strict equality, tolerating minor agent suffix drift while staying narrow.
- `npm run build` clean. Post-deploy verification on the mini: re-run a normal `.eml` ingest (must still end `done` with 1 transaction) and confirm guard wiring via code-path + a forced repro if feasible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)