### PR TITLE
fix(reconcile): near-dup canonical prefers earliest-created txn; harness r1 interleaving fix

### DIFF
--- a/scripts/eval-dedup.ts
+++ b/scripts/eval-dedup.ts
@@ -133,7 +133,13 @@ async function pollBatch(batchId: string, timeoutMs = 420_000): Promise<any> {
 function stubFile(ins: Record<string, unknown>): UploadFile {
   return {
     name: `stub-${randomUUID().slice(0, 8)}.json`,
-    bytes: Buffer.from(JSON.stringify({ __stub__: true, ...ins }, null, 1)),
+    // __salt__ keeps every stub upload byte-unique — otherwise two
+    // identical instruction files trip L1 sha-dedup and the second
+    // batch is born `dedup` without ever running the stub (observed:
+    // r1's batch B). A correct L1 behavior, wrong test vehicle.
+    bytes: Buffer.from(
+      JSON.stringify({ __stub__: true, __salt__: randomUUID(), ...ins }, null, 1),
+    ),
     mime: "application/json",
   };
 }
@@ -312,13 +318,18 @@ async function main(): Promise<void> {
     assert(links.length === 2, `expected 2 links on canonical, got ${links.length}`);
     const orphan = await q(`SELECT 1 FROM document_links WHERE transaction_id = $1`, [txB!.id]);
     assert(orphan.length === 0, "voided duplicate still owns links");
+    // The 1.0 proposal may land in EITHER batch depending on which
+    // side's fire-and-forget reconcile saw the pair first (A's can run
+    // after B's txn commits). Either way the earlier txn must survive.
     const [prop] = await q<{ score: string; status: string }>(
-      `SELECT score, status FROM reconcile_proposals WHERE batch_id = $1 AND kind='dedup'`,
-      [b.batchId],
+      `SELECT score, status FROM reconcile_proposals
+        WHERE batch_id IN ($1, $2) AND kind='dedup'
+        ORDER BY score DESC LIMIT 1`,
+      [a.batchId, b.batchId],
     );
     assert(prop && Number(prop.score) === 1 && prop.status === "auto_applied",
       `proposal: ${JSON.stringify(prop)}`);
-    notes.push(`B auto-voided @1.0; canonical holds both documents`);
+    notes.push(`later txn auto-voided @1.0; earliest survives with both documents`);
   });
 
   // r2 — card-last4 conflict kills the pair → no proposal

--- a/src/generated/build-info.ts
+++ b/src/generated/build-info.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant",
   "version": "1.0.0",
-  "gitSha": "b47d2b74ae75fb0c8f177b060d5cd538e1d4ad2b",
-  "gitShortSha": "b47d2b7",
-  "gitBranch": "fix/134-calibration-notes",
-  "builtAt": "2026-06-10T14:34:35.507Z"
+  "gitSha": "12bf57173afb07055ed00f89ecea7acf78c22b33",
+  "gitShortSha": "12bf571",
+  "gitBranch": "fix/near-dup-canonical-earliest",
+  "builtAt": "2026-06-12T01:44:43.497Z"
 } as const;

--- a/src/reconcile/dedup.ts
+++ b/src/reconcile/dedup.ts
@@ -200,10 +200,11 @@ export async function detectNearDuplicates(params: {
     SELECT b.id  AS b_id, b.occurred_on AS b_date, b.payee AS b_payee,
            b.merchant_id AS b_merchant, b.order_number AS b_order,
            b.payment_id AS b_payment_id, b.payment AS b_payment,
-           b.total AS total,
+           b.created_at AS b_created, b.total AS total,
            o.id  AS o_id, o.occurred_on AS o_date, o.payee AS o_payee,
            o.merchant_id AS o_merchant, o.order_number AS o_order,
-           o.payment_id AS o_payment_id, o.payment AS o_payment
+           o.payment_id AS o_payment_id, o.payment AS o_payment,
+           o.created_at AS o_created
       FROM batch_txns b
       JOIN outside o
         ON o.total = b.total
@@ -269,9 +270,18 @@ export async function detectNearDuplicates(params: {
       score = Math.min(score, 0.9);
     }
     if (score < 0.5) continue;
+    // Canonical = the EARLIER transaction, matching the exact pass's
+    // earliest-created_at rule. Without this, two near-simultaneous
+    // batches race: whichever batch reconciles first sees the OTHER
+    // side as "outside" and voids its own (earlier) txn — observed in
+    // the eval-dedup r1 case. Converges either way, but the survivor
+    // should be deterministic.
+    const bNewer =
+      new Date(String(r.b_created)).getTime() >=
+      new Date(String(r.o_created)).getTime();
     pairs.push({
-      duplicate_id: String(r.b_id),
-      canonical_id: String(r.o_id),
+      duplicate_id: String(bNewer ? r.b_id : r.o_id),
+      canonical_id: String(bNewer ? r.o_id : r.b_id),
       score: Math.max(0, Math.min(1, score)),
       reasons,
       occurred_on: bDate,


### PR DESCRIPTION
The cross-batch near-dup pass used pure batch-vs-outside directionality
for duplicate/canonical roles, so two near-simultaneous batches raced:
whichever side's fire-and-forget reconcile ran after both txns existed
would void its OWN (possibly earlier) transaction. Observed in the
eval-dedup r1 case — txn A (earlier) got voided, B survived. Converged
to one live txn either way, but the survivor was nondeterministic.

The pair now swaps roles when the outside txn is newer, matching the
exact pass's earliest-created_at canonical rule. Harness r1 updated to
accept the proposal landing in either batch (interleaving-dependent)
while still asserting the earliest survives with both documents.

Refs #135

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
