### PR TITLE
feat(transactions): flagged=near_dup filter + near-dup-review dismiss endpoint

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3746,6 +3746,42 @@
           }
         }
       },
+      "NearDupReviewResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "flagged_for_review": {
+            "type": "boolean"
+          },
+          "reviewed_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "flagged_for_review",
+          "reviewed_at"
+        ]
+      },
+      "NearDupReviewRequest": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "dismiss"
+            ]
+          }
+        },
+        "required": [
+          "action"
+        ]
+      },
       "UnreconcileTransactionRequest": {
         "type": "object",
         "properties": {
@@ -4773,6 +4809,17 @@
             "schema": {
               "type": "string",
               "enum": [
+                "near_dup"
+              ]
+            },
+            "required": false,
+            "name": "flagged",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
                 "occurred_on",
                 "amount",
                 "created_at"
@@ -5056,6 +5103,57 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/transactions/{id}/near-dup-review": {
+      "post": {
+        "summary": "Resolve a near-duplicate review flag (#134 branch 4); v1 action: dismiss",
+        "tags": [
+          "transactions"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NearDupReviewRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Flag cleared",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NearDupReviewResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found or not flagged",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }

--- a/src/routes/transactions.service.ts
+++ b/src/routes/transactions.service.ts
@@ -694,6 +694,11 @@ export async function listTransactions(
   if (query.amount_max_minor !== undefined) {
     conditions.push(sql`EXISTS (SELECT 1 FROM postings p WHERE p.transaction_id = t.id AND ABS(p.amount_base_minor) <= ${query.amount_max_minor})`);
   }
+  if (query.flagged === "near_dup") {
+    conditions.push(
+      sql`(t.metadata->'near_dup_check'->>'flagged_for_review')::boolean IS TRUE`,
+    );
+  }
   if (query.has_document === true) {
     conditions.push(sql`EXISTS (SELECT 1 FROM document_links dl WHERE dl.transaction_id = t.id)`);
   } else if (query.has_document === false) {
@@ -1491,4 +1496,41 @@ export async function getPosting(
     );
   if (rows.length === 0) throw new NotFoundProblem("Posting", id);
   return mapPostingRow(rows[0]!);
+}
+
+/**
+ * Resolve a #134 branch-4 near-dup flag (v1: dismiss only). Clears
+ * `metadata.near_dup_check.flagged_for_review`, stamps `reviewed_at`,
+ * and appends a transaction_events row so the review is auditable.
+ * Returns null when the transaction doesn't exist or isn't flagged
+ * (idempotent dismiss of an unflagged row is a 404 — the queue is the
+ * only caller and it only shows flagged rows).
+ */
+export async function dismissNearDupFlag(
+  workspaceId: string,
+  userId: string,
+  txId: string,
+): Promise<{ id: string; flagged_for_review: boolean; reviewed_at: string } | null> {
+  const reviewedAt = new Date().toISOString();
+  const res = await db.execute(sql`
+    UPDATE transactions
+       SET metadata = jsonb_set(
+             jsonb_set(metadata, '{near_dup_check,flagged_for_review}', 'false'::jsonb),
+             '{near_dup_check,reviewed_at}', to_jsonb(${reviewedAt}::text)
+           ),
+           updated_at = NOW()
+     WHERE id = ${txId}::uuid
+       AND workspace_id = ${workspaceId}::uuid
+       AND (metadata->'near_dup_check'->>'flagged_for_review')::boolean IS TRUE
+     RETURNING id`);
+  if (res.rows.length === 0) return null;
+  await db.insert(transactionEvents).values({
+    id: newId(),
+    workspaceId,
+    transactionId: txId,
+    eventType: "near_dup_reviewed",
+    actorId: userId,
+    payload: { action: "dismiss", reviewed_at: reviewedAt },
+  });
+  return { id: txId, flagged_for_review: false, reviewed_at: reviewedAt };
 }

--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -19,6 +19,8 @@ import {
   CreateTransactionRequest,
   UpdateTransactionRequest,
   VoidTransactionRequest,
+  NearDupReviewRequest,
+  NearDupReviewResponse,
   UnreconcileTransactionRequest,
   UpdatePostingRequest,
   NewPosting,
@@ -51,6 +53,7 @@ import {
   updateTransaction,
   deleteTransaction,
   voidTransaction,
+  dismissNearDupFlag,
   reconcileTransaction,
   unreconcileTransaction,
   addPosting,
@@ -455,6 +458,29 @@ transactionsRouter.delete(
 
 // ── OpenAPI registration ───────────────────────────────────────────────
 
+transactionsRouter.post(
+  "/:id/near-dup-review",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { id } = parseOrThrow(IdParam, req.params);
+      parseOrThrow(NearDupReviewRequest, req.body ?? {});
+      // No If-Match: clearing a review flag is an idempotent, last-write-
+      // wins toggle with no payload to clobber — unlike void/reconcile,
+      // which mutate ledger state.
+      const out = await dismissNearDupFlag(
+        req.ctx.workspaceId,
+        req.ctx.userId,
+        id,
+      );
+      if (!out) throw new NotFoundProblem("Flagged transaction", id);
+      res.json(out);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+
 export function registerTransactionsOpenApi(registry: OpenAPIRegistry): void {
   registry.register("Transaction", TransactionSchema);
   registry.register("Posting", PostingSchema);
@@ -589,6 +615,26 @@ export function registerTransactionsOpenApi(registry: OpenAPIRegistry): void {
         description: "Mirror transaction created",
         content: { "application/json": { schema: TransactionSchema } },
       },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/transactions/{id}/near-dup-review",
+    summary: "Resolve a near-duplicate review flag (#134 branch 4); v1 action: dismiss",
+    tags: ["transactions"],
+    request: {
+      params: z.object({ id: Uuid }),
+      body: {
+        content: { "application/json": { schema: NearDupReviewRequest } },
+      },
+    },
+    responses: {
+      200: {
+        description: "Flag cleared",
+        content: { "application/json": { schema: NearDupReviewResponse } },
+      },
+      404: { description: "Not found or not flagged", content: problemContent },
     },
   });
 

--- a/src/schemas/v1/transaction.ts
+++ b/src/schemas/v1/transaction.ts
@@ -234,6 +234,11 @@ export const ListTransactionsQuery = z.object({
   trip_id: Uuid.optional(),
   has_document: z.coerce.boolean().optional(),
   source_ingest_id: Uuid.optional(),
+  /** flagged=near_dup → only transactions whose extraction recorded
+   *  metadata.near_dup_check.flagged_for_review=true (#134 branch 4:
+   *  a same-amount/date candidate existed but neither side had a
+   *  strong tiebreaker, so the agent inserted AND flagged). */
+  flagged: z.enum(["near_dup"]).optional(),
   sort: z.enum(["occurred_on", "amount", "created_at"]).optional(),
   order: z.enum(["asc", "desc"]).optional(),
   cursor: z.string().optional(),
@@ -272,3 +277,20 @@ export const BulkResponse = z
   .object({ results: z.array(BulkResultItem) })
   .openapi("BulkResponse");
 
+
+/** POST /v1/transactions/:id/near-dup-review — resolve a #134 branch-4
+ *  flag. v1 supports only dismiss ("I checked; they are distinct
+ *  purchases"): clears flagged_for_review and stamps reviewed_at. A
+ *  future "merge" action would attach this txn's documents to the
+ *  candidate and void — that's the reconcile apply path's job today. */
+export const NearDupReviewRequest = z
+  .object({ action: z.literal("dismiss") })
+  .openapi("NearDupReviewRequest");
+
+export const NearDupReviewResponse = z
+  .object({
+    id: Uuid,
+    flagged_for_review: z.boolean(),
+    reviewed_at: IsoDateTime,
+  })
+  .openapi("NearDupReviewResponse");


### PR DESCRIPTION
Backend half of the #134 branch-4 review surface (flags were write-only). `GET /v1/transactions?flagged=near_dup` + `POST /v1/transactions/:id/near-dup-review {action:'dismiss'}` (clears flag, stamps `reviewed_at`, audit event). Verified end-to-end by the eval-dedup harness + browser run in the follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)