### PR TITLE
fix(migration): split void data-cleanup so no ALTER follows the DML (#170/#171)

### DIFF
--- a/drizzle/0032_perpetual_madrox.sql
+++ b/drizzle/0032_perpetual_madrox.sql
@@ -1,13 +1,1 @@
 ALTER TABLE "transactions" ADD COLUMN "deleted_at" timestamp with time zone;
---> statement-breakpoint
--- #170/#171: eliminate the void double-count and migrate off the void model.
--- Delete the negated "VOID:" mirror transactions (identified by the
--- metadata.voided marker written only by void); their postings cascade via FK,
--- and each original's voided_by_id is set NULL by the FK onDelete rule.
-DELETE FROM "transactions" WHERE "status" = 'posted' AND jsonb_exists("metadata", 'voided');
---> statement-breakpoint
--- Convert the (now mirror-less) voided originals into soft-deleted tombstones.
--- They were duplicates removed by dedup; under the new model a removed row is
--- hidden via deleted_at, not reversed. Money queries filter deleted_at IS NULL,
--- so they stop counting exactly as before — but without the double-count.
-UPDATE "transactions" SET "status" = 'posted', "deleted_at" = now() WHERE "status" = 'voided';

--- a/drizzle/0034_void_data_cleanup.sql
+++ b/drizzle/0034_void_data_cleanup.sql
@@ -1,0 +1,17 @@
+-- Data cleanup for #170/#171. Runs AFTER the schema DDL (0032 add
+-- deleted_at, 0033 drop voided_by_id) so no ALTER TABLE follows this DML
+-- inside the migrator's transaction — otherwise the deferred balance
+-- triggers queued here would trip "cannot ALTER TABLE ... pending trigger
+-- events" (55006).
+--
+-- Delete the negated "VOID:" mirror transactions (identified by the
+-- metadata.voided marker written only by void); their postings cascade via
+-- FK. The deferred postings_balance_ck skips deleted transactions.
+DELETE FROM "transactions" WHERE "status" = 'posted' AND jsonb_exists("metadata", 'voided');
+--> statement-breakpoint
+-- Convert the (now mirror-less) voided originals into soft-deleted
+-- tombstones. They were duplicates removed by dedup; under the new model a
+-- removed row is hidden via deleted_at, not reversed. Money queries filter
+-- deleted_at IS NULL, so they stop counting exactly as before — without the
+-- double-count.
+UPDATE "transactions" SET "status" = 'posted', "deleted_at" = now() WHERE "status" = 'voided';

--- a/drizzle/meta/0034_snapshot.json
+++ b/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,4600 @@
+{
+	"id": "bd689369-80fd-4a38-aecf-d619cc5c887e",
+	"prevId": "113d622e-30b7-4654-8116-6d1331762263",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"users_email_lower_uniq": {
+					"name": "users_email_lower_uniq",
+					"columns": [
+						{
+							"expression": "lower(\"email\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workspace_members": {
+			"name": "workspace_members",
+			"schema": "",
+			"columns": {
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "workspace_role",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'member'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workspace_members_workspace_id_workspaces_id_fk": {
+					"name": "workspace_members_workspace_id_workspaces_id_fk",
+					"tableFrom": "workspace_members",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"workspace_members_user_id_users_id_fk": {
+					"name": "workspace_members_user_id_users_id_fk",
+					"tableFrom": "workspace_members",
+					"tableTo": "users",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"workspace_members_workspace_id_user_id_pk": {
+					"name": "workspace_members_workspace_id_user_id_pk",
+					"columns": [
+						"workspace_id",
+						"user_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workspaces": {
+			"name": "workspaces",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"owner_id": {
+					"name": "owner_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"base_currency": {
+					"name": "base_currency",
+					"type": "char(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"workspaces_owner_id_users_id_fk": {
+					"name": "workspaces_owner_id_users_id_fk",
+					"tableFrom": "workspaces",
+					"tableTo": "users",
+					"columnsFrom": [
+						"owner_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.accounts": {
+			"name": "accounts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "account_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"subtype": {
+					"name": "subtype",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"currency": {
+					"name": "currency",
+					"type": "char(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"institution": {
+					"name": "institution",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last4": {
+					"name": "last4",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opening_balance_minor": {
+					"name": "opening_balance_minor",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "0"
+				},
+				"closed_at": {
+					"name": "closed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"version": {
+					"name": "version",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"accounts_workspace_idx": {
+					"name": "accounts_workspace_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"accounts_parent_idx": {
+					"name": "accounts_parent_idx",
+					"columns": [
+						{
+							"expression": "parent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"accounts_workspace_type_idx": {
+					"name": "accounts_workspace_type_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"accounts_workspace_id_workspaces_id_fk": {
+					"name": "accounts_workspace_id_workspaces_id_fk",
+					"tableFrom": "accounts",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"accounts_parent_id_accounts_id_fk": {
+					"name": "accounts_parent_id_accounts_id_fk",
+					"tableFrom": "accounts",
+					"tableTo": "accounts",
+					"columnsFrom": [
+						"parent_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.transactions": {
+			"name": "transactions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"occurred_on": {
+					"name": "occurred_on",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"occurred_at": {
+					"name": "occurred_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"payee": {
+					"name": "payee",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"narration": {
+					"name": "narration",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "txn_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'posted'"
+				},
+				"deleted_at": {
+					"name": "deleted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_ingest_id": {
+					"name": "source_ingest_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trip_id": {
+					"name": "trip_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"place_id": {
+					"name": "place_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"merchant_id": {
+					"name": "merchant_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"version": {
+					"name": "version",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"transactions_keyset_idx": {
+					"name": "transactions_keyset_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_on",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"transactions_created_at_keyset_idx": {
+					"name": "transactions_created_at_keyset_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"transactions_status_idx": {
+					"name": "transactions_status_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"transactions_source_ingest_idx": {
+					"name": "transactions_source_ingest_idx",
+					"columns": [
+						{
+							"expression": "source_ingest_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"transactions_trip_idx": {
+					"name": "transactions_trip_idx",
+					"columns": [
+						{
+							"expression": "trip_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"transactions_place_idx": {
+					"name": "transactions_place_idx",
+					"columns": [
+						{
+							"expression": "place_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"transactions_merchant_idx": {
+					"name": "transactions_merchant_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "merchant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"transactions_workspace_id_workspaces_id_fk": {
+					"name": "transactions_workspace_id_workspaces_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"transactions_source_ingest_id_ingests_id_fk": {
+					"name": "transactions_source_ingest_id_ingests_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "ingests",
+					"columnsFrom": [
+						"source_ingest_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"transactions_place_id_places_id_fk": {
+					"name": "transactions_place_id_places_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "places",
+					"columnsFrom": [
+						"place_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"transactions_merchant_id_merchants_id_fk": {
+					"name": "transactions_merchant_id_merchants_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "merchants",
+					"columnsFrom": [
+						"merchant_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"transactions_created_by_users_id_fk": {
+					"name": "transactions_created_by_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "users",
+					"columnsFrom": [
+						"created_by"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.product_assets": {
+			"name": "product_assets",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"product_id": {
+					"name": "product_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tier": {
+					"name": "tier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source_url": {
+					"name": "source_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"local_path": {
+					"name": "local_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content_hash": {
+					"name": "content_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content_type": {
+					"name": "content_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"width": {
+					"name": "width",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"height": {
+					"name": "height",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"bytes": {
+					"name": "bytes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"acquired_at": {
+					"name": "acquired_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"agent_relevance": {
+					"name": "agent_relevance",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"agent_notes": {
+					"name": "agent_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"extraction_version": {
+					"name": "extraction_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"user_rating": {
+					"name": "user_rating",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_uploaded": {
+					"name": "user_uploaded",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"user_notes": {
+					"name": "user_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retired_at": {
+					"name": "retired_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				}
+			},
+			"indexes": {
+				"product_assets_product_hash_uq": {
+					"name": "product_assets_product_hash_uq",
+					"columns": [
+						{
+							"expression": "product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "content_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"product_assets_product_idx": {
+					"name": "product_assets_product_idx",
+					"columns": [
+						{
+							"expression": "product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"product_assets_product_id_products_id_fk": {
+					"name": "product_assets_product_id_products_id_fk",
+					"tableFrom": "product_assets",
+					"tableTo": "products",
+					"columnsFrom": [
+						"product_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"product_assets_tier_ck": {
+					"name": "product_assets_tier_ck",
+					"value": "\"product_assets\".\"tier\" IN ('manual_seed','user_upload','agent_fetch')"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.products": {
+			"name": "products",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"product_key": {
+					"name": "product_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"canonical_name": {
+					"name": "canonical_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"merchant_id": {
+					"name": "merchant_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"item_class": {
+					"name": "item_class",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"color": {
+					"name": "color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"size": {
+					"name": "size",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variant": {
+					"name": "variant",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sku": {
+					"name": "sku",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"manufacturer": {
+					"name": "manufacturer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_purchased_on": {
+					"name": "first_purchased_on",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_purchased_on": {
+					"name": "last_purchased_on",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"purchase_count": {
+					"name": "purchase_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"total_spent_minor": {
+					"name": "total_spent_minor",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"custom_name": {
+					"name": "custom_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retired_from_catalog_at": {
+					"name": "retired_from_catalog_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preferred_asset_id": {
+					"name": "preferred_asset_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preferred_asset_chosen_at": {
+					"name": "preferred_asset_chosen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"products_workspace_merchant_key_uq": {
+					"name": "products_workspace_merchant_key_uq",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "merchant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "product_key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"products_workspace_class_idx": {
+					"name": "products_workspace_class_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_class",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"products_workspace_brand_idx": {
+					"name": "products_workspace_brand_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"products_workspace_merchant_idx": {
+					"name": "products_workspace_merchant_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "merchant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"products_workspace_id_workspaces_id_fk": {
+					"name": "products_workspace_id_workspaces_id_fk",
+					"tableFrom": "products",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"products_merchant_id_merchants_id_fk": {
+					"name": "products_merchant_id_merchants_id_fk",
+					"tableFrom": "products",
+					"tableTo": "merchants",
+					"columnsFrom": [
+						"merchant_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"products_brand_id_brands_brand_id_fk": {
+					"name": "products_brand_id_brands_brand_id_fk",
+					"tableFrom": "products",
+					"tableTo": "brands",
+					"columnsFrom": [
+						"brand_id"
+					],
+					"columnsTo": [
+						"brand_id"
+					],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"products_item_class_ck": {
+					"name": "products_item_class_ck",
+					"value": "\"products\".\"item_class\" IN ('durable','consumable','food_drink','service','other')"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.transaction_items": {
+			"name": "transaction_items",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transaction_id": {
+					"name": "transaction_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"line_no": {
+					"name": "line_no",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"parent_line_no": {
+					"name": "parent_line_no",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_name": {
+					"name": "raw_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"normalized_name": {
+					"name": "normalized_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"product_variant": {
+					"name": "product_variant",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unit_price_minor": {
+					"name": "unit_price_minor",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"line_total_minor": {
+					"name": "line_total_minor",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"currency": {
+					"name": "currency",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"item_class": {
+					"name": "item_class",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"durability_tier": {
+					"name": "durability_tier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"food_kind": {
+					"name": "food_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence": {
+					"name": "confidence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"line_type": {
+					"name": "line_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'product'"
+				},
+				"product_id": {
+					"name": "product_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tax_minor": {
+					"name": "tax_minor",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tip_share_minor": {
+					"name": "tip_share_minor",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"discount_share_minor": {
+					"name": "discount_share_minor",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"effective_total_minor": {
+					"name": "effective_total_minor",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false,
+					"generated": {
+						"as": "line_total_minor + COALESCE(tax_minor, 0) + COALESCE(tip_share_minor, 0) - COALESCE(discount_share_minor, 0)",
+						"type": "stored"
+					}
+				},
+				"extraction_run": {
+					"name": "extraction_run",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"retired_at": {
+					"name": "retired_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"extraction_version": {
+					"name": "extraction_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"transaction_items_line_no_run_uq": {
+					"name": "transaction_items_line_no_run_uq",
+					"columns": [
+						{
+							"expression": "transaction_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "line_no",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "extraction_run",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"transaction_items_tx_idx": {
+					"name": "transaction_items_tx_idx",
+					"columns": [
+						{
+							"expression": "transaction_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"transaction_items_workspace_class_created_idx": {
+					"name": "transaction_items_workspace_class_created_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_class",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"transaction_items_workspace_id_workspaces_id_fk": {
+					"name": "transaction_items_workspace_id_workspaces_id_fk",
+					"tableFrom": "transaction_items",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"transaction_items_transaction_id_transactions_id_fk": {
+					"name": "transaction_items_transaction_id_transactions_id_fk",
+					"tableFrom": "transaction_items",
+					"tableTo": "transactions",
+					"columnsFrom": [
+						"transaction_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"transaction_items_product_id_products_id_fk": {
+					"name": "transaction_items_product_id_products_id_fk",
+					"tableFrom": "transaction_items",
+					"tableTo": "products",
+					"columnsFrom": [
+						"product_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.owned_items": {
+			"name": "owned_items",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"product_id": {
+					"name": "product_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transaction_item_id": {
+					"name": "transaction_item_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"instance_index": {
+					"name": "instance_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"serial_number": {
+					"name": "serial_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"acquired_on": {
+					"name": "acquired_on",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"warranty_until": {
+					"name": "warranty_until",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"condition": {
+					"name": "condition",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retired_at": {
+					"name": "retired_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"target_days": {
+					"name": "target_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"owned_items_tx_item_instance_uq": {
+					"name": "owned_items_tx_item_instance_uq",
+					"columns": [
+						{
+							"expression": "transaction_item_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "instance_index",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"owned_items_workspace_product_idx": {
+					"name": "owned_items_workspace_product_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"owned_items_workspace_id_workspaces_id_fk": {
+					"name": "owned_items_workspace_id_workspaces_id_fk",
+					"tableFrom": "owned_items",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"owned_items_product_id_products_id_fk": {
+					"name": "owned_items_product_id_products_id_fk",
+					"tableFrom": "owned_items",
+					"tableTo": "products",
+					"columnsFrom": [
+						"product_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"owned_items_transaction_item_id_transaction_items_id_fk": {
+					"name": "owned_items_transaction_item_id_transaction_items_id_fk",
+					"tableFrom": "owned_items",
+					"tableTo": "transaction_items",
+					"columnsFrom": [
+						"transaction_item_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wish_items": {
+			"name": "wish_items",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"product_id": {
+					"name": "product_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"target_price_minor": {
+					"name": "target_price_minor",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"currency": {
+					"name": "currency",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'USD'"
+				},
+				"planned_days": {
+					"name": "planned_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"urgency": {
+					"name": "urgency",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'someday'"
+				},
+				"snoozed_until": {
+					"name": "snoozed_until",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"converted_transaction_id": {
+					"name": "converted_transaction_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"wish_items_workspace_status_idx": {
+					"name": "wish_items_workspace_status_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wish_items_workspace_id_workspaces_id_fk": {
+					"name": "wish_items_workspace_id_workspaces_id_fk",
+					"tableFrom": "wish_items",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"wish_items_product_id_products_id_fk": {
+					"name": "wish_items_product_id_products_id_fk",
+					"tableFrom": "wish_items",
+					"tableTo": "products",
+					"columnsFrom": [
+						"product_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"wish_items_converted_transaction_id_transactions_id_fk": {
+					"name": "wish_items_converted_transaction_id_transactions_id_fk",
+					"tableFrom": "wish_items",
+					"tableTo": "transactions",
+					"columnsFrom": [
+						"converted_transaction_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.insights": {
+			"name": "insights",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dedupe_key": {
+					"name": "dedupe_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"dismissed_at": {
+					"name": "dismissed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"insights_workspace_dedupe_uq": {
+					"name": "insights_workspace_dedupe_uq",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "dedupe_key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"insights_workspace_active_idx": {
+					"name": "insights_workspace_active_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "dismissed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"insights_workspace_id_workspaces_id_fk": {
+					"name": "insights_workspace_id_workspaces_id_fk",
+					"tableFrom": "insights",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.transaction_parties": {
+			"name": "transaction_parties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transaction_id": {
+					"name": "transaction_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transaction_item_id": {
+					"name": "transaction_item_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"transaction_parties_workspace_brand_idx": {
+					"name": "transaction_parties_workspace_brand_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "role",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"transaction_parties_tx_idx": {
+					"name": "transaction_parties_tx_idx",
+					"columns": [
+						{
+							"expression": "transaction_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"transaction_parties_workspace_id_workspaces_id_fk": {
+					"name": "transaction_parties_workspace_id_workspaces_id_fk",
+					"tableFrom": "transaction_parties",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"transaction_parties_transaction_id_transactions_id_fk": {
+					"name": "transaction_parties_transaction_id_transactions_id_fk",
+					"tableFrom": "transaction_parties",
+					"tableTo": "transactions",
+					"columnsFrom": [
+						"transaction_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"transaction_parties_transaction_item_id_transaction_items_id_fk": {
+					"name": "transaction_parties_transaction_item_id_transaction_items_id_fk",
+					"tableFrom": "transaction_parties",
+					"tableTo": "transaction_items",
+					"columnsFrom": [
+						"transaction_item_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"transaction_parties_identity_uq": {
+					"name": "transaction_parties_identity_uq",
+					"nullsNotDistinct": true,
+					"columns": [
+						"transaction_id",
+						"transaction_item_id",
+						"role",
+						"display_name"
+					]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.brand_assets": {
+			"name": "brand_assets",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tier": {
+					"name": "tier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source_url": {
+					"name": "source_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"local_path": {
+					"name": "local_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content_hash": {
+					"name": "content_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content_type": {
+					"name": "content_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"width": {
+					"name": "width",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"height": {
+					"name": "height",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"bytes": {
+					"name": "bytes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"acquired_at": {
+					"name": "acquired_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"agent_relevance": {
+					"name": "agent_relevance",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"agent_notes": {
+					"name": "agent_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"extraction_version": {
+					"name": "extraction_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"user_rating": {
+					"name": "user_rating",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_uploaded": {
+					"name": "user_uploaded",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"user_notes": {
+					"name": "user_notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retired_at": {
+					"name": "retired_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				}
+			},
+			"indexes": {
+				"brand_assets_brand_hash_uq": {
+					"name": "brand_assets_brand_hash_uq",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "content_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"brand_assets_brand_idx": {
+					"name": "brand_assets_brand_idx",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"brand_assets_brand_tier_idx": {
+					"name": "brand_assets_brand_tier_idx",
+					"columns": [
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "tier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"brand_assets_brand_id_brands_brand_id_fk": {
+					"name": "brand_assets_brand_id_brands_brand_id_fk",
+					"tableFrom": "brand_assets",
+					"tableTo": "brands",
+					"columnsFrom": [
+						"brand_id"
+					],
+					"columnsTo": [
+						"brand_id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"brand_assets_tier_ck": {
+					"name": "brand_assets_tier_ck",
+					"value": "\"brand_assets\".\"tier\" IN ('itunes','svgl','logo_dev','simple_icons','google_play','user_upload','manual_url')"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.brands": {
+			"name": "brands",
+			"schema": "",
+			"columns": {
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preferred_asset_id": {
+					"name": "preferred_asset_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_chose_at": {
+					"name": "user_chose_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"brands_parent_id_brands_brand_id_fk": {
+					"name": "brands_parent_id_brands_brand_id_fk",
+					"tableFrom": "brands",
+					"tableTo": "brands",
+					"columnsFrom": [
+						"parent_id"
+					],
+					"columnsTo": [
+						"brand_id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.postings": {
+			"name": "postings",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transaction_id": {
+					"name": "transaction_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount_minor": {
+					"name": "amount_minor",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"currency": {
+					"name": "currency",
+					"type": "char(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fx_rate": {
+					"name": "fx_rate",
+					"type": "numeric(20, 10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"amount_base_minor": {
+					"name": "amount_base_minor",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"memo": {
+					"name": "memo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"postings_transaction_idx": {
+					"name": "postings_transaction_idx",
+					"columns": [
+						{
+							"expression": "transaction_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"postings_account_idx": {
+					"name": "postings_account_idx",
+					"columns": [
+						{
+							"expression": "account_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"postings_workspace_idx": {
+					"name": "postings_workspace_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"postings_workspace_id_workspaces_id_fk": {
+					"name": "postings_workspace_id_workspaces_id_fk",
+					"tableFrom": "postings",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"postings_transaction_id_transactions_id_fk": {
+					"name": "postings_transaction_id_transactions_id_fk",
+					"tableFrom": "postings",
+					"tableTo": "transactions",
+					"columnsFrom": [
+						"transaction_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"postings_account_id_accounts_id_fk": {
+					"name": "postings_account_id_accounts_id_fk",
+					"tableFrom": "postings",
+					"tableTo": "accounts",
+					"columnsFrom": [
+						"account_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.document_links": {
+			"name": "document_links",
+			"schema": "",
+			"columns": {
+				"document_id": {
+					"name": "document_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transaction_id": {
+					"name": "transaction_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"document_links_txn_idx": {
+					"name": "document_links_txn_idx",
+					"columns": [
+						{
+							"expression": "transaction_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"document_links_document_id_documents_id_fk": {
+					"name": "document_links_document_id_documents_id_fk",
+					"tableFrom": "document_links",
+					"tableTo": "documents",
+					"columnsFrom": [
+						"document_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"document_links_transaction_id_transactions_id_fk": {
+					"name": "document_links_transaction_id_transactions_id_fk",
+					"tableFrom": "document_links",
+					"tableTo": "transactions",
+					"columnsFrom": [
+						"transaction_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"document_links_document_id_transaction_id_pk": {
+					"name": "document_links_document_id_transaction_id_pk",
+					"columns": [
+						"document_id",
+						"transaction_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.documents": {
+			"name": "documents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "document_kind",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mime_type": {
+					"name": "mime_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sha256": {
+					"name": "sha256",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ocr_text": {
+					"name": "ocr_text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ocr_model_version": {
+					"name": "ocr_model_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"extraction_meta": {
+					"name": "extraction_meta",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"message_id": {
+					"name": "message_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phash": {
+					"name": "phash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_meta": {
+					"name": "source_meta",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_ingest_id": {
+					"name": "source_ingest_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"deleted_at": {
+					"name": "deleted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"documents_workspace_sha_uniq": {
+					"name": "documents_workspace_sha_uniq",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "sha256",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"documents_workspace_message_id_uniq": {
+					"name": "documents_workspace_message_id_uniq",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "message_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"documents\".\"message_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"documents_kind_idx": {
+					"name": "documents_kind_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"documents_source_ingest_idx": {
+					"name": "documents_source_ingest_idx",
+					"columns": [
+						{
+							"expression": "source_ingest_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"documents_workspace_live_idx": {
+					"name": "documents_workspace_live_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"documents\".\"deleted_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"documents_workspace_id_workspaces_id_fk": {
+					"name": "documents_workspace_id_workspaces_id_fk",
+					"tableFrom": "documents",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"documents_source_ingest_id_ingests_id_fk": {
+					"name": "documents_source_ingest_id_ingests_id_fk",
+					"tableFrom": "documents",
+					"tableTo": "ingests",
+					"columnsFrom": [
+						"source_ingest_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.transaction_events": {
+			"name": "transaction_events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transaction_id": {
+					"name": "transaction_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"txn_events_txn_idx": {
+					"name": "txn_events_txn_idx",
+					"columns": [
+						{
+							"expression": "transaction_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"transaction_events_workspace_id_workspaces_id_fk": {
+					"name": "transaction_events_workspace_id_workspaces_id_fk",
+					"tableFrom": "transaction_events",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"transaction_events_transaction_id_transactions_id_fk": {
+					"name": "transaction_events_transaction_id_transactions_id_fk",
+					"tableFrom": "transaction_events",
+					"tableTo": "transactions",
+					"columnsFrom": [
+						"transaction_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"transaction_events_actor_id_users_id_fk": {
+					"name": "transaction_events_actor_id_users_id_fk",
+					"tableFrom": "transaction_events",
+					"tableTo": "users",
+					"columnsFrom": [
+						"actor_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.idempotency_keys": {
+			"name": "idempotency_keys",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_hash": {
+					"name": "request_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"response_status": {
+					"name": "response_status",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"response_body": {
+					"name": "response_body",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"idempotency_keys_uniq": {
+					"name": "idempotency_keys_uniq",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"idempotency_keys_workspace_id_workspaces_id_fk": {
+					"name": "idempotency_keys_workspace_id_workspaces_id_fk",
+					"tableFrom": "idempotency_keys",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.batches": {
+			"name": "batches",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "batch_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"file_count": {
+					"name": "file_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"auto_reconcile": {
+					"name": "auto_reconcile",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reconciled_at": {
+					"name": "reconciled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"batches_workspace_created_idx": {
+					"name": "batches_workspace_created_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"batches_status_idx": {
+					"name": "batches_status_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"batches_workspace_id_workspaces_id_fk": {
+					"name": "batches_workspace_id_workspaces_id_fk",
+					"tableFrom": "batches",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ingests": {
+			"name": "ingests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"batch_id": {
+					"name": "batch_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"filename": {
+					"name": "filename",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"mime_type": {
+					"name": "mime_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "ingest_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"classification": {
+					"name": "classification",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"produced": {
+					"name": "produced",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ingests_batch_idx": {
+					"name": "ingests_batch_idx",
+					"columns": [
+						{
+							"expression": "batch_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ingests_workspace_created_idx": {
+					"name": "ingests_workspace_created_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ingests_status_idx": {
+					"name": "ingests_status_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ingests_workspace_id_workspaces_id_fk": {
+					"name": "ingests_workspace_id_workspaces_id_fk",
+					"tableFrom": "ingests",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"ingests_batch_id_batches_id_fk": {
+					"name": "ingests_batch_id_batches_id_fk",
+					"tableFrom": "ingests",
+					"tableTo": "batches",
+					"columnsFrom": [
+						"batch_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.reconcile_proposals": {
+			"name": "reconcile_proposals",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"batch_id": {
+					"name": "batch_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"score": {
+					"name": "score",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"resolved_at": {
+					"name": "resolved_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"reconcile_proposals_batch_idx": {
+					"name": "reconcile_proposals_batch_idx",
+					"columns": [
+						{
+							"expression": "batch_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"reconcile_proposals_kind_idx": {
+					"name": "reconcile_proposals_kind_idx",
+					"columns": [
+						{
+							"expression": "batch_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"reconcile_proposals_batch_id_batches_id_fk": {
+					"name": "reconcile_proposals_batch_id_batches_id_fk",
+					"tableFrom": "reconcile_proposals",
+					"tableTo": "batches",
+					"columnsFrom": [
+						"batch_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.place_photos": {
+			"name": "place_photos",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"place_id": {
+					"name": "place_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"google_photo_name": {
+					"name": "google_photo_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"rank": {
+					"name": "rank",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"width_px": {
+					"name": "width_px",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"height_px": {
+					"name": "height_px",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"author_attributions": {
+					"name": "author_attributions",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mime_type": {
+					"name": "mime_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sha256": {
+					"name": "sha256",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ocr_extracted": {
+					"name": "ocr_extracted",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.place_reviews": {
+			"name": "place_reviews",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"place_id": {
+					"name": "place_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"google_review_name": {
+					"name": "google_review_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"rating": {
+					"name": "rating",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"text_text": {
+					"name": "text_text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"text_language": {
+					"name": "text_language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"original_text_text": {
+					"name": "original_text_text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"original_text_language": {
+					"name": "original_text_language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"relative_publish_time": {
+					"name": "relative_publish_time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"publish_time": {
+					"name": "publish_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"author_display_name": {
+					"name": "author_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"author_uri": {
+					"name": "author_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"author_photo_uri": {
+					"name": "author_photo_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"snapshot_taken_at": {
+					"name": "snapshot_taken_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"raw": {
+					"name": "raw",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.places": {
+			"name": "places",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"google_place_id": {
+					"name": "google_place_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"formatted_address": {
+					"name": "formatted_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lat": {
+					"name": "lat",
+					"type": "numeric(9, 6)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lng": {
+					"name": "lng",
+					"type": "numeric(9, 6)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_response": {
+					"name": "raw_response",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"hit_count": {
+					"name": "hit_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"display_name_en": {
+					"name": "display_name_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"display_name_zh": {
+					"name": "display_name_zh",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"display_name_zh_locale": {
+					"name": "display_name_zh_locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"display_name_zh_source": {
+					"name": "display_name_zh_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"display_name_zh_is_native": {
+					"name": "display_name_zh_is_native",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"custom_name": {
+					"name": "custom_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"primary_type": {
+					"name": "primary_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"primary_type_display_zh": {
+					"name": "primary_type_display_zh",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"maps_type_label_zh": {
+					"name": "maps_type_label_zh",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"types": {
+					"name": "types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"formatted_address_en": {
+					"name": "formatted_address_en",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"formatted_address_zh": {
+					"name": "formatted_address_zh",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"postal_code": {
+					"name": "postal_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"country_code": {
+					"name": "country_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"business_status": {
+					"name": "business_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"business_hours": {
+					"name": "business_hours",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"time_zone": {
+					"name": "time_zone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rating": {
+					"name": "rating",
+					"type": "numeric(2, 1)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_rating_count": {
+					"name": "user_rating_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"national_phone_number": {
+					"name": "national_phone_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"website_uri": {
+					"name": "website_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"google_maps_uri": {
+					"name": "google_maps_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"yelp_business_id": {
+					"name": "yelp_business_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"yelp_alias": {
+					"name": "yelp_alias",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"yelp_price_level": {
+					"name": "yelp_price_level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"yelp_categories": {
+					"name": "yelp_categories",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"yelp_raw_response": {
+					"name": "yelp_raw_response",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"places_lat_lng_idx": {
+					"name": "places_lat_lng_idx",
+					"columns": [
+						{
+							"expression": "lat",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "lng",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"places_google_place_id_unique": {
+					"name": "places_google_place_id_unique",
+					"nullsNotDistinct": false,
+					"columns": [
+						"google_place_id"
+					]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.place_snapshots": {
+			"name": "place_snapshots",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"place_id": {
+					"name": "place_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_response": {
+					"name": "raw_response",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"fetched_by_sha": {
+					"name": "fetched_by_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"place_snapshots_place_idx": {
+					"name": "place_snapshots_place_idx",
+					"columns": [
+						{
+							"expression": "place_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "fetched_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"place_snapshots_place_id_places_id_fk": {
+					"name": "place_snapshots_place_id_places_id_fk",
+					"tableFrom": "place_snapshots",
+					"tableTo": "places",
+					"columnsFrom": [
+						"place_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.merchants": {
+			"name": "merchants",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"brand_id": {
+					"name": "brand_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"canonical_name": {
+					"name": "canonical_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"place_id": {
+					"name": "place_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"photo_url": {
+					"name": "photo_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"photo_attribution": {
+					"name": "photo_attribution",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lat": {
+					"name": "lat",
+					"type": "numeric(9, 6)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lng": {
+					"name": "lng",
+					"type": "numeric(9, 6)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enrichment_status": {
+					"name": "enrichment_status",
+					"type": "merchant_enrichment_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"enrichment_attempted_at": {
+					"name": "enrichment_attempted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"custom_name": {
+					"name": "custom_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				}
+			},
+			"indexes": {
+				"merchants_workspace_brand_idx": {
+					"name": "merchants_workspace_brand_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "brand_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"merchants_workspace_idx": {
+					"name": "merchants_workspace_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"merchants_enrichment_pending_idx": {
+					"name": "merchants_enrichment_pending_idx",
+					"columns": [
+						{
+							"expression": "enrichment_status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"merchants_workspace_id_workspaces_id_fk": {
+					"name": "merchants_workspace_id_workspaces_id_fk",
+					"tableFrom": "merchants",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"merchants_brand_id_brands_brand_id_fk": {
+					"name": "merchants_brand_id_brands_brand_id_fk",
+					"tableFrom": "merchants",
+					"tableTo": "brands",
+					"columnsFrom": [
+						"brand_id"
+					],
+					"columnsTo": [
+						"brand_id"
+					],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"merchants_brand_id_format": {
+					"name": "merchants_brand_id_format",
+					"value": "\"merchants\".\"brand_id\" ~ '^[a-z0-9-]+$'"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.derivation_events": {
+			"name": "derivation_events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"entity_type": {
+					"name": "entity_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"prompt_version": {
+					"name": "prompt_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"prompt_git_sha": {
+					"name": "prompt_git_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ran_at": {
+					"name": "ran_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "NOW()"
+				},
+				"before": {
+					"name": "before",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"after": {
+					"name": "after",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"changed_keys": {
+					"name": "changed_keys",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"derivation_events_entity_idx": {
+					"name": "derivation_events_entity_idx",
+					"columns": [
+						{
+							"expression": "entity_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "ran_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"derivation_events_version_idx": {
+					"name": "derivation_events_version_idx",
+					"columns": [
+						{
+							"expression": "prompt_version",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "ran_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"derivation_events_workspace_id_workspaces_id_fk": {
+					"name": "derivation_events_workspace_id_workspaces_id_fk",
+					"tableFrom": "derivation_events",
+					"tableTo": "workspaces",
+					"columnsFrom": [
+						"workspace_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.account_type": {
+			"name": "account_type",
+			"schema": "public",
+			"values": [
+				"asset",
+				"liability",
+				"equity",
+				"income",
+				"expense"
+			]
+		},
+		"public.batch_status": {
+			"name": "batch_status",
+			"schema": "public",
+			"values": [
+				"pending",
+				"processing",
+				"extracted",
+				"reconciling",
+				"reconciled",
+				"failed",
+				"reconcile_error"
+			]
+		},
+		"public.document_kind": {
+			"name": "document_kind",
+			"schema": "public",
+			"values": [
+				"receipt_image",
+				"receipt_email",
+				"receipt_pdf",
+				"statement_pdf",
+				"other"
+			]
+		},
+		"public.ingest_status": {
+			"name": "ingest_status",
+			"schema": "public",
+			"values": [
+				"queued",
+				"processing",
+				"done",
+				"error",
+				"unsupported",
+				"dedup",
+				"near_dup"
+			]
+		},
+		"public.merchant_enrichment_status": {
+			"name": "merchant_enrichment_status",
+			"schema": "public",
+			"values": [
+				"pending",
+				"success",
+				"not_found",
+				"failed"
+			]
+		},
+		"public.txn_status": {
+			"name": "txn_status",
+			"schema": "public",
+			"values": [
+				"draft",
+				"posted",
+				"voided",
+				"reconciled",
+				"error"
+			]
+		},
+		"public.workspace_role": {
+			"name": "workspace_role",
+			"schema": "public",
+			"values": [
+				"owner",
+				"admin",
+				"member",
+				"viewer"
+			]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,244 +1,251 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1776588427012,
-      "tag": "0000_init",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1776588444835,
-      "tag": "0001_ledger_invariants",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1776593049864,
-      "tag": "0002_batch_ingest",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1776726080523,
-      "tag": "0003_foamy_lady_mastermind",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1777512323003,
-      "tag": "0004_magenta_aaron_stack",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1778475015969,
-      "tag": "0005_marvelous_radioactive_man",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1778571038628,
-      "tag": "0006_chilly_smasher",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1778623810414,
-      "tag": "0007_align_expense_accounts_to_seven",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1778636612525,
-      "tag": "0008_backfill_canonical_merchant_category",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1778657498049,
-      "tag": "0009_multilingual_place_cache",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1778715060674,
-      "tag": "0010_display_name_zh_is_native",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1778838477369,
-      "tag": "0011_phase2_re_derive",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1778899238110,
-      "tag": "0012_place_snapshots",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1778901566060,
-      "tag": "0013_documents_ocr_model_version",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1778908371437,
-      "tag": "0014_places_custom_name",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1778911497324,
-      "tag": "0015_natural_ezekiel_stane",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1778913979897,
-      "tag": "0016_complete_gateway",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1778919812124,
-      "tag": "0017_dusty_tinkerer",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1778920670679,
-      "tag": "0018_zippy_gateway",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1778927292094,
-      "tag": "0019_tricky_korvac",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1778930945721,
-      "tag": "0020_jazzy_matthew_murdock",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1778939586594,
-      "tag": "0021_new_lethal_legion",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1779963043381,
-      "tag": "0022_stale_slipstream",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1780023179614,
-      "tag": "0023_slim_piledriver",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1781095505462,
-      "tag": "0024_relative_file_paths",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1781101418019,
-      "tag": "0025_closed_vindicator",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1781103138621,
-      "tag": "0026_outstanding_ikaris",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "7",
-      "when": 1781259898600,
-      "tag": "0027_dear_zarda",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "7",
-      "when": 1781261127486,
-      "tag": "0028_rare_thunderbolt_ross",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "7",
-      "when": 1781261983094,
-      "tag": "0029_dear_wendell_vaughn",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "7",
-      "when": 1782289849066,
-      "tag": "0030_motionless_weapon_omega",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "7",
-      "when": 1782891944144,
-      "tag": "0031_hard_arclight",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "7",
-      "when": 1784186220105,
-      "tag": "0032_perpetual_madrox",
-      "breakpoints": true
-    },
-    {
-      "idx": 33,
-      "version": "7",
-      "when": 1784186368107,
-      "tag": "0033_strange_sally_floyd",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1776588427012,
+			"tag": "0000_init",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1776588444835,
+			"tag": "0001_ledger_invariants",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1776593049864,
+			"tag": "0002_batch_ingest",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1776726080523,
+			"tag": "0003_foamy_lady_mastermind",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1777512323003,
+			"tag": "0004_magenta_aaron_stack",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1778475015969,
+			"tag": "0005_marvelous_radioactive_man",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1778571038628,
+			"tag": "0006_chilly_smasher",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1778623810414,
+			"tag": "0007_align_expense_accounts_to_seven",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1778636612525,
+			"tag": "0008_backfill_canonical_merchant_category",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1778657498049,
+			"tag": "0009_multilingual_place_cache",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1778715060674,
+			"tag": "0010_display_name_zh_is_native",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1778838477369,
+			"tag": "0011_phase2_re_derive",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1778899238110,
+			"tag": "0012_place_snapshots",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1778901566060,
+			"tag": "0013_documents_ocr_model_version",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1778908371437,
+			"tag": "0014_places_custom_name",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1778911497324,
+			"tag": "0015_natural_ezekiel_stane",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1778913979897,
+			"tag": "0016_complete_gateway",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1778919812124,
+			"tag": "0017_dusty_tinkerer",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1778920670679,
+			"tag": "0018_zippy_gateway",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1778927292094,
+			"tag": "0019_tricky_korvac",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1778930945721,
+			"tag": "0020_jazzy_matthew_murdock",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1778939586594,
+			"tag": "0021_new_lethal_legion",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1779963043381,
+			"tag": "0022_stale_slipstream",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1780023179614,
+			"tag": "0023_slim_piledriver",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1781095505462,
+			"tag": "0024_relative_file_paths",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1781101418019,
+			"tag": "0025_closed_vindicator",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1781103138621,
+			"tag": "0026_outstanding_ikaris",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1781259898600,
+			"tag": "0027_dear_zarda",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1781261127486,
+			"tag": "0028_rare_thunderbolt_ross",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "7",
+			"when": 1781261983094,
+			"tag": "0029_dear_wendell_vaughn",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1782289849066,
+			"tag": "0030_motionless_weapon_omega",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1782891944144,
+			"tag": "0031_hard_arclight",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "7",
+			"when": 1784186220105,
+			"tag": "0032_perpetual_madrox",
+			"breakpoints": true
+		},
+		{
+			"idx": 33,
+			"version": "7",
+			"when": 1784186368107,
+			"tag": "0033_strange_sally_floyd",
+			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1784186369107,
+			"tag": "0034_void_data_cleanup",
+			"breakpoints": true
+		}
+	]
 }


### PR DESCRIPTION
Hotfix for #173's deploy crash-loop: 0032's DML queued deferred balance-constraint events and 0033's `ALTER TABLE DROP CONSTRAINT` then failed with 55006. Splits the data cleanup into a new 0034 that runs after all DDL. Verified by prod dry-run (SET CONSTRAINTS ALL IMMEDIATE: DELETE 17, UPDATE 18, 0 voided, 18 tombstones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)