### PR TITLE
fix(sandbox-reset): docker exec -i — the truncate heredoc never reached psql

### DIFF
--- a/scripts/sandbox-reset.sh
+++ b/scripts/sandbox-reset.sh
@@ -56,7 +56,11 @@ echo "[sandbox-reset] truncating tables in ${CONTAINER}…"
 
 # TRUNCATE every user-data table. CASCADE follows FKs so order doesn't matter.
 # RESTART IDENTITY resets sequences too.
-docker exec "$CONTAINER" psql -U postgres -d receipts -v ON_ERROR_STOP=1 <<'SQL'
+# -i is load-bearing: without it the heredoc never reaches psql, which
+# exits 0 having truncated NOTHING — the script silently no-ops while
+# printing "done" (bit us 2026-06-11; the "clean" sandboxes that round
+# were clean only because the test pipeline ran its own TRUNCATE).
+docker exec -i "$CONTAINER" psql -U postgres -d receipts -v ON_ERROR_STOP=1 <<'SQL'
 DO $$
 DECLARE
   tbl text;


### PR DESCRIPTION
Without -i the heredoc is not piped into the container, psql exits 0
having read empty stdin, and the script prints "done" after truncating
NOTHING. It has silently no-op'd since #113 — the sandboxes that
looked clean this week were clean only because the eval pipeline ran
its own manual TRUNCATE. Verified post-fix: NOTICE lines for every
table, counts 0|0|0|0.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
