### PR TITLE
chore(eval-dedup): race case poll budget 10 → 20 min

### DIFF
--- a/scripts/eval-dedup.ts
+++ b/scripts/eval-dedup.ts
@@ -502,7 +502,7 @@ async function main(): Promise<void> {
       { name: "race-a.jpg", bytes: await reencode(RACE_IMAGE, 70), mime: "image/jpeg" },
       { name: "race-b.jpg", bytes: await reencode(RACE_IMAGE, 64), mime: "image/jpeg" },
     ]);
-    await pollBatch(up.batchId, 600_000);
+    await pollBatch(up.batchId, 1_200_000); // two concurrent heavy extractions + icon pipeline legitimately exceed 10 min
     const ings = await q<{ status: string }>(
       `SELECT status FROM ingests WHERE batch_id = $1`, [up.batchId]);
     const statuses = ings.map((i) => i.status).sort();


### PR DESCRIPTION
Two concurrent heavy extractions + the icon pipeline legitimately
exceed 10 minutes; the case itself passed once allowed to finish
(both agents raced past L3a transiently, then the later agent
self-corrected during close-out: deleted its own insert, attached its
document, closed near_dup — ledger converged to 1 live txn with both
documents, no void noise).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
