### PR TITLE
feat: product imagery — product_assets table + image endpoints + seed (#159)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ ENV DB_PATH=/data/receipts.db
 ENV UPLOAD_DIR=/data/uploads
 ENV HOME=/home/node
 
-RUN mkdir -p /data/uploads /home/node/.claude && \
+RUN mkdir -p /data/uploads /data/product-assets /home/node/.claude && \
     chown -R node:node /data /home/node /app
 
 USER node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,4 +116,11 @@ services:
       # dedup semantics on byte-equal re-fetch). On a fresh machine:
       #   mkdir -p ~/Developer/receipt-assistant-data/brand-assets
       - ${HOME}/Developer/receipt-assistant-data/brand-assets:/data/brand-assets
+      # Product image assets cache (#159). Each product_assets row's
+      # `local_path` is relative to /data/product-assets/, structure:
+      #   <product_id>/<tier>/<sha8>.<ext>
+      # SIBLING dir same rationale as brand-assets — outside git and
+      # outside iCloud. On a fresh machine:
+      #   mkdir -p ~/Developer/receipt-assistant-data/product-assets
+      - ${HOME}/Developer/receipt-assistant-data/product-assets:/data/product-assets
     restart: unless-stopped

--- a/drizzle/0030_motionless_weapon_omega.sql
+++ b/drizzle/0030_motionless_weapon_omega.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "product_assets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"product_id" uuid NOT NULL,
+	"tier" text NOT NULL,
+	"source_url" text,
+	"local_path" text NOT NULL,
+	"content_hash" text NOT NULL,
+	"content_type" text NOT NULL,
+	"width" integer,
+	"height" integer,
+	"bytes" integer,
+	"acquired_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	"agent_relevance" smallint,
+	"agent_notes" text,
+	"extraction_version" integer DEFAULT 1 NOT NULL,
+	"user_rating" smallint,
+	"user_uploaded" boolean DEFAULT false NOT NULL,
+	"user_notes" text,
+	"retired_at" timestamp with time zone,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	CONSTRAINT "product_assets_tier_ck" CHECK ("product_assets"."tier" IN ('manual_seed','user_upload','agent_fetch'))
+);
+--> statement-breakpoint
+ALTER TABLE "products" ADD COLUMN "preferred_asset_id" uuid;--> statement-breakpoint
+ALTER TABLE "products" ADD COLUMN "preferred_asset_chosen_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "product_assets" ADD CONSTRAINT "product_assets_product_id_products_id_fk" FOREIGN KEY ("product_id") REFERENCES "public"."products"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "product_assets_product_hash_uq" ON "product_assets" USING btree ("product_id","content_hash");--> statement-breakpoint
+CREATE INDEX "product_assets_product_idx" ON "product_assets" USING btree ("product_id");

--- a/drizzle/meta/0030_snapshot.json
+++ b/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,4601 @@
+{
+  "id": "cf8e1d97-d7a4-4e02-889d-c8c325ea0c41",
+  "prevId": "d618ffd6-f138-4c57-a87d-3d90e0fa29fb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_uniq": {
+          "name": "users_email_lower_uniq",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_users_id_fk": {
+          "name": "workspace_members_user_id_users_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_workspace_id_user_id_pk": {
+          "name": "workspace_members_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_owner_id_users_id_fk": {
+          "name": "workspaces_owner_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_balance_minor": {
+          "name": "opening_balance_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "accounts_workspace_idx": {
+          "name": "accounts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_parent_idx": {
+          "name": "accounts_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_workspace_type_idx": {
+          "name": "accounts_workspace_type_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_workspace_id_workspaces_id_fk": {
+          "name": "accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_parent_id_accounts_id_fk": {
+          "name": "accounts_parent_id_accounts_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narration": {
+          "name": "narration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "txn_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "voided_by_id": {
+          "name": "voided_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transactions_keyset_idx": {
+          "name": "transactions_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_created_at_keyset_idx": {
+          "name": "transactions_created_at_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_source_ingest_idx": {
+          "name": "transactions_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_trip_idx": {
+          "name": "transactions_trip_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_place_idx": {
+          "name": "transactions_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_merchant_idx": {
+          "name": "transactions_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_workspace_id_workspaces_id_fk": {
+          "name": "transactions_workspace_id_workspaces_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_voided_by_id_transactions_id_fk": {
+          "name": "transactions_voided_by_id_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "voided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_source_ingest_id_ingests_id_fk": {
+          "name": "transactions_source_ingest_id_ingests_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_place_id_places_id_fk": {
+          "name": "transactions_place_id_places_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_merchant_id_merchants_id_fk": {
+          "name": "transactions_merchant_id_merchants_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_created_by_users_id_fk": {
+          "name": "transactions_created_by_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_assets": {
+      "name": "product_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "agent_relevance": {
+          "name": "agent_relevance",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_notes": {
+          "name": "agent_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uploaded": {
+          "name": "user_uploaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "product_assets_product_hash_uq": {
+          "name": "product_assets_product_hash_uq",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_assets_product_idx": {
+          "name": "product_assets_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_assets_product_id_products_id_fk": {
+          "name": "product_assets_product_id_products_id_fk",
+          "tableFrom": "product_assets",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "product_assets_tier_ck": {
+          "name": "product_assets_tier_ck",
+          "value": "\"product_assets\".\"tier\" IN ('manual_seed','user_upload','agent_fetch')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_purchased_on": {
+          "name": "first_purchased_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_purchased_on": {
+          "name": "last_purchased_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_spent_minor": {
+          "name": "total_spent_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_from_catalog_at": {
+          "name": "retired_from_catalog_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_asset_id": {
+          "name": "preferred_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_asset_chosen_at": {
+          "name": "preferred_asset_chosen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "products_workspace_merchant_key_uq": {
+          "name": "products_workspace_merchant_key_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_class_idx": {
+          "name": "products_workspace_class_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_brand_idx": {
+          "name": "products_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_merchant_idx": {
+          "name": "products_workspace_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_workspace_id_workspaces_id_fk": {
+          "name": "products_workspace_id_workspaces_id_fk",
+          "tableFrom": "products",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "products_merchant_id_merchants_id_fk": {
+          "name": "products_merchant_id_merchants_id_fk",
+          "tableFrom": "products",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "products_brand_id_brands_brand_id_fk": {
+          "name": "products_brand_id_brands_brand_id_fk",
+          "tableFrom": "products",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "products_item_class_ck": {
+          "name": "products_item_class_ck",
+          "value": "\"products\".\"item_class\" IN ('durable','consumable','food_drink','service','other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transaction_items": {
+      "name": "transaction_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price_minor": {
+          "name": "unit_price_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_total_minor": {
+          "name": "line_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability_tier": {
+          "name": "durability_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_kind": {
+          "name": "food_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'product'"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_minor": {
+          "name": "tax_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tip_share_minor": {
+          "name": "tip_share_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_share_minor": {
+          "name": "discount_share_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_total_minor": {
+          "name": "effective_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "line_total_minor + COALESCE(tax_minor, 0) + COALESCE(tip_share_minor, 0) - COALESCE(discount_share_minor, 0)",
+            "type": "stored"
+          }
+        },
+        "extraction_run": {
+          "name": "extraction_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transaction_items_line_no_run_uq": {
+          "name": "transaction_items_line_no_run_uq",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "extraction_run",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_items_tx_idx": {
+          "name": "transaction_items_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_items_workspace_class_created_idx": {
+          "name": "transaction_items_workspace_class_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_items_workspace_id_workspaces_id_fk": {
+          "name": "transaction_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_items_transaction_id_transactions_id_fk": {
+          "name": "transaction_items_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_items_product_id_products_id_fk": {
+          "name": "transaction_items_product_id_products_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.owned_items": {
+      "name": "owned_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_item_id": {
+          "name": "transaction_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_index": {
+          "name": "instance_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_on": {
+          "name": "acquired_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warranty_until": {
+          "name": "warranty_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_days": {
+          "name": "target_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "owned_items_tx_item_instance_uq": {
+          "name": "owned_items_tx_item_instance_uq",
+          "columns": [
+            {
+              "expression": "transaction_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instance_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "owned_items_workspace_product_idx": {
+          "name": "owned_items_workspace_product_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "owned_items_workspace_id_workspaces_id_fk": {
+          "name": "owned_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "owned_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "owned_items_product_id_products_id_fk": {
+          "name": "owned_items_product_id_products_id_fk",
+          "tableFrom": "owned_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "owned_items_transaction_item_id_transaction_items_id_fk": {
+          "name": "owned_items_transaction_item_id_transaction_items_id_fk",
+          "tableFrom": "owned_items",
+          "tableTo": "transaction_items",
+          "columnsFrom": [
+            "transaction_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wish_items": {
+      "name": "wish_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_price_minor": {
+          "name": "target_price_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "planned_days": {
+          "name": "planned_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'someday'"
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "converted_transaction_id": {
+          "name": "converted_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "wish_items_workspace_status_idx": {
+          "name": "wish_items_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wish_items_workspace_id_workspaces_id_fk": {
+          "name": "wish_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "wish_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wish_items_product_id_products_id_fk": {
+          "name": "wish_items_product_id_products_id_fk",
+          "tableFrom": "wish_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wish_items_converted_transaction_id_transactions_id_fk": {
+          "name": "wish_items_converted_transaction_id_transactions_id_fk",
+          "tableFrom": "wish_items",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "converted_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights": {
+      "name": "insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "insights_workspace_dedupe_uq": {
+          "name": "insights_workspace_dedupe_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insights_workspace_active_idx": {
+          "name": "insights_workspace_active_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dismissed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_workspace_id_workspaces_id_fk": {
+          "name": "insights_workspace_id_workspaces_id_fk",
+          "tableFrom": "insights",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_parties": {
+      "name": "transaction_parties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_item_id": {
+          "name": "transaction_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transaction_parties_workspace_brand_idx": {
+          "name": "transaction_parties_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_parties_tx_idx": {
+          "name": "transaction_parties_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_parties_workspace_id_workspaces_id_fk": {
+          "name": "transaction_parties_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_parties",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_parties_transaction_id_transactions_id_fk": {
+          "name": "transaction_parties_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_parties",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_parties_transaction_item_id_transaction_items_id_fk": {
+          "name": "transaction_parties_transaction_item_id_transaction_items_id_fk",
+          "tableFrom": "transaction_parties",
+          "tableTo": "transaction_items",
+          "columnsFrom": [
+            "transaction_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transaction_parties_identity_uq": {
+          "name": "transaction_parties_identity_uq",
+          "nullsNotDistinct": true,
+          "columns": [
+            "transaction_id",
+            "transaction_item_id",
+            "role",
+            "display_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_assets": {
+      "name": "brand_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "agent_relevance": {
+          "name": "agent_relevance",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_notes": {
+          "name": "agent_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uploaded": {
+          "name": "user_uploaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "brand_assets_brand_hash_uq": {
+          "name": "brand_assets_brand_hash_uq",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brand_assets_brand_idx": {
+          "name": "brand_assets_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brand_assets_brand_tier_idx": {
+          "name": "brand_assets_brand_tier_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_assets_brand_id_brands_brand_id_fk": {
+          "name": "brand_assets_brand_id_brands_brand_id_fk",
+          "tableFrom": "brand_assets",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "brand_assets_tier_ck": {
+          "name": "brand_assets_tier_ck",
+          "value": "\"brand_assets\".\"tier\" IN ('itunes','svgl','logo_dev','simple_icons','google_play','user_upload','manual_url')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.brands": {
+      "name": "brands",
+      "schema": "",
+      "columns": {
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_asset_id": {
+          "name": "preferred_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_chose_at": {
+          "name": "user_chose_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "brands_parent_id_brands_brand_id_fk": {
+          "name": "brands_parent_id_brands_brand_id_fk",
+          "tableFrom": "brands",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.postings": {
+      "name": "postings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fx_rate": {
+          "name": "fx_rate",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_base_minor": {
+          "name": "amount_base_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "postings_transaction_idx": {
+          "name": "postings_transaction_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_account_idx": {
+          "name": "postings_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_workspace_idx": {
+          "name": "postings_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "postings_workspace_id_workspaces_id_fk": {
+          "name": "postings_workspace_id_workspaces_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_transaction_id_transactions_id_fk": {
+          "name": "postings_transaction_id_transactions_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_account_id_accounts_id_fk": {
+          "name": "postings_account_id_accounts_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_links": {
+      "name": "document_links",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "document_links_txn_idx": {
+          "name": "document_links_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_links_document_id_documents_id_fk": {
+          "name": "document_links_document_id_documents_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_links_transaction_id_transactions_id_fk": {
+          "name": "document_links_transaction_id_transactions_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_links_document_id_transaction_id_pk": {
+          "name": "document_links_document_id_transaction_id_pk",
+          "columns": [
+            "document_id",
+            "transaction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocr_text": {
+          "name": "ocr_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_model_version": {
+          "name": "ocr_model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_meta": {
+          "name": "extraction_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phash": {
+          "name": "phash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_meta": {
+          "name": "source_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "documents_workspace_sha_uniq": {
+          "name": "documents_workspace_sha_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_workspace_message_id_uniq": {
+          "name": "documents_workspace_message_id_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"documents\".\"message_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_kind_idx": {
+          "name": "documents_kind_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_source_ingest_idx": {
+          "name": "documents_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_workspace_live_idx": {
+          "name": "documents_workspace_live_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"documents\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_workspace_id_workspaces_id_fk": {
+          "name": "documents_workspace_id_workspaces_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_source_ingest_id_ingests_id_fk": {
+          "name": "documents_source_ingest_id_ingests_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_events": {
+      "name": "transaction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "txn_events_txn_idx": {
+          "name": "txn_events_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_events_workspace_id_workspaces_id_fk": {
+          "name": "transaction_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_transaction_id_transactions_id_fk": {
+          "name": "transaction_events_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_actor_id_users_id_fk": {
+          "name": "transaction_events_actor_id_users_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "idempotency_keys_uniq": {
+          "name": "idempotency_keys_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_workspace_id_workspaces_id_fk": {
+          "name": "idempotency_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reconcile": {
+          "name": "auto_reconcile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "batches_workspace_created_idx": {
+          "name": "batches_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_status_idx": {
+          "name": "batches_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batches_workspace_id_workspaces_id_fk": {
+          "name": "batches_workspace_id_workspaces_id_fk",
+          "tableFrom": "batches",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingests": {
+      "name": "ingests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ingest_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "produced": {
+          "name": "produced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingests_batch_idx": {
+          "name": "ingests_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_workspace_created_idx": {
+          "name": "ingests_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_status_idx": {
+          "name": "ingests_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingests_workspace_id_workspaces_id_fk": {
+          "name": "ingests_workspace_id_workspaces_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingests_batch_id_batches_id_fk": {
+          "name": "ingests_batch_id_batches_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconcile_proposals": {
+      "name": "reconcile_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconcile_proposals_batch_idx": {
+          "name": "reconcile_proposals_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconcile_proposals_kind_idx": {
+          "name": "reconcile_proposals_kind_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconcile_proposals_batch_id_batches_id_fk": {
+          "name": "reconcile_proposals_batch_id_batches_id_fk",
+          "tableFrom": "reconcile_proposals",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_photos": {
+      "name": "place_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_photo_name": {
+          "name": "google_photo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width_px": {
+          "name": "width_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_px": {
+          "name": "height_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_attributions": {
+          "name": "author_attributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_extracted": {
+          "name": "ocr_extracted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_reviews": {
+      "name": "place_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_review_name": {
+          "name": "google_review_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_language": {
+          "name": "text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_text": {
+          "name": "original_text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_language": {
+          "name": "original_text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relative_publish_time": {
+          "name": "relative_publish_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_time": {
+          "name": "publish_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_uri": {
+          "name": "author_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_photo_uri": {
+          "name": "author_photo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_taken_at": {
+          "name": "snapshot_taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "google_place_id": {
+          "name": "google_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_name_en": {
+          "name": "display_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh": {
+          "name": "display_name_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_locale": {
+          "name": "display_name_zh_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_source": {
+          "name": "display_name_zh_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_is_native": {
+          "name": "display_name_zh_is_native",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type_display_zh": {
+          "name": "primary_type_display_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maps_type_label_zh": {
+          "name": "maps_type_label_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "types": {
+          "name": "types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_en": {
+          "name": "formatted_address_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_zh": {
+          "name": "formatted_address_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_status": {
+          "name": "business_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_hours": {
+          "name": "business_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_rating_count": {
+          "name": "user_rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "national_phone_number": {
+          "name": "national_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_uri": {
+          "name": "website_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_maps_uri": {
+          "name": "google_maps_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_business_id": {
+          "name": "yelp_business_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_alias": {
+          "name": "yelp_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_price_level": {
+          "name": "yelp_price_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_categories": {
+          "name": "yelp_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_raw_response": {
+          "name": "yelp_raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "places_lat_lng_idx": {
+          "name": "places_lat_lng_idx",
+          "columns": [
+            {
+              "expression": "lat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lng",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "places_google_place_id_unique": {
+          "name": "places_google_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_place_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_snapshots": {
+      "name": "place_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "fetched_by_sha": {
+          "name": "fetched_by_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "place_snapshots_place_idx": {
+          "name": "place_snapshots_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "place_snapshots_place_id_places_id_fk": {
+          "name": "place_snapshots_place_id_places_id_fk",
+          "tableFrom": "place_snapshots",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merchants": {
+      "name": "merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_attribution": {
+          "name": "photo_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_status": {
+          "name": "enrichment_status",
+          "type": "merchant_enrichment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enrichment_attempted_at": {
+          "name": "enrichment_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "merchants_workspace_brand_idx": {
+          "name": "merchants_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merchants_workspace_idx": {
+          "name": "merchants_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merchants_enrichment_pending_idx": {
+          "name": "merchants_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "merchants_workspace_id_workspaces_id_fk": {
+          "name": "merchants_workspace_id_workspaces_id_fk",
+          "tableFrom": "merchants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "merchants_brand_id_brands_brand_id_fk": {
+          "name": "merchants_brand_id_brands_brand_id_fk",
+          "tableFrom": "merchants",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "merchants_brand_id_format": {
+          "name": "merchants_brand_id_format",
+          "value": "\"merchants\".\"brand_id\" ~ '^[a-z0-9-]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.derivation_events": {
+      "name": "derivation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_git_sha": {
+          "name": "prompt_git_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_keys": {
+          "name": "changed_keys",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "derivation_events_entity_idx": {
+          "name": "derivation_events_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "derivation_events_version_idx": {
+          "name": "derivation_events_version_idx",
+          "columns": [
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "derivation_events_workspace_id_workspaces_id_fk": {
+          "name": "derivation_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "derivation_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "asset",
+        "liability",
+        "equity",
+        "income",
+        "expense"
+      ]
+    },
+    "public.batch_status": {
+      "name": "batch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "extracted",
+        "reconciling",
+        "reconciled",
+        "failed",
+        "reconcile_error"
+      ]
+    },
+    "public.document_kind": {
+      "name": "document_kind",
+      "schema": "public",
+      "values": [
+        "receipt_image",
+        "receipt_email",
+        "receipt_pdf",
+        "statement_pdf",
+        "other"
+      ]
+    },
+    "public.ingest_status": {
+      "name": "ingest_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "done",
+        "error",
+        "unsupported",
+        "dedup",
+        "near_dup"
+      ]
+    },
+    "public.merchant_enrichment_status": {
+      "name": "merchant_enrichment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "not_found",
+        "failed"
+      ]
+    },
+    "public.txn_status": {
+      "name": "txn_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided",
+        "reconciled",
+        "error"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1781261983094,
       "tag": "0029_dear_wendell_vaughn",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1782289849066,
+      "tag": "0030_motionless_weapon_omega",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1405,6 +1405,20 @@
             ],
             "format": "date-time"
           },
+          "preferred_asset_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "image_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "metadata": {
             "type": "object",
             "additionalProperties": {},
@@ -1441,9 +1455,148 @@
           "custom_name",
           "notes",
           "retired_from_catalog_at",
+          "preferred_asset_id",
+          "image_url",
           "created_at",
           "updated_at"
         ]
+      },
+      "ProductAsset": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "product_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "tier": {
+            "type": "string",
+            "enum": [
+              "manual_seed",
+              "user_upload",
+              "agent_fetch"
+            ]
+          },
+          "source_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "local_path": {
+            "type": "string"
+          },
+          "content_hash": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "width": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "height": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "bytes": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "acquired_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_seen_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "agent_relevance": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "agent_notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "extraction_version": {
+            "type": "integer"
+          },
+          "user_rating": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "user_uploaded": {
+            "type": "boolean"
+          },
+          "user_notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "retired_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "default": {},
+            "description": "User-defined JSON object; not schema-validated."
+          }
+        },
+        "required": [
+          "id",
+          "product_id",
+          "tier",
+          "source_url",
+          "local_path",
+          "content_hash",
+          "content_type",
+          "width",
+          "height",
+          "bytes",
+          "acquired_at",
+          "last_seen_at",
+          "agent_relevance",
+          "agent_notes",
+          "extraction_version",
+          "user_rating",
+          "user_uploaded",
+          "user_notes",
+          "retired_at"
+        ]
+      },
+      "UploadProductAssetForm": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary"
+          }
+        }
       },
       "UpdateProductRequest": {
         "type": "object",
@@ -1480,6 +1633,14 @@
               "null"
             ],
             "format": "date-time"
+          },
+          "preferred_asset_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
           }
         }
       },
@@ -6297,6 +6458,219 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/products/{id}/image": {
+      "get": {
+        "summary": "Stream the product's preferred image bytes",
+        "description": "Resolves preferred_asset_id and streams the file. 404 when the product is missing, no asset is preferred, the asset is retired, or the file is missing on disk. Frontend falls back to a category placeholder on 404 — never to a different candidate.",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Image bytes"
+          },
+          "404": {
+            "description": "Product or image unavailable",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/products/{id}/assets": {
+      "get": {
+        "summary": "List candidate images for a product",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ProductAsset"
+                      }
+                    },
+                    "next_cursor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "next_cursor"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Upload a user-provided product image",
+        "description": "Multipart upload (field name `file`) — saves bytes to the product-assets bind-mount, inserts a product_assets row with tier=user_upload, and stamps preferred_asset_chosen_at + preferred_asset_id to the new asset (the upload IS the user's choice; Layer-3 lock). Re-uploading identical bytes returns the existing row 200 OK (UNIQUE on (product_id, content_hash)); new bytes return 201.",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadProductAssetForm"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Dedup hit — existing asset returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductAsset"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "New asset created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductAsset"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Product not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/products/{id}/assets/{assetId}/image": {
+      "get": {
+        "summary": "Stream an individual candidate asset's bytes",
+        "description": "Streams any candidate (not just preferred) so the UI picker can render thumbnails. Scoped by product_id to prevent cross-product asset_id enumeration. 404 if missing, retired, or the file is gone from disk.",
+        "tags": [
+          "products"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "assetId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Asset bytes"
           },
           "404": {
             "description": "Not Found",

--- a/scripts/seed-apple-product-images.ts
+++ b/scripts/seed-apple-product-images.ts
@@ -171,6 +171,9 @@ async function main() {
           WHERE workspace_id = ${workspaceId}::uuid
             AND brand_id = 'apple'
             AND retired_from_catalog_at IS NULL
+            AND item_class = 'durable'
+            AND canonical_name NOT ILIKE '%applecare%'
+            AND canonical_name NOT ILIKE '%service%'
             AND (${pred()})`,
     );
     const ids = (matchRows.rows as Array<{ id: string }>).map((r) => r.id);

--- a/scripts/seed-apple-product-images.ts
+++ b/scripts/seed-apple-product-images.ts
@@ -1,0 +1,273 @@
+/**
+ * #159 — seed Apple product hero images into `product_assets`.
+ *
+ * Mirrors the #101 brand-asset seeding idea, but for the product
+ * catalog. For each filename → canonical_name predicate (mapping `D`
+ * in the impl brief), this script:
+ *   1. SELECTs every live (`retired_from_catalog_at IS NULL`) product
+ *      row under `brand_id='apple'` in the target workspace matching
+ *      the predicate.
+ *   2. sha256s the source PNG, copies it to
+ *      `<root>/<product_id>/manual_seed/<sha8>.png`, and INSERTs a
+ *      `product_assets` row (tier=manual_seed) with
+ *      `ON CONFLICT (product_id, content_hash) DO UPDATE last_seen_at`.
+ *   3. UPDATEs `products.preferred_asset_id` + `preferred_asset_chosen_at`
+ *      only WHERE `preferred_asset_chosen_at IS NULL` (Layer-3 lock:
+ *      never clobbers a user/agent choice).
+ *
+ * Idempotent — re-running only bumps `last_seen_at` and leaves chosen
+ * rows alone. Prints a matched / unmatched / multi reconciliation
+ * report at the end.
+ *
+ * Resolution is by PREDICATE at run time — product UUIDs are
+ * `gen_random_uuid()` and are never hard-coded.
+ *
+ * Run (host, against a reachable DB):
+ *   DATABASE_URL=... npx tsx scripts/seed-apple-product-images.ts [workspace_id]
+ *
+ * Env:
+ *   SEED_WORKSPACE_ID    target workspace (else first positional arg,
+ *                        else the single existing workspace).
+ *   PRODUCT_IMAGE_DIR    source PNG dir (default ~/Desktop/apple_product_imgs).
+ *   PRODUCT_ASSETS_ROOT  bind-mount root (default
+ *                        ~/Developer/receipt-assistant-data/product-assets).
+ *   --dry-run            resolve + report; write nothing.
+ */
+import "dotenv/config";
+import { readFile, mkdir, writeFile, stat } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import { sql } from "drizzle-orm";
+import { db, pool } from "../src/db/client.js";
+
+const HOME = homedir();
+const IMAGE_DIR = process.env.PRODUCT_IMAGE_DIR || join(HOME, "Desktop", "apple_product_imgs");
+const ASSETS_ROOT =
+  process.env.PRODUCT_ASSETS_ROOT ||
+  join(HOME, "Developer", "receipt-assistant-data", "product-assets");
+const DRY_RUN = process.argv.includes("--dry-run");
+
+/**
+ * filename (under IMAGE_DIR, `<name>.png`) → SQL predicate fragment
+ * (applied with `canonical_name ILIKE`, ANDed with `brand_id='apple'`
+ * and `retired_from_catalog_at IS NULL`). Each `pred` is a function
+ * returning a drizzle `sql` fragment so multi-clause matches compose.
+ *
+ * Files explicitly skipped per the brief: `*_norm.png` (stale white-bg),
+ * `_GRID_*`, `_flagged_*`, `iPhone_17_Pro.png` (no DB product). Those
+ * are simply not listed here.
+ */
+const MAPPING: Array<{ file: string; pred: () => ReturnType<typeof sql> }> = [
+  { file: "AirPods_Max.png", pred: () => sql`canonical_name ILIKE '%airpods max%'` },
+  { file: "AirPods_Pro_3.png", pred: () => sql`canonical_name ILIKE '%airpods pro%'` },
+  { file: "Apple_Pencil_2.png", pred: () => sql`canonical_name ILIKE '%apple pencil%'` },
+  {
+    file: "Apple_Watch_S11.png",
+    pred: () =>
+      sql`canonical_name ILIKE '%apple watch%' AND (canonical_name ILIKE '%series 11%' OR canonical_name ILIKE '%s11%')`,
+  },
+  {
+    file: "Apple_Watch_Series_7.png",
+    pred: () => sql`canonical_name ILIKE '%apple watch%series 7%'`,
+  },
+  { file: "HomePod_mini.png", pred: () => sql`canonical_name ILIKE '%homepod mini%'` },
+  {
+    file: "HomePod.png",
+    pred: () =>
+      sql`canonical_name ILIKE '%homepod%' AND canonical_name NOT ILIKE '%mini%'`,
+  },
+  { file: "iPad_mini.png", pred: () => sql`canonical_name ILIKE '%ipad mini%'` },
+  { file: "iPad_Pro.png", pred: () => sql`canonical_name ILIKE '%ipad pro%'` },
+  { file: "iPhone_12.png", pred: () => sql`canonical_name ILIKE '%iphone 12%'` },
+  {
+    file: "iPhone_13.png",
+    pred: () =>
+      sql`canonical_name ILIKE '%iphone 13%' AND canonical_name NOT ILIKE '%pro%'`,
+  },
+  {
+    file: "iPhone_14_Pro.png",
+    pred: () =>
+      sql`canonical_name ILIKE '%iphone 14 pro%' AND canonical_name NOT ILIKE '%max%'`,
+  },
+  {
+    file: "iPhone_16_Pro_Max.png",
+    pred: () => sql`canonical_name ILIKE '%iphone 16 pro max%'`,
+  },
+  {
+    file: "iPhone_17.png",
+    pred: () =>
+      sql`canonical_name ILIKE '%iphone 17%' AND canonical_name NOT ILIKE '%pro%'`,
+  },
+  {
+    file: "iPhone_17_Pro_Max.png",
+    pred: () => sql`canonical_name ILIKE '%iphone 17 pro max%'`,
+  },
+  { file: "MacBook_Pro_14.png", pred: () => sql`canonical_name ILIKE '%macbook pro 14%'` },
+  { file: "Pro_Display_XDR.png", pred: () => sql`canonical_name ILIKE '%pro display xdr%'` },
+];
+
+async function resolveWorkspaceId(): Promise<string> {
+  const explicit =
+    process.env.SEED_WORKSPACE_ID ||
+    process.argv.slice(2).find((a) => !a.startsWith("--"));
+  if (explicit) return explicit;
+  const rows = await db.execute(sql`SELECT id FROM workspaces ORDER BY created_at ASC`);
+  const list = rows.rows as Array<{ id: string }>;
+  if (list.length === 0) {
+    throw new Error("No workspaces exist; pass SEED_WORKSPACE_ID or an arg.");
+  }
+  if (list.length > 1) {
+    console.warn(
+      `⚠️  ${list.length} workspaces exist; defaulting to the oldest (${list[0]!.id}). ` +
+        `Pass SEED_WORKSPACE_ID to target a specific one.`,
+    );
+  }
+  return list[0]!.id;
+}
+
+interface RowResult {
+  file: string;
+  matched: string[]; // product ids
+  status: "matched" | "unmatched" | "multi";
+  attached: number; // new asset rows inserted
+  refreshed: number; // existing asset rows touched
+  pointed: number; // products whose preferred_asset_id we set
+}
+
+async function main() {
+  const workspaceId = await resolveWorkspaceId();
+  console.log(`Workspace : ${workspaceId}`);
+  console.log(`Image dir : ${IMAGE_DIR}`);
+  console.log(`Asset root: ${ASSETS_ROOT}`);
+  console.log(DRY_RUN ? "Mode      : DRY RUN (no writes)\n" : "Mode      : LIVE\n");
+
+  const results: RowResult[] = [];
+
+  for (const { file, pred } of MAPPING) {
+    const srcPath = join(IMAGE_DIR, file);
+    let bytes: Buffer;
+    try {
+      bytes = await readFile(srcPath);
+    } catch {
+      console.warn(`✗ ${file}: source PNG missing at ${srcPath} — skipped`);
+      results.push({
+        file,
+        matched: [],
+        status: "unmatched",
+        attached: 0,
+        refreshed: 0,
+        pointed: 0,
+      });
+      continue;
+    }
+    const sha = createHash("sha256").update(bytes).digest("hex");
+    const sha8 = sha.slice(0, 8);
+    const relPath = `__pid__/manual_seed/${sha8}.png`; // placeholder, per-product below
+
+    // Resolve product ids by predicate (workspace + apple + live).
+    const matchRows = await db.execute(
+      sql`SELECT id FROM products
+          WHERE workspace_id = ${workspaceId}::uuid
+            AND brand_id = 'apple'
+            AND retired_from_catalog_at IS NULL
+            AND (${pred()})`,
+    );
+    const ids = (matchRows.rows as Array<{ id: string }>).map((r) => r.id);
+
+    const status: RowResult["status"] =
+      ids.length === 0 ? "unmatched" : ids.length > 1 ? "multi" : "matched";
+
+    let attached = 0;
+    let refreshed = 0;
+    let pointed = 0;
+
+    if (!DRY_RUN) {
+      for (const productId of ids) {
+        const productRel = `${productId}/manual_seed/${sha8}.png`;
+        const absPath = join(ASSETS_ROOT, productRel);
+        // Write the file (idempotent for identical bytes).
+        let alreadyOnDisk = false;
+        try {
+          await stat(absPath);
+          alreadyOnDisk = true;
+        } catch {
+          /* not present */
+        }
+        if (!alreadyOnDisk) {
+          await mkdir(dirname(absPath), { recursive: true });
+          await writeFile(absPath, bytes);
+        }
+
+        // INSERT ... ON CONFLICT (product_id, content_hash) DO UPDATE.
+        const ins = await db.execute(
+          sql`INSERT INTO product_assets
+                (product_id, tier, source_url, local_path, content_hash,
+                 content_type, bytes, metadata)
+              VALUES
+                (${productId}::uuid, 'manual_seed', NULL, ${productRel},
+                 ${sha}, 'image/png', ${bytes.length},
+                 ${sql.raw(`'${JSON.stringify({ seed_source: file })}'::jsonb`)})
+              ON CONFLICT (product_id, content_hash)
+                DO UPDATE SET last_seen_at = NOW()
+              RETURNING id, (xmax = 0) AS inserted`,
+        );
+        const row = ins.rows[0] as { id: string; inserted: boolean };
+        if (row.inserted) attached++;
+        else refreshed++;
+        const assetId = row.id;
+
+        // Point preferred at it only if the user/agent hasn't chosen.
+        const upd = await db.execute(
+          sql`UPDATE products
+              SET preferred_asset_id = ${assetId}::uuid,
+                  preferred_asset_chosen_at = NOW(),
+                  updated_at = NOW()
+              WHERE id = ${productId}::uuid
+                AND workspace_id = ${workspaceId}::uuid
+                AND preferred_asset_chosen_at IS NULL
+              RETURNING id`,
+        );
+        if (upd.rows.length > 0) pointed++;
+      }
+    }
+
+    void relPath;
+    results.push({ file, matched: ids, status, attached, refreshed, pointed });
+    const tag =
+      status === "matched" ? "✓" : status === "multi" ? "≡" : "·";
+    console.log(
+      `${tag} ${file.padEnd(26)} → ${ids.length} product(s)` +
+        (DRY_RUN
+          ? ""
+          : ` | +${attached} new, ~${refreshed} refreshed, →${pointed} preferred`),
+    );
+  }
+
+  // ── Reconciliation report ────────────────────────────────────────────
+  const matched = results.filter((r) => r.status === "matched");
+  const multi = results.filter((r) => r.status === "multi");
+  const unmatched = results.filter((r) => r.status === "unmatched");
+  const totalAttached = results.reduce((s, r) => s + r.attached, 0);
+  const totalRefreshed = results.reduce((s, r) => s + r.refreshed, 0);
+  const totalPointed = results.reduce((s, r) => s + r.pointed, 0);
+
+  console.log("\n──────────── Reconciliation ────────────");
+  console.log(`Mappings           : ${results.length}`);
+  console.log(`  matched (1 prod) : ${matched.length}`);
+  console.log(`  multi (>1 prod)  : ${multi.length}` + (multi.length ? `  [${multi.map((m) => m.file).join(", ")}]` : ""));
+  console.log(`  unmatched (0)    : ${unmatched.length}` + (unmatched.length ? `  [${unmatched.map((m) => m.file).join(", ")}]` : ""));
+  if (!DRY_RUN) {
+    console.log(`Asset rows inserted: ${totalAttached}`);
+    console.log(`Asset rows refresh : ${totalRefreshed}`);
+    console.log(`Products pointed   : ${totalPointed}`);
+  }
+  console.log("────────────────────────────────────────");
+}
+
+main()
+  .then(() => pool.end())
+  .catch((err) => {
+    console.error("❌ Seed failed:", err);
+    pool.end().finally(() => process.exit(1));
+  });

--- a/src/generated/build-info.ts
+++ b/src/generated/build-info.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant",
   "version": "1.0.0",
-  "gitSha": "12bf57173afb07055ed00f89ecea7acf78c22b33",
-  "gitShortSha": "12bf571",
-  "gitBranch": "fix/near-dup-canonical-earliest",
-  "builtAt": "2026-06-12T01:44:43.497Z"
+  "gitSha": "5851ba3634c9e42c16ab3b82219db1594c829c32",
+  "gitShortSha": "5851ba3",
+  "gitBranch": "feat/product-images",
+  "builtAt": "2026-06-24T08:34:43.031Z"
 } as const;

--- a/src/generated/build-info.ts
+++ b/src/generated/build-info.ts
@@ -1,8 +1,8 @@
 export const buildInfo = {
   "service": "receipt-assistant",
   "version": "1.0.0",
-  "gitSha": "5851ba3634c9e42c16ab3b82219db1594c829c32",
-  "gitShortSha": "5851ba3",
+  "gitSha": "26a87603cd2618dc346b131ac3978c3d80d8025e",
+  "gitShortSha": "26a8760",
   "gitBranch": "feat/product-images",
-  "builtAt": "2026-06-24T08:34:43.031Z"
+  "builtAt": "2026-06-24T08:45:51.961Z"
 } as const;

--- a/src/routes/products.ts
+++ b/src/routes/products.ts
@@ -10,10 +10,16 @@
 import express, { Router, type Request, type Response, type NextFunction } from "express";
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
-import { sql, eq, and } from "drizzle-orm";
+import { sql, eq, and, isNull } from "drizzle-orm";
+import { createReadStream } from "fs";
+import { mkdir, stat, writeFile } from "fs/promises";
+import { join, isAbsolute, dirname } from "path";
+import { createHash } from "crypto";
+import multer from "multer";
 import { db } from "../db/client.js";
 import {
   products,
+  productAssets,
   transactionItems,
   ownedItems,
   derivationEvents,
@@ -23,6 +29,8 @@ import { PROMPT_VERSION } from "../ingest/prompt.js";
 import { parseOrThrow } from "../http/validate.js";
 import {
   Product,
+  ProductAsset,
+  UploadProductAssetForm,
   UpdateProductRequest,
   ListProductsQuery,
   MergeProductRequest,
@@ -32,6 +40,7 @@ import { ProblemDetails, paginated, Uuid } from "../schemas/v1/common.js";
 import {
   HttpProblem,
   NotFoundProblem,
+  ValidationProblem,
 } from "../http/problem.js";
 import {
   clampLimit,
@@ -40,6 +49,45 @@ import {
   DEFAULT_PAGE_LIMIT,
   emitNextLink,
 } from "../http/pagination.js";
+
+// Where the bind-mount lands inside the container. Bytes are written to
+// `<PRODUCT_ASSETS_ROOT>/<product_id>/<tier>/<sha8>.<ext>` and the
+// relative path (everything after the root) is stored in
+// `product_assets.local_path`. Streaming joins root + local_path.
+const PRODUCT_ASSETS_ROOT =
+  process.env.PRODUCT_ASSETS_ROOT || "/data/product-assets";
+
+// Multer for user-uploaded product images. Memory storage so we can
+// sha256 the bytes before writing to disk (UNIQUE (product_id,
+// content_hash) catches re-uploads of the same image).
+const uploadProductAsset = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 }, // 10 MB — product photos
+});
+
+const ACCEPTED_IMAGE_MIMES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/webp",
+  "image/gif",
+]);
+
+function extensionForMime(mime: string): string {
+  switch (mime) {
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+    case "image/jpg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    default:
+      return "bin";
+  }
+}
 
 export const productsRouter: Router = Router();
 
@@ -87,9 +135,54 @@ function rowToProductDto(row: any) {
       (row.retiredFromCatalogAt ?? row.retired_from_catalog_at) === undefined
         ? null
         : toIsoString(row.retiredFromCatalogAt ?? row.retired_from_catalog_at),
+    preferred_asset_id:
+      row.preferredAssetId ?? row.preferred_asset_id ?? null,
+    image_url:
+      (row.preferredAssetId ?? row.preferred_asset_id)
+        ? `/v1/products/${row.id}/image`
+        : null,
     metadata: row.metadata ?? {},
     created_at: toIsoString(row.createdAt ?? row.created_at),
     updated_at: toIsoString(row.updatedAt ?? row.updated_at),
+  };
+}
+
+function rowToAssetDto(row: any) {
+  return {
+    id: row.id,
+    product_id: row.productId ?? row.product_id,
+    tier: row.tier,
+    source_url: row.sourceUrl ?? row.source_url ?? null,
+    local_path: row.localPath ?? row.local_path,
+    content_hash: row.contentHash ?? row.content_hash,
+    content_type: row.contentType ?? row.content_type,
+    width: row.width === null || row.width === undefined ? null : Number(row.width),
+    height:
+      row.height === null || row.height === undefined ? null : Number(row.height),
+    bytes:
+      row.bytes === null || row.bytes === undefined ? null : Number(row.bytes),
+    acquired_at: toIsoString(row.acquiredAt ?? row.acquired_at),
+    last_seen_at: toIsoString(row.lastSeenAt ?? row.last_seen_at),
+    agent_relevance:
+      (row.agentRelevance ?? row.agent_relevance) === null ||
+      (row.agentRelevance ?? row.agent_relevance) === undefined
+        ? null
+        : Number(row.agentRelevance ?? row.agent_relevance),
+    agent_notes: row.agentNotes ?? row.agent_notes ?? null,
+    extraction_version: Number(row.extractionVersion ?? row.extraction_version ?? 1),
+    user_rating:
+      (row.userRating ?? row.user_rating) === null ||
+      (row.userRating ?? row.user_rating) === undefined
+        ? null
+        : Number(row.userRating ?? row.user_rating),
+    user_uploaded: !!(row.userUploaded ?? row.user_uploaded ?? false),
+    user_notes: row.userNotes ?? row.user_notes ?? null,
+    retired_at:
+      (row.retiredAt ?? row.retired_at) === null ||
+      (row.retiredAt ?? row.retired_at) === undefined
+        ? null
+        : toIsoString(row.retiredAt ?? row.retired_at),
+    metadata: row.metadata ?? {},
   };
 }
 
@@ -202,6 +295,15 @@ productsRouter.patch(
           ? new Date(body.retired_from_catalog_at)
           : null;
       }
+      if (body.preferred_asset_id !== undefined) {
+        updates["preferredAssetId"] = body.preferred_asset_id;
+        // Setting to non-null stamps preferred_asset_chosen_at — Layer-3
+        // lock so re-seed honors the choice. Clearing (null) leaves the
+        // timestamp intact (a prior override survives an explicit reset).
+        if (body.preferred_asset_id !== null) {
+          updates["preferredAssetChosenAt"] = new Date();
+        }
+      }
       if (Object.keys(updates).length === 0) {
         throw new HttpProblem(
           400,
@@ -223,6 +325,327 @@ productsRouter.patch(
         .returning();
       if (updated.length === 0) throw new NotFoundProblem("Product", id);
       res.json(rowToProductDto(updated[0]!));
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── GET /v1/products/:id/image ─────────────────────────────────────────
+//
+// Resolves the product's preferred_asset_id and streams the bytes from
+// `${PRODUCT_ASSETS_ROOT}/<local_path>`. Returns 404 if the product is
+// missing, no asset is preferred, the asset row is retired, or the file
+// is missing on disk. The frontend falls back to a category placeholder
+// on any 404; never to a different candidate (the seed/agent already
+// picked the winner).
+
+productsRouter.get(
+  "/:id/image",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = String(req.params.id);
+      const rows = await db
+        .select({ preferredAssetId: products.preferredAssetId })
+        .from(products)
+        .where(
+          and(
+            eq(products.id, id),
+            eq(products.workspaceId, req.ctx.workspaceId),
+          ),
+        );
+      if (rows.length === 0) throw new NotFoundProblem("Product", id);
+      const preferredId = rows[0]!.preferredAssetId;
+      if (!preferredId) {
+        throw new NotFoundProblem(
+          "Product image",
+          `No preferred_asset_id for product=${id}`,
+        );
+      }
+      const assetRows = await db
+        .select({
+          localPath: productAssets.localPath,
+          contentType: productAssets.contentType,
+          contentHash: productAssets.contentHash,
+          retiredAt: productAssets.retiredAt,
+        })
+        .from(productAssets)
+        .where(
+          and(
+            eq(productAssets.id, preferredId),
+            eq(productAssets.productId, id),
+          ),
+        );
+      if (assetRows.length === 0) {
+        throw new NotFoundProblem(
+          "Product image",
+          `preferred_asset_id=${preferredId} not found for product=${id}`,
+        );
+      }
+      const asset = assetRows[0]!;
+      if (asset.retiredAt !== null) {
+        throw new NotFoundProblem(
+          "Product image",
+          `preferred_asset_id=${preferredId} is retired for product=${id}`,
+        );
+      }
+      const absPath = isAbsolute(asset.localPath)
+        ? asset.localPath
+        : join(PRODUCT_ASSETS_ROOT, asset.localPath);
+      try {
+        const st = await stat(absPath);
+        if (!st.isFile()) throw new Error("not a file");
+      } catch {
+        throw new NotFoundProblem(
+          "Product image",
+          `File missing on disk: ${absPath}`,
+        );
+      }
+      // Strong ETag is the asset's content_hash. The URL stays stable
+      // (`/products/<id>/image`) while the underlying bytes flip whenever
+      // the user re-picks `preferred_asset_id` — so `immutable` would be
+      // wrong. `max-age=0, must-revalidate` makes every request a
+      // conditional GET; the 304 path is cheap.
+      const etag = `"${asset.contentHash}"`;
+      res.setHeader("ETag", etag);
+      res.setHeader("Cache-Control", "public, max-age=0, must-revalidate");
+      if (req.headers["if-none-match"] === etag) {
+        res.status(304).end();
+        return;
+      }
+      res.setHeader("Content-Type", asset.contentType);
+      createReadStream(absPath).pipe(res);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── GET /v1/products/:id/assets ────────────────────────────────────────
+
+productsRouter.get(
+  "/:id/assets",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = String(req.params.id);
+      const exists = await db
+        .select({ id: products.id })
+        .from(products)
+        .where(
+          and(
+            eq(products.id, id),
+            eq(products.workspaceId, req.ctx.workspaceId),
+          ),
+        );
+      if (exists.length === 0) throw new NotFoundProblem("Product", id);
+      const rows = await db
+        .select()
+        .from(productAssets)
+        .where(
+          and(
+            eq(productAssets.productId, id),
+            isNull(productAssets.retiredAt),
+          ),
+        );
+      res.json({
+        items: rows.map(rowToAssetDto),
+        next_cursor: null,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── POST /v1/products/:id/assets ───────────────────────────────────────
+//
+// User uploads a product image (multipart/form-data, field name `file`).
+// The upload IS the user's choice — we auto-set preferred_asset_id and
+// stamp preferred_asset_chosen_at so re-seed honors it (Layer-3 lock).
+//
+// Dedup via UNIQUE (product_id, content_hash). Re-uploading the same
+// bytes returns the existing row 200 OK; new bytes 201 Created. Bytes
+// are stored at
+// `${PRODUCT_ASSETS_ROOT}/<product_id>/user_upload/<sha>.<ext>`.
+
+productsRouter.post(
+  "/:id/assets",
+  uploadProductAsset.single("file"),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = String(req.params.id);
+      const file = req.file;
+      if (!file) {
+        throw new ValidationProblem([
+          { path: "file", code: "required", message: "multipart field `file` is required" },
+        ]);
+      }
+      const mime = (file.mimetype || "application/octet-stream").toLowerCase();
+      if (!ACCEPTED_IMAGE_MIMES.has(mime)) {
+        throw new ValidationProblem([
+          {
+            path: "file",
+            code: "unsupported_mime",
+            message: `Unsupported image MIME type "${mime}". Accepted: ${Array.from(ACCEPTED_IMAGE_MIMES).join(", ")}`,
+          },
+        ]);
+      }
+      const productRows = await db
+        .select({ id: products.id })
+        .from(products)
+        .where(
+          and(
+            eq(products.id, id),
+            eq(products.workspaceId, req.ctx.workspaceId),
+          ),
+        );
+      if (productRows.length === 0) throw new NotFoundProblem("Product", id);
+
+      const bytes = file.buffer;
+      const sha = createHash("sha256").update(bytes).digest("hex");
+      const ext = extensionForMime(mime);
+      const relPath = `${id}/user_upload/${sha.slice(0, 8)}.${ext}`;
+      const absPath = join(PRODUCT_ASSETS_ROOT, relPath);
+
+      const existing = await db
+        .select()
+        .from(productAssets)
+        .where(
+          and(
+            eq(productAssets.productId, id),
+            eq(productAssets.contentHash, sha),
+          ),
+        );
+
+      let assetId: string;
+      let created: boolean;
+      if (existing.length > 0) {
+        const row = existing[0]!;
+        if (row.retiredAt !== null) {
+          await db
+            .update(productAssets)
+            .set({ retiredAt: null, lastSeenAt: new Date() })
+            .where(eq(productAssets.id, row.id));
+        } else {
+          await db
+            .update(productAssets)
+            .set({ lastSeenAt: new Date() })
+            .where(eq(productAssets.id, row.id));
+        }
+        assetId = row.id;
+        created = false;
+      } else {
+        await mkdir(dirname(absPath), { recursive: true });
+        await writeFile(absPath, bytes);
+        const inserted = await db
+          .insert(productAssets)
+          .values({
+            productId: id,
+            tier: "user_upload",
+            sourceUrl: null,
+            localPath: relPath,
+            contentHash: sha,
+            contentType: mime,
+            bytes: bytes.length,
+            userUploaded: true,
+          })
+          .returning({ id: productAssets.id });
+        assetId = inserted[0]!.id;
+        created = true;
+      }
+
+      // Layer-3 user-truth: stamp preferred_asset_chosen_at + point
+      // preferred at the uploaded asset.
+      await db
+        .update(products)
+        .set({
+          preferredAssetId: assetId,
+          preferredAssetChosenAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(products.id, id),
+            eq(products.workspaceId, req.ctx.workspaceId),
+          ),
+        );
+
+      const finalRows = await db
+        .select()
+        .from(productAssets)
+        .where(eq(productAssets.id, assetId));
+      res.status(created ? 201 : 200).json(rowToAssetDto(finalRows[0]!));
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ── GET /v1/products/:id/assets/:assetId/image ─────────────────────────
+//
+// Streams the bytes of an arbitrary candidate (NOT just the preferred
+// one). Powers the product-detail picker UI so the user can visually
+// compare candidates. Scoped by product_id so an asset_id can't be
+// enumerated across products.
+
+productsRouter.get(
+  "/:id/assets/:assetId/image",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = String(req.params.id);
+      const assetId = String(req.params.assetId);
+      // Scope the product to the workspace first.
+      const exists = await db
+        .select({ id: products.id })
+        .from(products)
+        .where(
+          and(
+            eq(products.id, id),
+            eq(products.workspaceId, req.ctx.workspaceId),
+          ),
+        );
+      if (exists.length === 0) throw new NotFoundProblem("Product", id);
+      const rows = await db
+        .select({
+          localPath: productAssets.localPath,
+          contentType: productAssets.contentType,
+          retiredAt: productAssets.retiredAt,
+        })
+        .from(productAssets)
+        .where(
+          and(
+            eq(productAssets.id, assetId),
+            eq(productAssets.productId, id),
+          ),
+        );
+      if (rows.length === 0) {
+        throw new NotFoundProblem(
+          "Product asset",
+          `asset_id=${assetId} not found under product=${id}`,
+        );
+      }
+      const asset = rows[0]!;
+      if (asset.retiredAt !== null) {
+        throw new NotFoundProblem(
+          "Product asset",
+          `asset_id=${assetId} is retired`,
+        );
+      }
+      const absPath = isAbsolute(asset.localPath)
+        ? asset.localPath
+        : join(PRODUCT_ASSETS_ROOT, asset.localPath);
+      try {
+        const st = await stat(absPath);
+        if (!st.isFile()) throw new Error("not a file");
+      } catch {
+        throw new NotFoundProblem(
+          "Product asset",
+          `File missing on disk: ${absPath}`,
+        );
+      }
+      res.setHeader("Content-Type", asset.contentType);
+      res.setHeader("Cache-Control", "public, max-age=86400, immutable");
+      createReadStream(absPath).pipe(res);
     } catch (err) {
       next(err);
     }
@@ -507,6 +930,8 @@ productsRouter.post(
 
 export function registerProductsOpenApi(registry: OpenAPIRegistry): void {
   registry.register("Product", Product);
+  registry.register("ProductAsset", ProductAsset);
+  registry.register("UploadProductAssetForm", UploadProductAssetForm);
   registry.register("UpdateProductRequest", UpdateProductRequest);
   registry.register("MergeProductRequest", MergeProductRequest);
   registry.register("MergeProductResponse", MergeProductResponse);
@@ -563,6 +988,88 @@ export function registerProductsOpenApi(registry: OpenAPIRegistry): void {
         description: "OK",
         content: { "application/json": { schema: Product } },
       },
+      404: { description: "Not Found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/products/{id}/image",
+    summary: "Stream the product's preferred image bytes",
+    description:
+      "Resolves preferred_asset_id and streams the file. 404 when the product is missing, no asset is preferred, the asset is retired, or the file is missing on disk. Frontend falls back to a category placeholder on 404 — never to a different candidate.",
+    tags: ["products"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: { description: "Image bytes" },
+      404: { description: "Product or image unavailable", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/products/{id}/assets",
+    summary: "List candidate images for a product",
+    tags: ["products"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      200: {
+        description: "OK",
+        content: {
+          "application/json": {
+            schema: z.object({
+              items: z.array(ProductAsset),
+              next_cursor: z.string().nullable(),
+            }),
+          },
+        },
+      },
+      404: { description: "Not Found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/products/{id}/assets",
+    summary: "Upload a user-provided product image",
+    description:
+      "Multipart upload (field name `file`) — saves bytes to the product-assets bind-mount, inserts a product_assets row with tier=user_upload, and stamps preferred_asset_chosen_at + preferred_asset_id to the new asset (the upload IS the user's choice; Layer-3 lock). Re-uploading identical bytes returns the existing row 200 OK (UNIQUE on (product_id, content_hash)); new bytes return 201.",
+    tags: ["products"],
+    request: {
+      params: z.object({ id: Uuid }),
+      body: {
+        required: true,
+        content: {
+          "multipart/form-data": { schema: UploadProductAssetForm },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Dedup hit — existing asset returned",
+        content: { "application/json": { schema: ProductAsset } },
+      },
+      201: {
+        description: "New asset created",
+        content: { "application/json": { schema: ProductAsset } },
+      },
+      404: { description: "Product not found", content: problemContent },
+      422: { description: "Validation failed", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/products/{id}/assets/{assetId}/image",
+    summary: "Stream an individual candidate asset's bytes",
+    description:
+      "Streams any candidate (not just preferred) so the UI picker can render thumbnails. Scoped by product_id to prevent cross-product asset_id enumeration. 404 if missing, retired, or the file is gone from disk.",
+    tags: ["products"],
+    request: {
+      params: z.object({ id: Uuid, assetId: Uuid }),
+    },
+    responses: {
+      200: { description: "Asset bytes" },
       404: { description: "Not Found", content: problemContent },
     },
   });

--- a/src/schema/products.ts
+++ b/src/schema/products.ts
@@ -23,12 +23,15 @@ import {
   text,
   integer,
   bigint,
+  smallint,
+  boolean,
   date,
   timestamp,
   jsonb,
   index,
   uniqueIndex,
   check,
+  type AnyPgColumn,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { workspaces } from "./workspaces.js";
@@ -81,6 +84,16 @@ export const products = pgTable(
       withTimezone: true,
     }),
 
+    // Product imagery (#159, mirrors the #101 brand-asset pattern).
+    // `productAssets` retains every candidate; the chosen one is pointed
+    // at here. NULL preferred → frontend renders a category fallback.
+    preferredAssetId: uuid("preferred_asset_id"),
+    /** Layer-3 lock — when NOT NULL, re-extract / re-seed leaves
+     *  `preferred_asset_id` alone (a choice has been made). */
+    preferredAssetChosenAt: timestamp("preferred_asset_chosen_at", {
+      withTimezone: true,
+    }),
+
     metadata: jsonb("metadata").notNull().default({}),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
@@ -105,6 +118,66 @@ export const products = pgTable(
     check(
       "products_item_class_ck",
       sql`${t.itemClass} IN ('durable','consumable','food_drink','service','other')`,
+    ),
+  ],
+);
+
+/**
+ * #159 — multi-candidate product imagery, mirroring `brand_assets`
+ * (#101). Each row is one product hero/photo candidate. `tier` is
+ * provenance ("where this image came from"), NOT priority. The render
+ * path does NOT consult tier; it reads `products.preferred_asset_id`.
+ *
+ * Layer separation:
+ *   - raw      : local_path, source_url, tier, content_hash, dimensions
+ *   - derived  : agent_relevance, agent_notes, extraction_version
+ *   - user     : user_rating, user_uploaded, user_notes
+ */
+export const productAssets = pgTable(
+  "product_assets",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    productId: uuid("product_id")
+      .notNull()
+      .references((): AnyPgColumn => products.id, { onDelete: "cascade" }),
+    tier: text("tier").notNull(),
+    sourceUrl: text("source_url"),
+    /** Path under `~/Developer/receipt-assistant-data/product-assets/`,
+     *  bind-mounted into the container at `/data/product-assets`. */
+    localPath: text("local_path").notNull(),
+    /** Content-addressable dedup key. */
+    contentHash: text("content_hash").notNull(),
+    contentType: text("content_type").notNull(),
+    width: integer("width"),
+    height: integer("height"),
+    bytes: integer("bytes"),
+    acquiredAt: timestamp("acquired_at", { withTimezone: true })
+      .notNull()
+      .default(sql`NOW()`),
+    /** Bumped on byte-equal re-acquisition. */
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true })
+      .notNull()
+      .default(sql`NOW()`),
+
+    // Derived layer.
+    agentRelevance: smallint("agent_relevance"),
+    agentNotes: text("agent_notes"),
+    extractionVersion: integer("extraction_version").notNull().default(1),
+
+    // User-truth layer.
+    userRating: smallint("user_rating"),
+    userUploaded: boolean("user_uploaded").notNull().default(false),
+    userNotes: text("user_notes"),
+
+    retiredAt: timestamp("retired_at", { withTimezone: true }),
+    metadata: jsonb("metadata").notNull().default({}),
+  },
+  (t) => [
+    uniqueIndex("product_assets_product_hash_uq").on(t.productId, t.contentHash),
+    index("product_assets_product_idx").on(t.productId),
+    check(
+      "product_assets_tier_ck",
+      sql`${t.tier} IN ('manual_seed','user_upload','agent_fetch')`,
     ),
   ],
 );

--- a/src/schemas/v1/product.ts
+++ b/src/schemas/v1/product.ts
@@ -14,6 +14,53 @@ export const ProductItemClass = z.enum([
   "other",
 ]);
 
+export const ProductAssetTier = z.enum([
+  "manual_seed",
+  "user_upload",
+  "agent_fetch",
+]);
+
+/**
+ * Multipart form for `POST /v1/products/:id/assets`. Zod can't fully
+ * model multipart bodies; this exists so the OpenAPI doc reflects the
+ * expected field shape. The actual parsing is done by multer.
+ */
+export const UploadProductAssetForm = z
+  .object({
+    file: z.any().openapi({ type: "string", format: "binary" }),
+  })
+  .openapi("UploadProductAssetForm");
+
+/**
+ * One product image candidate (#159, mirrors BrandAsset). The chosen
+ * one is pointed at by `products.preferred_asset_id`. `tier` is
+ * provenance, not priority.
+ */
+export const ProductAsset = z
+  .object({
+    id: Uuid,
+    product_id: Uuid,
+    tier: ProductAssetTier,
+    source_url: z.string().nullable(),
+    local_path: z.string(),
+    content_hash: z.string(),
+    content_type: z.string(),
+    width: z.number().int().nullable(),
+    height: z.number().int().nullable(),
+    bytes: z.number().int().nullable(),
+    acquired_at: IsoDateTime,
+    last_seen_at: IsoDateTime,
+    agent_relevance: z.number().int().nullable(),
+    agent_notes: z.string().nullable(),
+    extraction_version: z.number().int(),
+    user_rating: z.number().int().nullable(),
+    user_uploaded: z.boolean(),
+    user_notes: z.string().nullable(),
+    retired_at: IsoDateTime.nullable(),
+    metadata: Metadata,
+  })
+  .openapi("ProductAsset");
+
 export const Product = z
   .object({
     id: Uuid,
@@ -44,6 +91,12 @@ export const Product = z
     notes: z.string().nullable(),
     retired_from_catalog_at: IsoDateTime.nullable(),
 
+    /** Currently-preferred image asset id (#159). NULL → no image. */
+    preferred_asset_id: Uuid.nullable(),
+    /** Computed URL: `null` when `preferred_asset_id` is null, else
+     *  `/v1/products/:id/image` (the resolved-image endpoint). */
+    image_url: z.string().nullable(),
+
     metadata: Metadata,
     created_at: IsoDateTime,
     updated_at: IsoDateTime,
@@ -62,6 +115,9 @@ export const UpdateProductRequest = z
     merchant_id: Uuid.nullable().optional(),
     /** Soft-archive the row. */
     retired_from_catalog_at: IsoDateTime.nullable().optional(),
+    /** Layer-3 preferred image override (#159). Setting non-null stamps
+     *  `preferred_asset_chosen_at=now()` so re-seed honors the choice. */
+    preferred_asset_id: Uuid.nullable().optional(),
   })
   .openapi("UpdateProductRequest");
 


### PR DESCRIPTION
## Summary
Backend slice of product imagery (#159). Mirrors the #101 brand-asset architecture verbatim for the product catalog: a multi-candidate `product_assets` table plus a `products.preferred_asset_id` pointer, stream/upload/list endpoints, and a predicate-resolved seed script for the Apple hero shots.

## Changes
- **Schema** (`src/schema/products.ts`): add `preferred_asset_id` (uuid, nullable) + `preferred_asset_chosen_at` (timestamptz) to `products`; new `product_assets` table — FK `product_id → products.id ON DELETE CASCADE`, `UNIQUE (product_id, content_hash)`, index on `product_id`, `tier CHECK IN ('manual_seed','user_upload','agent_fetch')`, raw/derived/user layer columns matching `brand_assets`.
- **Migration**: `drizzle/0030_motionless_weapon_omega.sql` — `CREATE TABLE product_assets` + `ALTER products ADD` the two columns. Applied to the local `receipts-postgres`.
- **Routes** (`src/routes/products.ts`):
  - `GET /v1/products/:id/image` — resolves preferred → streams bytes, strong ETag (content_hash) + conditional 304, 404 on missing/null/retired/file-absent.
  - `GET /v1/products/:id/assets` — list live candidates.
  - `POST /v1/products/:id/assets` — multipart upload; writes `<root>/<product_id>/user_upload/<sha8>.<ext>`, inserts row, stamps `preferred_asset_id` + `preferred_asset_chosen_at` (the upload IS the choice). Dedup via `UNIQUE` → 200 on identical bytes, 201 on new.
  - `GET /v1/products/:id/assets/:assetId/image` — stream an arbitrary candidate (picker UI), scoped by product_id.
  - `PATCH /v1/products/:id` now accepts `preferred_asset_id` (Layer-3 lock).
  - `image_url` added to product responses (`preferred_asset_id ? "/v1/products/${id}/image" : null`).
- **Zod** (`src/schemas/v1/product.ts`): `ProductAsset`, `ProductAssetTier`, `UploadProductAssetForm`, `Product.{preferred_asset_id,image_url}`, `UpdateProductRequest.preferred_asset_id`.
- **OpenAPI**: regenerated code-first (`71 paths, 106 schemas`).
- **Storage**: `docker-compose.yml` adds the `product-assets` bind-mount after `brand-assets`; `Dockerfile` mkdir adds `/data/product-assets`.
- **Seed** (`scripts/seed-apple-product-images.ts`): for each filename→`canonical_name ILIKE` predicate, resolves live `brand_id='apple'` product UUIDs at run time (never hard-coded), sha256s the PNG, copies to `<product_id>/manual_seed/<sha8>.png`, `INSERT ... ON CONFLICT (product_id, content_hash) DO UPDATE last_seen_at`, points `preferred_asset_id` only where `preferred_asset_chosen_at IS NULL`. Idempotent; prints a matched/multi/unmatched reconciliation report. Ignores `*_norm`/`_GRID_*`/`_flagged_*`/`iPhone_17_Pro.png`.

## Verification
- `npm run build` (tsc) — passes.
- `npm run openapi:generate` — clean; all four new paths + `ProductAsset` schema present.
- Migration applied to local `receipts-postgres`; `\d product_assets` confirms columns/indexes/check/FK.
- Seed smoke-tested against the local DB (only `iPad mini` products exist there): run 1 inserted 2 assets + pointed 2 products; **run 2 inserted 0, refreshed 2, re-pointed 0** — confirms idempotency and the `preferred_asset_chosen_at` Layer-3 lock.

## Notes
- Full Apple-catalog seeding is a no-op-until-data step: the dev DB only has iPad mini rows, so most mappings report unmatched here. The script is data-driven and will attach hero shots as the catalog fills.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)