### PR TITLE
feat(#135): L3b reconcile — cross-batch weighted near-dup pass + evidence re-link before void

### DIFF
--- a/src/reconcile/dedup.ts
+++ b/src/reconcile/dedup.ts
@@ -124,3 +124,162 @@ export async function detectDuplicates(params: {
   }
   return groups;
 }
+
+// ── Near-duplicate detection across batches (#135, L3b) ────────────────
+//
+// The exact pass above only compares transactions WITHIN one batch — a
+// cross-batch duplicate (the same charge ingested weeks apart, or a
+// statement row duplicating a receipt with a settlement-date offset and
+// a processor-mangled payee string) is invisible to it. This fuzzy pass
+// compares the batch's transactions against the prior 90 days OUTSIDE
+// the batch, weighted-scores each candidate pair, and lets the engine
+// propose them. Conservative by design: the score is CAPPED below the
+// auto-apply threshold unless an order/payment identifier matches
+// exactly — same-day same-amount same-merchant can legitimately be two
+// purchases (the "two coffees" case), so cross-batch matches default to
+// human review.
+
+/** Extract a card last-4 from the agent's metadata.payment string
+ *  (e.g. "Visa ****7846 (Contactless)" / "Visa xxxxxxxx7846"). */
+function cardLast4(payment: string | null): string | null {
+  if (!payment) return null;
+  const m = payment.match(/(\d{4})(?!.*\d)/);
+  return m ? m[1]! : null;
+}
+
+export interface NearDuplicatePair {
+  /** The batch-side (newer) transaction proposed for voiding. */
+  duplicate_id: string;
+  /** The pre-existing transaction outside the batch. */
+  canonical_id: string;
+  score: number;
+  reasons: string[];
+  occurred_on: string;
+  canonical_occurred_on: string;
+  payee: string | null;
+  canonical_payee: string | null;
+  total_base_minor: number;
+}
+
+export async function detectNearDuplicates(params: {
+  workspaceId: string;
+  batchId: string;
+}): Promise<NearDuplicatePair[]> {
+  const { workspaceId, batchId } = params;
+  const res = await db.execute(sql`
+    WITH batch_txns AS (
+      SELECT t.id, t.occurred_on, t.payee, t.merchant_id, t.created_at,
+             t.metadata->>'order_number' AS order_number,
+             t.metadata->>'payment_id'   AS payment_id,
+             t.metadata->>'payment'      AS payment,
+             COALESCE(SUM(GREATEST(p.amount_base_minor, 0)), 0) AS total
+        FROM transactions t
+        JOIN postings p ON p.transaction_id = t.id
+       WHERE t.workspace_id = ${workspaceId}::uuid
+         AND t.status IN ('posted', 'reconciled')
+         AND t.source_ingest_id IN (
+           SELECT id FROM ingests WHERE batch_id = ${batchId}::uuid
+         )
+       GROUP BY t.id
+    ),
+    outside AS (
+      SELECT t.id, t.occurred_on, t.payee, t.merchant_id, t.created_at,
+             t.metadata->>'order_number' AS order_number,
+             t.metadata->>'payment_id'   AS payment_id,
+             t.metadata->>'payment'      AS payment,
+             COALESCE(SUM(GREATEST(p.amount_base_minor, 0)), 0) AS total
+        FROM transactions t
+        JOIN postings p ON p.transaction_id = t.id
+       WHERE t.workspace_id = ${workspaceId}::uuid
+         AND t.status IN ('posted', 'reconciled')
+         AND (t.source_ingest_id IS NULL OR t.source_ingest_id NOT IN (
+           SELECT id FROM ingests WHERE batch_id = ${batchId}::uuid
+         ))
+       GROUP BY t.id
+    )
+    SELECT b.id  AS b_id, b.occurred_on AS b_date, b.payee AS b_payee,
+           b.merchant_id AS b_merchant, b.order_number AS b_order,
+           b.payment_id AS b_payment_id, b.payment AS b_payment,
+           b.total AS total,
+           o.id  AS o_id, o.occurred_on AS o_date, o.payee AS o_payee,
+           o.merchant_id AS o_merchant, o.order_number AS o_order,
+           o.payment_id AS o_payment_id, o.payment AS o_payment
+      FROM batch_txns b
+      JOIN outside o
+        ON o.total = b.total
+       AND o.occurred_on BETWEEN b.occurred_on - 3 AND b.occurred_on + 3
+       AND o.occurred_on >= b.occurred_on - 90
+     WHERE b.total > 0
+     LIMIT 50
+  `);
+
+  const pairs: NearDuplicatePair[] = [];
+  for (const r of res.rows as Array<Record<string, unknown>>) {
+    const reasons: string[] = ["amount equal within ±3-day window"];
+    let score = 0.5;
+    const bDate = String(r.b_date).slice(0, 10);
+    const oDate = String(r.o_date).slice(0, 10);
+    if (bDate === oDate) {
+      score += 0.25;
+      reasons.push("same occurred_on");
+    }
+    const bPayee = (r.b_payee as string | null)?.trim().toLowerCase() ?? null;
+    const oPayee = (r.o_payee as string | null)?.trim().toLowerCase() ?? null;
+    if (
+      (bPayee && oPayee && bPayee === oPayee) ||
+      (r.b_merchant && r.b_merchant === r.o_merchant)
+    ) {
+      score += 0.15;
+      reasons.push("same payee/merchant");
+    }
+    const b4 = cardLast4(r.b_payment as string | null);
+    const o4 = cardLast4(r.o_payment as string | null);
+    if (b4 && o4) {
+      if (b4 === o4) {
+        score += 0.1;
+        reasons.push(`same card last-4 ${b4}`);
+      } else {
+        score -= 1.0;
+        reasons.push("card last-4 differs");
+      }
+    }
+    const bOrder = (r.b_order as string | null) ?? null;
+    const oOrder = (r.o_order as string | null) ?? null;
+    const bPid = (r.b_payment_id as string | null) ?? null;
+    const oPid = (r.o_payment_id as string | null) ?? null;
+    const strongIdMatch =
+      (bOrder && oOrder && bOrder === oOrder) || (bPid && oPid && bPid === oPid);
+    if (bOrder && oOrder && bOrder !== oOrder) {
+      score -= 1.0;
+      reasons.push("order numbers differ");
+    }
+    if (bPid && oPid && bPid !== oPid) {
+      score -= 1.0;
+      reasons.push("payment ids differ");
+    }
+    if (strongIdMatch) {
+      // Exact order/payment identifier — true identity, eligible for
+      // auto-apply.
+      score = 1.0;
+      reasons.push("order/payment identifier matches exactly");
+    } else {
+      // No strong identifier → cap below the auto-apply threshold so a
+      // cross-batch match is always a human-review proposal ("two
+      // coffees" false-positive class).
+      score = Math.min(score, 0.9);
+    }
+    if (score < 0.5) continue;
+    pairs.push({
+      duplicate_id: String(r.b_id),
+      canonical_id: String(r.o_id),
+      score: Math.max(0, Math.min(1, score)),
+      reasons,
+      occurred_on: bDate,
+      canonical_occurred_on: oDate,
+      payee: (r.b_payee as string | null) ?? null,
+      canonical_payee: (r.o_payee as string | null) ?? null,
+      total_base_minor: Number(r.total),
+    });
+  }
+  return pairs;
+}

--- a/src/reconcile/engine.ts
+++ b/src/reconcile/engine.ts
@@ -33,7 +33,7 @@ import { batches, reconcileProposals, transactions } from "../schema/index.js";
 import { newId } from "../http/uuid.js";
 import { NotFoundProblem } from "../http/problem.js";
 import { voidTransaction } from "../routes/transactions.service.js";
-import { detectDuplicates } from "./dedup.js";
+import { detectDuplicates, detectNearDuplicates } from "./dedup.js";
 import {
   paymentLinkStub,
   inventoryStub,
@@ -213,6 +213,19 @@ async function voidDuplicate(params: {
   if (cur.status === "voided" || cur.status === "draft" || cur.status === "error") {
     return false;
   }
+  // #135: evidence survives the void. Re-point the duplicate's
+  // document_links at the canonical transaction (keep-both model —
+  // documents are never casualties of ledger repair), then drop the
+  // now-redundant link rows so the voided mirror doesn't claim them.
+  await db.execute(sql`
+    INSERT INTO document_links (document_id, transaction_id)
+    SELECT dl.document_id, ${canonicalId}::uuid
+      FROM document_links dl
+     WHERE dl.transaction_id = ${duplicateId}::uuid
+    ON CONFLICT DO NOTHING`);
+  await db.execute(
+    sql`DELETE FROM document_links WHERE transaction_id = ${duplicateId}::uuid`,
+  );
   await voidTransaction(
     workspaceId,
     userId,
@@ -295,6 +308,34 @@ export async function runReconcile(params: {
             resolvedAt: null,
           });
         }
+      }
+
+      // ── Step 1b: cross-batch near-duplicates (#135) ────────────────
+      // Weighted fuzzy pass against the prior 90 days outside this
+      // batch. Strong order/payment-id matches score 1.0 (auto-apply);
+      // everything else is capped at 0.9 → human-review proposal.
+      const nearPairs = await detectNearDuplicates({ workspaceId, batchId });
+      for (const np of nearPairs) {
+        newProposals.push({
+          id: newId(),
+          kind: "dedup",
+          payload: {
+            duplicate: np.duplicate_id,
+            duplicate_of: np.canonical_id,
+            near: true,
+            key: {
+              occurred_on: np.occurred_on,
+              canonical_occurred_on: np.canonical_occurred_on,
+              payee: np.payee,
+              canonical_payee: np.canonical_payee,
+              total_base_minor: np.total_base_minor,
+            },
+            reasons: np.reasons,
+          },
+          score: np.score,
+          status: "proposed",
+          resolvedAt: null,
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes #135. Repair-layer counterpart of #134: (1) a cross-batch weighted near-duplicate detection pass (the exact pass only ever compared within one batch), and (2) the keep-both consequence — a voided duplicate's `document_links` are re-pointed at the canonical transaction before the void, so evidence never dies with ledger repair.

## Scoring
amount-equal within ±3 days = 0.5 base; +0.25 same date; +0.15 same payee/merchant; +0.10 same card last-4 (regex from `metadata.payment`); conflicting card/order/payment-id kills the pair. **Exact order/payment-identifier match → 1.0 (auto-apply); anything else capped at 0.9 → always human review** ("two coffees" false-positive class stays insert-and-flag, consistent with #134's tiebreaker doctrine).

## Verification
- Build clean; query shape validated against the local DB (0 rows on a no-transaction batch, as expected).
- Post-deploy on the mini: re-run reconcile over the batch containing the known leftover cross-batch pair `208fbba7`↔`b0971803` ($108.65 email↔email, flagged 2026-05-29) and confirm a `near:true` proposal is created for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)