### PR TITLE
prompt: version-control lessons.md, own the curation cadence (v2.23)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,12 @@ WORKDIR /app
 # Copy compiled output and production node_modules from the builder stage.
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
+# Curated lessons file (self-evolution loop) ships WITH the prompt: it is
+# version-controlled source, read at runtime by buildExtractorPrompt via a
+# path relative to the compiled module. tsc does not copy .md, so place it
+# next to dist/ingest/prompt.js explicitly. lessons.proposed.md (the agent's
+# raw proposals) is NOT here — it stays a runtime bind-mount on the mini.
+COPY --from=builder /app/src/ingest/lessons.md ./dist/ingest/lessons.md
 # Drizzle migrations (SQL files + journal) ship with the image — the
 # migrate runner resolves `<app>/drizzle/` at boot to apply any pending
 # schema changes. Committing these into the image is deliberate: it means

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,15 +123,14 @@ services:
       # outside iCloud. On a fresh machine:
       #   mkdir -p ~/Developer/receipt-assistant-data/product-assets
       - ${HOME}/Developer/receipt-assistant-data/product-assets:/data/product-assets
-      # Curated self-evolution loop (prompt-lessons). Two files:
-      #   lessons.md          — human-reviewed active lessons, READ into the
-      #                         extractor prompt by buildExtractorPrompt().
-      #   lessons.proposed.md — append-only agent PROPOSALS (one line/run),
-      #                         reviewed by a human who promotes good ones
-      #                         into lessons.md. The agent never reads this.
+      # Self-evolution loop — RUNTIME half only. The agent appends one-line
+      # PROPOSALS per run to `lessons.proposed.md` here (raw, unvetted,
+      # ephemeral until curated). The curated `lessons.md` is NOT here — it
+      # is version-controlled (src/ingest/lessons.md, baked into the image)
+      # and read from beside the compiled prompt. A human promotes good
+      # proposals out of lessons.proposed.md into the repo's lessons.md.
       # SIBLING dir, same rationale as claude / brand-assets: runtime state,
       # outside git and outside iCloud. On a fresh machine:
       #   mkdir -p ~/Developer/receipt-assistant-data/prompt-lessons
-      #   touch    ~/Developer/receipt-assistant-data/prompt-lessons/lessons.md
       - ${HOME}/Developer/receipt-assistant-data/prompt-lessons:/data/prompt-lessons
     restart: unless-stopped

--- a/src/ingest/lessons.md
+++ b/src/ingest/lessons.md
@@ -1,0 +1,12 @@
+# Curated extractor lessons — human-reviewed, one per line.
+#
+# These are promoted (via the agent-evolver skill / a human) from the
+# runtime `lessons.proposed.md` the agent appends to on the mini. Every
+# non-'#' line below is injected VERBATIM into the extractor prompt as
+# high-priority guidance, so keep each one short, specific, and evidence-
+# based. Lines starting with '#' are comments and are NOT injected.
+#
+# Promotion is a normal repo change: add the line here, commit, deploy.
+# See .claude/skills/agent-evolver/SKILL.md (Diagnose → Step 0).
+
+- [receipt_pdf] The printed transaction date can differ from the PDF's CreationDate metadata (the template/software date). Trust the printed receipt date, not the file metadata. (Promoted 2026-07-19 from an AAA/Club Assist invoice.)

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -8,6 +8,7 @@
  * (Node-side coerce + service-layer writes) to Phase 2.
  */
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { buildInfo } from "../generated/build-info.js";
 import {
   PHASE_2_6_BRAND_DISCOVERY,
@@ -22,7 +23,7 @@ import {
  * `extraction.prompt_version` ≠ `PROMPT_VERSION` are eligible to be
  * re-derived. See #80 / #88 for the 3-layer data model rationale.
  */
-export const PROMPT_VERSION = "2.22";
+export const PROMPT_VERSION = "2.23";
 
 export interface ExtractorPromptContext {
   /** Absolute path inside the container where the file was staged. */
@@ -64,32 +65,48 @@ upload. The SQL candidate check below still applies.)`;
 /**
  * Curated self-evolution loop (#prompt-lessons).
  *
- * `lessons.md` is a SHORT, HUMAN-REVIEWED list of lessons distilled from
- * past extraction runs. The agent never edits it directly — at the end of
- * a noteworthy run it appends a one-line PROPOSAL to `lessons.proposed.md`
- * (a separate file), and a human promotes good proposals into `lessons.md`.
- * This keeps the feedback loop "agent proposes → human gatekeeps", so the
- * prompt can only be improved by vetted lessons, never self-poisoned.
+ * Two files, two homes, by design:
+ *   • `lessons.md` — the curated, human-reviewed lesson set. VERSION-
+ *     CONTROLLED: it lives next to this module (`src/ingest/lessons.md`,
+ *     baked into the image at `dist/ingest/lessons.md`) and ships with the
+ *     prompt. It is small, non-sensitive, non-PII, and hand-curated —
+ *     irreplaceable knowledge that belongs in git with a review trail, so
+ *     the data-tiering "keep out of git" rule (which guards sensitive /
+ *     PII / regenerable state) does not apply. Read fresh per call; lines
+ *     starting with `#` are comments and are NOT injected.
+ *   • `lessons.proposed.md` — the agent's raw per-run PROPOSALS (Phase 6).
+ *     RUNTIME-ONLY on the mini (`/data/prompt-lessons/`, a bind-mount):
+ *     ephemeral, unvetted agent output, appended to and never read back.
  *
- * Path is a dedicated bind-mount (`~/Developer/receipt-assistant-data/
- * prompt-lessons` → `/data/prompt-lessons`): runtime state, not in any git
- * repo and not in iCloud, matching the data-tiering invariant. Read fresh
- * per call so promoting a lesson takes effect without a container restart.
- * Absent/empty/unreadable (e.g. local dev has no mount) → inject nothing.
+ * Flow: the agent appends a proposal → a human (via the agent-evolver
+ * skill) promotes good ones into `lessons.md` as a normal repo change +
+ * deploy. "agent proposes → human gatekeeps", so the prompt improves only
+ * via vetted lessons, never self-poisons. Missing/empty/unreadable →
+ * inject nothing (local dev without the file is fine).
  */
-const LESSONS_DIR = process.env.PROMPT_LESSONS_DIR ?? "/data/prompt-lessons";
-const ACTIVE_LESSONS_PATH = `${LESSONS_DIR}/lessons.md`;
-/** Append-only proposal file the agent writes (Phase 6); never read back. */
-const PROPOSED_LESSONS_PATH = `${LESSONS_DIR}/lessons.proposed.md`;
+const ACTIVE_LESSONS_PATH =
+  process.env.PROMPT_LESSONS_FILE ??
+  fileURLToPath(new URL("./lessons.md", import.meta.url));
+/** Append-only proposal file the agent writes (Phase 6); never read back.
+ *  Runtime-only bind-mount on the mini. */
+const PROPOSED_LESSONS_PATH =
+  process.env.PROMPT_LESSONS_PROPOSED ??
+  "/data/prompt-lessons/lessons.proposed.md";
 
 function renderActiveLessons(): string {
   let raw = "";
   try {
-    raw = readFileSync(ACTIVE_LESSONS_PATH, "utf8").trim();
+    raw = readFileSync(ACTIVE_LESSONS_PATH, "utf8");
   } catch {
     return "";
   }
-  if (!raw) return "";
+  // Drop comment lines (start with '#') and blanks; keep only lesson lines.
+  const body = raw
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .join("\n")
+    .trim();
+  if (!body) return "";
   return `
 ── Learned lessons (curated, human-reviewed — apply these) ────────────
 
@@ -98,7 +115,7 @@ They encode real mistakes and wins from earlier runs; treat them as
 high-priority guidance that overrides your default habits where they
 conflict. (These are vetted rules, NOT your own proposals.)
 
-${raw}
+${body}
 `;
 }
 


### PR DESCRIPTION
## Summary
Formalizes the self-evolution loop (follow-up to #176/#177) per the design decision:

- **`lessons.md` → version-controlled** at `src/ingest/lessons.md`, baked into the image (Dockerfile `COPY`), read beside the compiled prompt via `import.meta.url`. It's small, non-sensitive, non-PII, hand-curated knowledge — the data-tiering "keep out of git" rule (sensitive / PII / regenerable) doesn't apply, and runtime-only left it with **zero backup** (mini disk only). Now: durability + a git review trail. `#` lines are comments (not injected).
- **`lessons.proposed.md` stays runtime-only** on the mini (raw, ephemeral agent output). Compose comment updated.
- **Seeded the first curated lesson** — the durable half of the AAA agent's proposal (trust printed date over PDF `CreationDate`); the obsolete half (hand-decode PDFs) dropped now poppler is installed. Demonstrates the full loop: agent proposed → human vetted → promoted → injected.
- **agent-evolver skill now owns the curation cadence** (Diagnose Step 0: triage `lessons.proposed.md` → quick-promote or escalate). Skill lives in the iCloud project, not this repo.

`PROMPT_VERSION` 2.22 → 2.23.

## Verification
- [x] `tsc` passes; render confirms the seeded lesson injects and `#` comments are filtered; no template leaks
- [ ] Post-deploy: container reads `dist/ingest/lessons.md` and injects the seeded lesson

🤖 Generated with [Claude Code](https://claude.com/claude-code)