### PR TITLE
fix(ops): tsx-free prod migrate entry + docs (db:migrate:prod)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,6 +361,19 @@ Re-running re-extract on the same document with the same `REEXTRACT_PROMPT_VERSI
    confidence on a result where it missed the date entirely.
    Don't use confidence_score as sole quality gate.
 
+4. **`npm run db:migrate` fails in the prod runtime image — `tsx` is
+   dev-only.** That script runs `tsx scripts/migrate.ts`, but the
+   production image installs prod deps only, so `tsx` is absent
+   (`tsx: not found`). To apply migrations manually inside the
+   container, use the **compiled, tsx-free** entry:
+   `docker exec receipt-assistant npm run db:migrate:prod`
+   (= `node dist/db/migrate.js`). `src/db/migrate.ts` has a main-guard
+   so the same compiled file both *exports* `runMigrations()` (used by
+   `server.ts` at boot) and *runs* migrations when executed directly.
+   Idempotent — re-applying already-applied migrations is a no-op.
+   (Server boot auto-migrates anyway; this is for manual mid-deploy
+   application, as in #159.)
+
 ## Schema editing workflow (OpenAPI contract)
 
 The HTTP API contract lives in `src/schemas/` (one zod file per resource: `receipt.ts`, `job.ts`, `summary.ts`, `ask.ts`, `health.ts`, `common.ts`). Routes are registered in `src/openapi.ts`. The generated `openapi/openapi.json` is a build artifact — **never edit it by hand**, it gets overwritten.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx scripts/migrate.ts",
+    "db:migrate:prod": "node dist/db/migrate.js",
     "db:seed": "tsx scripts/seed.ts",
     "openapi:generate": "tsx scripts/generate-openapi.ts",
     "eval:dates": "tsx scripts/eval-dates.ts"

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -5,6 +5,13 @@
  *   - `src/server.ts` at container boot (production path).
  *   - `scripts/migrate.ts` as a standalone CLI (dev path, via tsx).
  *
+ * Also runnable as a standalone script — `node dist/db/migrate.js` — via the
+ * main-guard at the bottom. This is the prod-safe, tsx-free migrate path
+ * (`npm run db:migrate:prod`): tsx is a dev dependency and is absent from the
+ * production runtime image, so `npm run db:migrate` (which uses tsx) fails
+ * there. The compiled file works both as an import (no side effects) and as a
+ * direct entry point.
+ *
  * `migrationsFolder` resolves relative to the compiled file location.
  * In dev   : <repo>/src/db/migrate.ts → <repo>/drizzle
  * In prod  : <repo>/dist/db/migrate.js → <repo>/drizzle
@@ -14,7 +21,7 @@ import pg from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 import path from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const MIGRATIONS_FOLDER = path.resolve(__dirname, "..", "..", "drizzle");
@@ -32,4 +39,20 @@ export async function runMigrations(databaseUrl?: string): Promise<void> {
   } finally {
     await pool.end();
   }
+}
+
+// Main-guard: when this file is executed directly (`node dist/db/migrate.js`,
+// i.e. `npm run db:migrate:prod`) apply migrations and exit. Fires only on
+// direct execution, never on import (server boot / scripts/migrate.ts), so the
+// same compiled artifact serves both roles. This is the tsx-free prod path.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runMigrations()
+    .then(() => {
+      console.log("✅ Migrations complete");
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error("❌ Migration failed:", err);
+      process.exit(1);
+    });
 }


### PR DESCRIPTION
## Summary
`npm run db:migrate` runs `tsx scripts/migrate.ts`, but `tsx` is a **dev dependency** and is absent from the production runtime image — so applying migrations inside the prod container fails with `tsx: not found`. During the #159 deploy this was worked around by running the compiled migrator (`node /app/dist/db/migrate.js`) ad hoc. This PR makes that a first-class, documented path.

## Changes
- **Main-guard in `src/db/migrate.ts`**: the compiled file now both *exports* `runMigrations()` (used by `server.ts` at boot and by `scripts/migrate.ts`) and *applies* migrations when executed directly (`node dist/db/migrate.js`). Guard fires only on direct execution, never on import.
- **New script** `db:migrate:prod` → `node dist/db/migrate.js` (tsx-free).
- **Docs**: `CLAUDE.md` Known Pitfalls #4 + the `setup` skill's deploy step both note that the prod container migrates via `docker exec receipt-assistant npm run db:migrate:prod`, **not** `npm run db:migrate`.

## Verification
- `npm run build` passes.
- Ran the freshly-built compiled migrator inside the **actual prod container** (`tsx` confirmed absent) against the real app DB: `✅ Migrations complete`, exit 0. Idempotent — re-applying already-applied migrations is a no-op.

## Impact
Non-behavioral: server-boot auto-migration is unchanged; this only adds a manual, tsx-free path for mid-deploy migration. No redeploy required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)