### PR TITLE
fix: render text/html receipt documents in the Original receipt fold (#137)

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -666,6 +666,12 @@
           "kind": {
             "type": "string"
           },
+          "mime_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "source_meta": {
             "type": [
               "object",
@@ -8330,7 +8336,7 @@
     },
     "/v1/documents/{id}/rendered": {
       "get": {
-        "summary": "Decoded + sanitized HTML body of a receipt_email document, for the frontend 'Original email' fold. Served with a strict CSP; render inside a sandboxed iframe.",
+        "summary": "Sanitized HTML rendering of a document for the frontend's 'Original receipt / email' fold: a decoded receipt_email (.eml) body or a sanitized raw text/html document (#137). Served with a strict CSP; render inside a sandboxed iframe.",
         "tags": [
           "documents"
         ],
@@ -8348,7 +8354,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Sanitized email HTML",
+            "description": "Sanitized HTML (email body or text/html document)",
             "content": {
               "text/html": {
                 "schema": {
@@ -8358,7 +8364,7 @@
             }
           },
           "404": {
-            "description": "Not found / no file",
+            "description": "Not found / no file / empty render",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -8368,7 +8374,7 @@
             }
           },
           "422": {
-            "description": "Document is not an email (kind != receipt_email)",
+            "description": "Document has no HTML rendering (neither receipt_email nor text/html); code document-not-renderable",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/src/routes/documents.service.ts
+++ b/src/routes/documents.service.ts
@@ -293,23 +293,39 @@ const EMAIL_SANITIZE: sanitizeHtml.IOptions = {
 };
 
 /**
- * Decode + sanitize the HTML body of a receipt_email document.
- * Returns null when the document is missing/soft-deleted or its `.eml`
- * file is unreadable (→ 404). Throws 422 for non-email documents.
+ * Decode + sanitize an HTML rendering of a document for the detail
+ * page's "Original receipt / email" fold. Two renderable sources (#137):
+ *   - `.eml` email (`kind = receipt_email`) → RFC822-decode, take the
+ *     HTML (or text-as-HTML) body.
+ *   - raw `text/html` file (`mime_type = text/html`) → sanitize the file
+ *     bytes directly; there is no envelope to decode.
+ * Both pass through the same `EMAIL_SANITIZE` allowlist (drops <script>,
+ * event handlers, etc.), so together with the route's strict CSP and the
+ * frontend's sandboxed iframe the untrusted markup has three independent
+ * containment layers.
+ * Returns null when the document is missing/soft-deleted or its file is
+ * unreadable (→ 404). Throws 422 for a document that is neither source.
  */
-export async function renderEmailDocument(
+export async function renderDocumentHtml(
   workspaceId: string,
   id: string,
 ): Promise<string | null> {
   const doc = await getDocumentById(workspaceId, id);
   if (!doc) return null;
-  if (doc.kind !== "receipt_email") {
+  const isEmail = doc.kind === "receipt_email";
+  // Normalize the stored mime: strip the charset param and lowercase, so
+  // `text/html; charset=utf-8` and case variants still route here. Accept
+  // application/xhtml+xml too — otherwise an HTML-by-extension doc with a
+  // near-miss mime would fall to the non-sandboxed /content viewer. #137.
+  const baseMime = (doc.mime_type ?? "").split(";")[0]!.trim().toLowerCase();
+  const isHtml = baseMime === "text/html" || baseMime === "application/xhtml+xml";
+  if (!isEmail && !isHtml) {
     throw new HttpProblem(
       422,
-      "document-not-email",
-      "Not an email document",
-      `Document ${id} has kind=${doc.kind}; /rendered only serves receipt_email documents.`,
-      { document_id: id, kind: doc.kind },
+      "document-not-renderable",
+      "Document has no HTML rendering",
+      `Document ${id} (kind=${doc.kind}, mime_type=${doc.mime_type ?? "null"}) is not a renderable HTML source; /rendered serves receipt_email (.eml) or text/html documents.`,
+      { document_id: id, kind: doc.kind, mime_type: doc.mime_type },
     );
   }
   if (!doc.file_path) return null;
@@ -320,12 +336,17 @@ export async function renderEmailDocument(
     return null;
   }
   const raw = await readFile(absPath);
-  const parsed = await simpleParser(raw);
-  const body =
-    typeof parsed.html === "string" && parsed.html.length > 0
-      ? parsed.html
-      : parsed.textAsHtml ?? `<pre>${escapeHtml(parsed.text ?? "")}</pre>`;
-  return sanitizeHtml(body, EMAIL_SANITIZE);
+  if (isEmail) {
+    const parsed = await simpleParser(raw);
+    const body =
+      typeof parsed.html === "string" && parsed.html.length > 0
+        ? parsed.html
+        : parsed.textAsHtml ?? `<pre>${escapeHtml(parsed.text ?? "")}</pre>`;
+    return sanitizeHtml(body, EMAIL_SANITIZE);
+  }
+  // Raw text/html file (portal invoice, saved confirmation): the bytes
+  // are the HTML document — sanitize them as-is.
+  return sanitizeHtml(raw.toString("utf8"), EMAIL_SANITIZE);
 }
 
 export async function linkDocumentToTransaction(params: {

--- a/src/routes/documents.ts
+++ b/src/routes/documents.ts
@@ -50,7 +50,7 @@ import {
   restoreDocument,
   cascadeDeleteDocument,
   reExtractDocument,
-  renderEmailDocument,
+  renderDocumentHtml,
   extForMime,
   resolveUploadPath,
   type DocumentKindValue,
@@ -170,14 +170,30 @@ documentsRouter.get(
 
     const ext = extForMime(doc.mime_type) ?? path.extname(doc.file_path).replace(/^\./, "");
     const filename = ext ? `${doc.id}.${ext}` : doc.id;
-    res.setHeader(
-      "Content-Type",
-      doc.mime_type ?? "application/octet-stream",
-    );
-    res.setHeader(
-      "Content-Disposition",
-      `inline; filename="${filename}"`,
-    );
+
+    // /content streams the raw stored bytes. HTML/XML/SVG can execute
+    // script if a browser renders them inline same-origin (the detail
+    // viewer's PDF <iframe>, or a direct navigation), and this endpoint
+    // has no sanitize pass. Such docs are never legitimately viewed here
+    // — HTML receipts go through /rendered (sanitized + CSP + sandboxed)
+    // — so serve any active-content doc as an opaque, non-executable
+    // download instead of inline. Detected by mime OR extension so a
+    // near-miss mime (e.g. a .html uploaded as application/xhtml+xml)
+    // can't slip through. Images and PDFs are unchanged (rendered inline
+    // by <img> / the PDF viewer). #137 security review.
+    const baseMime = (doc.mime_type ?? "").split(";")[0]!.trim().toLowerCase();
+    const fileExt = path.extname(doc.file_path).toLowerCase();
+    const isActiveContent =
+      ["text/html", "application/xhtml+xml", "image/svg+xml", "application/xml", "text/xml"].includes(baseMime) ||
+      [".html", ".htm", ".xhtml", ".svg", ".xml"].includes(fileExt);
+    if (isActiveContent) {
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      res.setHeader("Content-Type", "application/octet-stream");
+      res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+    } else {
+      res.setHeader("Content-Type", doc.mime_type ?? "application/octet-stream");
+      res.setHeader("Content-Disposition", `inline; filename="${filename}"`);
+    }
     setEtag(res, DOC_VERSION);
     createReadStream(absPath).pipe(res);
   }),
@@ -185,8 +201,9 @@ documentsRouter.get(
 
 // ── GET /v1/documents/:id/rendered ─────────────────────────────────────
 //
-// For receipt_email documents: decode the raw .eml and serve the
-// sanitized HTML body for the frontend's "Original email" fold (#122).
+// Serve a sanitized HTML rendering for the detail page's "Original
+// receipt / email" fold. Two sources: a receipt_email `.eml` (decoded,
+// #122) or a raw text/html document (sanitized as-is, #137).
 // Safety: a strict CSP (no script-src) + the frontend's sandboxed iframe
 // neutralize any active content; the service-side sanitize is the third
 // layer. Remote images are allowed (product decision — fidelity).
@@ -194,8 +211,12 @@ documentsRouter.get(
   "/:id/rendered",
   asyncHandler(async (req, res) => {
     const { id } = parseOrThrow(IdOnlyParams, req.params);
-    const html = await renderEmailDocument(req.ctx.workspaceId, id);
-    if (html == null) throw new NotFoundProblem("Document content", id);
+    const html = await renderDocumentHtml(req.ctx.workspaceId, id);
+    // Treat an empty render (e.g. a 0-byte HTML file) as missing rather
+    // than serving a blank 200 that shows as an empty iframe. #137.
+    if (html == null || html.trim() === "") {
+      throw new NotFoundProblem("Document content", id);
+    }
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     res.setHeader("X-Content-Type-Options", "nosniff");
     res.setHeader(
@@ -427,21 +448,24 @@ export function registerDocumentsOpenApi(registry: OpenAPIRegistry): void {
     method: "get",
     path: "/v1/documents/{id}/rendered",
     summary:
-      "Decoded + sanitized HTML body of a receipt_email document, for the " +
-      "frontend 'Original email' fold. Served with a strict CSP; render " +
-      "inside a sandboxed iframe.",
+      "Sanitized HTML rendering of a document for the frontend's " +
+      "'Original receipt / email' fold: a decoded receipt_email (.eml) " +
+      "body or a sanitized raw text/html document (#137). Served with a " +
+      "strict CSP; render inside a sandboxed iframe.",
     tags: ["documents"],
     request: { params: z.object({ id: Uuid }) },
     responses: {
       200: {
-        description: "Sanitized email HTML",
+        description: "Sanitized HTML (email body or text/html document)",
         content: {
           "text/html": { schema: { type: "string" } },
         },
       },
-      404: { description: "Not found / no file", content: problemContent },
+      404: { description: "Not found / no file / empty render", content: problemContent },
       422: {
-        description: "Document is not an email (kind != receipt_email)",
+        description:
+          "Document has no HTML rendering (neither receipt_email nor " +
+          "text/html); code document-not-renderable",
         content: problemContent,
       },
     },

--- a/src/routes/ingest.service.ts
+++ b/src/routes/ingest.service.ts
@@ -431,6 +431,14 @@ function guessDocumentKind(
     return "receipt_image";
   }
   if (mt === "message/rfc822" || ext === ".eml") return "receipt_email";
+  if (mt === "text/html" || ext === ".html" || ext === ".htm") {
+    // Portal invoices saved as HTML (Tekmetric and other shop-management
+    // systems) and some web purchase confirmations. Display is gated on
+    // mime_type (the viewer renders text/html through /rendered), so this
+    // kind only drives the list glyph — receipt_pdf reads best for an
+    // invoice-style page. #137.
+    return "receipt_pdf";
+  }
   if (mt === "application/pdf" || ext === ".pdf") {
     // We can't tell receipt-vs-statement without reading it; the agent
     // classifies authoritatively. Default to receipt_pdf (more common).

--- a/src/routes/transactions.service.ts
+++ b/src/routes/transactions.service.ts
@@ -163,6 +163,10 @@ export interface TransactionRow {
   documents: Array<{
     id: string;
     kind: string;
+    /** Raw content type; drives the viewer's render path (text/html →
+     *  sanitized /rendered). Present on the detail read, null on the
+     *  list view. #137. */
+    mime_type?: string | null;
     /** Channel provenance (email sender/subject/received_at). Present on
      *  the single-tx detail read; omitted on the list view. #122. */
     source_meta?: Record<string, unknown> | null;
@@ -349,7 +353,7 @@ function itemsFromMetadataFallback(metadata: unknown): TransactionItemRow[] {
 function mapTransactionRow(
   row: any,
   posts: any[],
-  docs: Array<{ id: string; kind: string; sourceMeta?: unknown }>,
+  docs: Array<{ id: string; kind: string; mimeType?: unknown; sourceMeta?: unknown }>,
   place: PlaceRow | null = null,
   itemRows: any[] = [],
   merchant: MerchantRefRow | null = null,
@@ -380,6 +384,7 @@ function mapTransactionRow(
     documents: docs.map((d) => ({
       id: d.id,
       kind: d.kind,
+      mime_type: (d.mimeType ?? null) as string | null,
       source_meta: (d.sourceMeta ?? null) as Record<string, unknown> | null,
     })),
     place,
@@ -412,6 +417,7 @@ async function loadTransactionFull(
     .select({
       id: documents.id,
       kind: documents.kind,
+      mimeType: documents.mimeType,
       sourceMeta: documents.sourceMeta,
     })
     .from(documentLinks)

--- a/src/schemas/v1/transaction.ts
+++ b/src/schemas/v1/transaction.ts
@@ -66,6 +66,12 @@ export const TransactionDocumentRef = z
   .object({
     id: Uuid,
     kind: z.string(),
+    /** Raw content type of the stored document. Drives the detail
+     *  viewer's render path independently of `kind` — e.g. a
+     *  `text/html` portal invoice renders through /rendered even though
+     *  its `kind` is receipt_pdf. Present on the single-tx detail read;
+     *  null on the list view. #137. */
+    mime_type: z.string().nullish(),
     /** Channel provenance for email-sourced docs (sender/subject/
      *  received_at). Present on the single-tx detail read; omitted on
      *  the list view. #122. */


### PR DESCRIPTION
Backend slice of the cross-repo fix for **TINKPA/receipt-assistant-frontend#137** (HTML receipt documents can't be displayed). This is the contract-owning repo, so it merges first; the frontend slice codegens against the regenerated `openapi.json`.

## What was broken
HTML receipts (portal invoices saved as `.html`, first seen with a Tekmetric invoice, doc `019f62d7…`) ingest and post correctly, but `GET /v1/documents/:id/rendered` returned **422 `document-not-email`** — it only served `receipt_email` `.eml` docs — so the detail page's "Original receipt" fold was blank.

## Changes
- **`/rendered`** (`renderEmailDocument` → `renderDocumentHtml`): also serves raw `text/html` (and `application/xhtml+xml`) documents, sanitized through the existing `EMAIL_SANITIZE` allowlist; the `.eml` decode path is unchanged.
- **Transaction-detail** now exposes each embedded document's `mime_type` (additive `TransactionDocumentRef` field; list view leaves it null) so the viewer gates the render path on mime, not `kind`.
- **`guessDocumentKind`**: `text/html` / `.html` → `receipt_pdf` (drives only the list glyph; display is gated on mime_type).

## Security hardening (from an adversarial review of this change)
`GET /content` served raw stored bytes inline with the stored mime and **no `nosniff`/CSP** — a same-origin active-content sink. Because `.html` now classifies as `receipt_pdf`, a near-miss mime (a `.html` uploaded as `application/xhtml+xml`, which survives multer's normalization) could route to the **non-sandboxed PDF iframe** and execute script. Now: any HTML/XML/SVG doc (matched by mime **or** extension) is served as an opaque `application/octet-stream` **attachment** with `X-Content-Type-Options: nosniff`, so it can never render inline. The mime gate also strips charset params; an empty render now 404s instead of a blank 200. HTML receipts render only through `/rendered` (sanitize-html + strict CSP + sandboxed iframe = three containment layers).

## Verification
- `tsc` clean; `openapi:generate` regenerated (106 schemas).
- Against the mini before this change: `/rendered` for the Tekmetric doc → 422; `/content` → 200 text/html. Post-deploy verification (200 rendered + sandboxed browser render + no script execution) tracked on the frontend issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)