### PR TITLE
docs(#134): correct pHash calibration notes after production rerun

### DIFF
--- a/scripts/backfill-phash.ts
+++ b/scripts/backfill-phash.ts
@@ -110,7 +110,9 @@ async function main(): Promise<void> {
       if (d <= 24) console.log(`  ${String(d).padStart(2)}  ${hist.get(d)}`);
     }
     close.sort((a, b) => a[0] - b[0]);
-    console.log(`\n[calibrate] pairs at d ≤ 8 (expect: true dups ≤4, FPs ≥6):`);
+    console.log(
+      `\n[calibrate] pairs at d ≤ 8 (true dups ≤2; FPs from d=4, and same-app-template screenshots can FP at d=2 — fields decide, see #134):`,
+    );
     for (const [d, a, b] of close) console.log(`  d=${d}  ${a}  ${b}`);
   }
 

--- a/src/generated/build-info.ts
+++ b/src/generated/build-info.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant",
   "version": "1.0.0",
-  "gitSha": "a73ae27b22622308359f880effd39b3e1a6b978c",
-  "gitShortSha": "a73ae27",
-  "gitBranch": "feat/101-brand-assets",
-  "builtAt": "2026-05-16T08:39:38.008Z"
+  "gitSha": "b47d2b74ae75fb0c8f177b060d5cd538e1d4ad2b",
+  "gitShortSha": "b47d2b7",
+  "gitBranch": "fix/134-calibration-notes",
+  "builtAt": "2026-06-10T14:34:35.507Z"
 } as const;

--- a/src/images/phash.ts
+++ b/src/images/phash.ts
@@ -11,10 +11,19 @@
  * Re-derive thresholds with `scripts/backfill-phash.ts --calibrate`
  * after any change here.
  *
- * Calibration result (189-image production corpus): true duplicates
- * (re-shots / re-captured screenshots) at d ≤ 2, d=4 empty, false
- * positives (same composition, different receipt) from d = 6. Treat
- * d ≤ 4 as strong evidence; never auto-merge on pHash alone.
+ * Production calibration (mini corpus, 180 images, THIS implementation,
+ * 2026-06-10 — full evidence in #134):
+ *   - true duplicates (re-shots, re-captured screenshots): d ≤ 2
+ *   - false positives appear from d = 4 (two different Costco receipts,
+ *     same table/paper/framing — composition dominates the DCT)
+ *   - app-screenshot receipts collide HARD: two *different* Starbucks
+ *     purchases (different date/amount/receipt#) land at d = 2 because
+ *     the app's UI template carries all the low-frequency energy.
+ * Therefore: a pHash hit (d ≤ 2) is a CANDIDATE-SURFACING signal only —
+ * it tells the extraction agent "compare these documents' extracted
+ * fields"; the fields (date, amount, order/receipt number) are always
+ * the deciding evidence. Never attach/merge on pHash alone, at any
+ * threshold.
  */
 import sharp from "sharp";
 

--- a/src/schema/documents.ts
+++ b/src/schema/documents.ts
@@ -46,13 +46,15 @@ export const documents = pgTable(
      *  by the partial unique index below. See #122. */
     messageId: text("message_id"),
     /** 64-bit DCT perceptual hash, 16 hex chars. Image documents only;
-     *  NULL for pdf/eml and for legacy rows until backfilled
-     *  (`scripts/backfill-phash.ts`). L2 dedup evidence (#134): two
-     *  byte-different copies of the same shot/screenshot land at
-     *  hamming distance ≤ 4 (calibrated on the real corpus 2026-06-10:
-     *  true dups at d≤2, empty d=4 bucket, false positives from d=6 —
-     *  so a pHash hit is EVIDENCE for the extraction agent's near-dup
-     *  decision, never a standalone merge trigger). */
+     *  NULL for pdf/eml, undecodable files, and legacy rows until
+     *  backfilled (`scripts/backfill-phash.ts`). L2 dedup signal
+     *  (#134): byte-different copies of the same shot land at d ≤ 2 —
+     *  but so can two DIFFERENT purchases captured from the same app
+     *  UI template (production calibration 2026-06-10), and same-table
+     *  re-shots of different receipts appear from d = 4. A pHash hit
+     *  is therefore a candidate-surfacing signal for the extraction
+     *  agent's near-dup decision; extracted fields decide, never the
+     *  hash alone. */
     phash: text("phash"),
     /** Channel provenance for non-image sources, kept separate from
      *  `extraction_meta` (which records what produced the row). For


### PR DESCRIPTION
The TS-implementation rerun on the mini's 180-image corpus moved the
goalposts vs the python preview: false positives appear from d=4
(different Costco receipts, same table/framing), and app-screenshot
receipts collide at d=2 (two different Starbucks purchases — the UI
template owns the low-frequency energy). pHash is demoted from
"strong evidence at d≤4" to "candidate-surfacing signal at d≤2;
extracted fields always decide". Comments in phash.ts, the schema
column doc, and the calibrate output now state this.

Refs #134

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
