### PR TITLE
prompt+docker: budget brand discovery, install poppler for PDFs (v2.22)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         g++ \
         curl \
         postgresql-client \
+        poppler-utils \
+        ghostscript \
     && rm -rf /var/lib/apt/lists/*
+
+# poppler-utils (pdftoppm/pdftotext) is the extractor's PDF path: it
+# rasterizes a receipt PDF to PNG in ~1s so the agent reads pixels instead
+# of hand-decoding PDF streams (which cost ~400s on an AAA form-PDF before
+# this was installed). Debian's ImageMagick also ships a policy.xml that
+# blocks the PDF coder; relax it as a defensive fallback for any
+# convert-based path (no-op if ImageMagick isn't present). Receipts are the
+# user's own trusted files, so allowing the PDF coder is acceptable here.
+RUN for f in /etc/ImageMagick-*/policy.xml; do \
+        if [ -f "$f" ]; then \
+            sed -i 's#rights="none" pattern="PDF"#rights="read|write" pattern="PDF"#' "$f"; \
+        fi; \
+    done
 
 # Claude Code CLI — invoked by src/claude.ts as a subprocess.
 RUN npm install -g @anthropic-ai/claude-code

--- a/src/ingest/brand-icon-prompt.ts
+++ b/src/ingest/brand-icon-prompt.ts
@@ -25,6 +25,14 @@ Goal: ensure every brand_id you emitted has a row in the global
 discoverable) an official domain. The downstream Phase 4b uses the
 domain to query logo.dev; without it that tier is skipped.
 
+BUDGET GATE (see the extractor's Priority & effort-budget preamble):
+brand discovery is best-effort enrichment, not core. It is ONE cheap
+registry SELECT, and for a brand that is ALREADY KNOWN it ends right
+there — do not reason further, do not WebSearch, do not re-UPSERT, just
+move on. Only a genuinely unseen brand (no row at all, or a row with a
+NULL domain that is NOT marked 'discovery_failed') is worth any
+discovery work. When unsure, prefer skipping over spending turns.
+
 Steps (run once per unique merchant brand_id in this document):
 
   1. Cache check — read the registry first:

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -22,7 +22,7 @@ import {
  * `extraction.prompt_version` ≠ `PROMPT_VERSION` are eligible to be
  * re-derived. See #80 / #88 for the 3-layer data model rationale.
  */
-export const PROMPT_VERSION = "2.21";
+export const PROMPT_VERSION = "2.22";
 
 export interface ExtractorPromptContext {
   /** Absolute path inside the container where the file was staged. */
@@ -201,6 +201,22 @@ When you deliberately skip an enrichment step, record it so the trace shows
 a decision, not a failure:
   metadata.enrichment_skipped = ['photos','brand_icon', ...]   -- reasons ok
 ${renderActiveLessons()}
+── Reading the document (especially PDFs) ────────────────────────────
+
+For a PDF, do NOT hand-parse the byte structure (decompressing streams,
+mapping Form XObjects, sorting content-stream placements) — that path is
+slow and error-prone. Rasterize to an image and read the pixels, which is
+what you do best:
+
+  pdftoppm -png -r 200 "${ctx.filePath}" /tmp/${ctx.ingestId}/page
+  # → /tmp/${ctx.ingestId}/page-1.png, page-2.png, …  then Read those PNGs.
+
+\`pdftoppm\` and \`pdftotext\` (poppler) plus \`gs\` (ghostscript) are
+installed. \`pdftotext -layout "${ctx.filePath}" -\` gives a fast text
+layer for text-based PDFs; when the PDF is a flattened form or its text
+layer is empty/garbled, prefer the rasterized PNG. Only fall back to
+manual stream decoding if those tools are genuinely unavailable.
+
 ── Phase 1 — Classify ─────────────────────────────────────────────────
 
 Read the file (image / pdf / html / .eml) and decide which category:


### PR DESCRIPTION
## Summary
Follow-up to #176, driven by a **live measurement** of an AAA battery-service PDF ingest on the mini (v2.21): **586s / 34 turns**. The trace confirmed the v2.21 levers work (place enrichment skipped + logged with sound reasoning; a lesson proposed to `lessons.proposed.md`; accurate balanced `$266.33`, date beat a PDF-metadata trap), but exposed **two other bottlenecks**.

## Where the 586s went

| Stage | Time | The fix |
|---|---|---|
| Hand-decoding the PDF (no poppler in container) | ~400s (68%) | `poppler-utils` installed → **0.75s** rasterize, measured on the same file |
| Brand discovery for an *already-known* brand (`aaa`) | ~137s (23%) | v2.22 `BUDGET GATE` atop Phase 2.6 → known brand exits immediately |
| Core ledger write (the valuable output) | ~53s (9%) | already lean |

So ~530s of the 586s is addressable; the core extraction was never the problem.

## Fixes
1. **PDF tooling gap (~400s, 68%).** No `poppler`/`ghostscript`; ImageMagick's PDF coder is policy-blocked. The agent hand-decoded the PDF (streams → embedded images → Form-XObject layout reconstruction). **Fix (Dockerfile):** install `poppler-utils` + `ghostscript`, relax the ImageMagick PDF policy. `pdftoppm` rasterizes a receipt PDF to PNG in ~1s → the agent reads pixels (its strength). `prompt.ts` adds a "Reading the document (especially PDFs)" block steering it to `pdftoppm`/`pdftotext` first.
2. **Brand discovery ran ~137s (23%) for an already-known brand** (`aaa`), inserting nothing. **Fix (prompt):** a `BUDGET GATE` atop Phase 2.6 — one cheap registry SELECT; a known brand ends there, no further reasoning / WebSearch / re-UPSERT.

`PROMPT_VERSION` 2.21 → 2.22.

## Verification
- [x] `tsc --noEmit` passes; prompt renders clean (ctx interpolates in the `pdftoppm` hint, no template leaks)
- [x] Post-deploy on the mini: `pdftoppm` present; rasterized the exact AAA PDF (2 pages → PNG) in **752 ms** vs the ~400s hand-decode it replaces
- [ ] Full end-to-end re-run needs a fresh (non-dedup) PDF — expect the PDF-reading + known-brand phases to collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)