### PR TITLE
lessons: promote 3 curated lessons (dates, voucher tender, CA parts-tax)

### DIFF
--- a/src/ingest/lessons.md
+++ b/src/ingest/lessons.md
@@ -10,3 +10,6 @@
 # See .claude/skills/agent-evolver/SKILL.md (Diagnose → Step 0).
 
 - [receipt_pdf] The printed transaction date can differ from the PDF's CreationDate metadata (the template/software date). Trust the printed receipt date, not the file metadata. (Promoted 2026-07-19 from an AAA/Club Assist invoice.)
+- [receipt_pdf] Dealer/service invoices (Lexus/CDK and similar layouts) print vehicle-registration dates (DEL DATE / PROD DATE) near the top; the transaction date is the INV DATE / R.O.-opened date. Do not grab the earliest date on the page. (Promoted 2026-07-19.)
+- [receipt] When a voucher / Groupon / gift card splits the tender, total_minor is the residual card charge that reconciles to the bank/card statement, NOT the pre-voucher printed total. Treat the voucher like a gift card. (Promoted 2026-07-19.)
+- [receipt] California service receipts often tax parts only (labor is tax-exempt): recover the rate from tax ÷ parts_subtotal and allocate tax across the parts lines, not labor. (Promoted 2026-07-19.)


### PR DESCRIPTION
First live run of the agent-evolver curation cadence (Diagnose Step 0). Triaged the 7-item `lessons.proposed.md` queue: **promoted 3** broadly-useful (dealer date disambiguation, voucher/gift-card tender = residual card charge, CA parts-only tax allocation), **held 2** format-specific in the queue, **dropped 2** obsolete (PDF hand-decode, moot post-poppler). No `PROMPT_VERSION` bump — additive guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)