### PR TITLE
feat(ingest): surface & retry failed/non-extracted ingests (#158)

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3267,6 +3267,16 @@
           }
         }
       },
+      "IngestCategory": {
+        "type": "string",
+        "enum": [
+          "ok",
+          "in_progress",
+          "transient_actionable",
+          "input_problem",
+          "informational"
+        ]
+      },
       "Ingest": {
         "type": "object",
         "properties": {
@@ -3315,6 +3325,20 @@
               "null"
             ]
           },
+          "category": {
+            "$ref": "#/components/schemas/IngestCategory"
+          },
+          "retryable": {
+            "type": "boolean"
+          },
+          "dedup_of": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time"
@@ -3338,6 +3362,9 @@
           "classification",
           "produced",
           "error",
+          "category",
+          "retryable",
+          "dedup_of",
           "created_at",
           "completed_at"
         ]
@@ -3533,6 +3560,33 @@
           "batchId",
           "status",
           "items",
+          "poll"
+        ]
+      },
+      "RetryIngestResponse": {
+        "type": "object",
+        "properties": {
+          "retried_ingest_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "batch_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "ingest": {
+            "$ref": "#/components/schemas/Ingest"
+          },
+          "poll": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "retried_ingest_id",
+          "batch_id",
+          "ingest",
           "poll"
         ]
       },
@@ -8788,7 +8842,9 @@
           },
           {
             "schema": {
-              "$ref": "#/components/schemas/IngestStatus"
+              "type": "string",
+              "description": "Filter by ingest status. Single value or comma-separated set, e.g. `error,unsupported,dedup,near_dup`.",
+              "example": "error,unsupported"
             },
             "required": false,
             "name": "status",
@@ -8827,6 +8883,84 @@
         }
       }
     },
+    "/v1/ingests/problems": {
+      "get": {
+        "summary": "List uploads needing attention (#158) — every ingest that didn't reach `done` and isn't still in flight (default: error, unsupported, dedup, near_dup). Each row carries `category`, `retryable`, and `dedup_of` so a client can choose the right affordance without string-parsing `error`.",
+        "tags": [
+          "ingest"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Override the default problem set. Comma-separated ingest statuses; defaults to `error,unsupported,dedup,near_dup`.",
+              "example": "error"
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated problem ingests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Ingest"
+                      }
+                    },
+                    "next_cursor": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "next_cursor"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unknown status token in filter",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/ingests/{id}": {
       "get": {
         "summary": "Get one ingest with produced reverse-lookup",
@@ -8858,6 +8992,75 @@
           },
           "404": {
             "description": "Ingest not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/ingests/{id}/retry": {
+      "post": {
+        "summary": "Retry a failed/unsupported ingest (#158). Re-runs the original stored bytes through the batch pipeline (genuine-restore dedup branch — not suppressed). Returns 202 with the freshly-created ingest to poll. Only `error`/`unsupported` are retryable.",
+        "tags": [
+          "ingest"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Retry enqueued — poll the returned ingest / batch",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetryIngestResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ingest not found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Ingest is not in a retryable state",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Stored source bytes missing",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/src/http/problem.ts
+++ b/src/http/problem.ts
@@ -191,6 +191,43 @@ export class GooglePlacesUpstreamProblem extends HttpProblem {
   }
 }
 
+/**
+ * Returned by `POST /v1/ingests/:id/retry` when the ingest is in a
+ * state that cannot be re-run. Only `error` / `unsupported` ingests are
+ * retryable — `done` already succeeded, `queued`/`processing` are still
+ * in flight, and `dedup`/`near_dup` are duplicates whose canonical
+ * transaction is reachable via `dedup_of` (retrying would re-suppress).
+ */
+export class IngestNotRetryableProblem extends HttpProblem {
+  constructor(ingestId: string, status: string) {
+    super(
+      409,
+      "ingest-not-retryable",
+      "Ingest is not retryable",
+      `Ingest ${ingestId} has status='${status}'. Only 'error' and 'unsupported' ingests can be retried.`,
+      { ingest_id: ingestId, status },
+    );
+  }
+}
+
+/**
+ * Returned by `POST /v1/ingests/:id/retry` when the stored bytes for the
+ * ingest can no longer be read from disk (evicted, or the uploads volume
+ * was reset). Retry re-runs the original bytes, so a missing file is a
+ * hard stop — the caller must re-upload the source document.
+ */
+export class IngestFileMissingProblem extends HttpProblem {
+  constructor(ingestId: string, filePath: string) {
+    super(
+      422,
+      "ingest-file-missing",
+      "Ingest source file missing",
+      `Ingest ${ingestId} references stored bytes at '${filePath}' that could not be read. Re-upload the document instead.`,
+      { ingest_id: ingestId, file_path: filePath },
+    );
+  }
+}
+
 export class DocumentHasLinksProblem extends HttpProblem {
   constructor(documentId: string, linkCount: number) {
     super(

--- a/src/routes/ingest.service.ts
+++ b/src/routes/ingest.service.ts
@@ -16,13 +16,23 @@
  */
 import { and, eq, desc, sql } from "drizzle-orm";
 import * as path from "path";
-import { mkdir, writeFile } from "fs/promises";
+import { mkdir, writeFile, readFile } from "fs/promises";
 import { db } from "../db/client.js";
 import { batches, ingests } from "../schema/index.js";
 import { newId } from "../http/uuid.js";
-import { NotFoundProblem } from "../http/problem.js";
+import {
+  NotFoundProblem,
+  ValidationProblem,
+  IngestNotRetryableProblem,
+  IngestFileMissingProblem,
+} from "../http/problem.js";
 import { enqueue, maybeCompleteBatch } from "../ingest/worker.js";
-import { uploadDocumentBytes, getUploadDir, extForMime } from "./documents.service.js";
+import {
+  uploadDocumentBytes,
+  getUploadDir,
+  extForMime,
+  resolveUploadPath,
+} from "./documents.service.js";
 import {
   clampLimit,
   decodeCursor,
@@ -32,6 +42,22 @@ import {
 
 // ── Row shapes (API layer) ────────────────────────────────────────────
 
+export type IngestStatus =
+  | "queued"
+  | "processing"
+  | "done"
+  | "error"
+  | "unsupported"
+  | "dedup"
+  | "near_dup";
+
+export type IngestCategory =
+  | "ok"
+  | "in_progress"
+  | "transient_actionable"
+  | "input_problem"
+  | "informational";
+
 export interface IngestRow {
   id: string;
   workspace_id: string;
@@ -39,7 +65,7 @@ export interface IngestRow {
   filename: string;
   mime_type: string | null;
   file_path: string;
-  status: "queued" | "processing" | "done" | "error" | "unsupported" | "dedup" | "near_dup";
+  status: IngestStatus;
   classification: string | null;
   produced: {
     receipt_ids: string[];
@@ -47,8 +73,107 @@ export interface IngestRow {
     document_ids: string[];
   } | null;
   error: string | null;
+  // #158 derived fields.
+  category: IngestCategory;
+  retryable: boolean;
+  dedup_of: string | null;
   created_at: string;
   completed_at: string | null;
+}
+
+// The set surfaced by `GET /v1/ingests/problems` when no explicit status
+// filter is given: everything that didn't reach `done` and isn't still in
+// flight. Ordered most-actionable first for readability.
+export const PROBLEM_INGEST_STATUSES: IngestStatus[] = [
+  "error",
+  "unsupported",
+  "dedup",
+  "near_dup",
+];
+
+const ALL_INGEST_STATUSES: readonly IngestStatus[] = [
+  "queued",
+  "processing",
+  "done",
+  "error",
+  "unsupported",
+  "dedup",
+  "near_dup",
+];
+
+// An `error` string matching this pattern is a transient/infrastructure
+// fault (expired auth, timeout, rate-limit, upstream 5xx) — re-running the
+// same bytes is likely to succeed once the outage clears. Anything else
+// (missing date, illegible, "no total") is treated as an input problem
+// where a blind retry won't help. Matches the 401 auth-expiry class that
+// motivated #158.
+const TRANSIENT_ERROR_RE =
+  /\b(401|403|429|500|502|503|504)\b|invalid authentication|unauthor|forbidden|timed?[ -]?out|timeout|rate.?limit|overloaded|econnreset|econnrefused|etimedout|network|socket hang up|fetch failed|temporarily|try again/i;
+
+/**
+ * Derive the reason bucket + affordance hints for one ingest (#158). Pure
+ * function of (status, error, produced) so both the list and problems
+ * endpoints stay consistent.
+ */
+export function categorizeIngest(
+  status: IngestStatus,
+  error: string | null,
+  produced: IngestRow["produced"],
+): { category: IngestCategory; retryable: boolean; dedup_of: string | null } {
+  switch (status) {
+    case "done":
+      return { category: "ok", retryable: false, dedup_of: null };
+    case "queued":
+    case "processing":
+      return { category: "in_progress", retryable: false, dedup_of: null };
+    case "dedup":
+    case "near_dup":
+      return {
+        category: "informational",
+        retryable: false,
+        dedup_of: produced?.transaction_ids?.[0] ?? null,
+      };
+    case "unsupported":
+      return { category: "input_problem", retryable: false, dedup_of: null };
+    case "error": {
+      const transient = TRANSIENT_ERROR_RE.test(error ?? "");
+      return {
+        category: transient ? "transient_actionable" : "input_problem",
+        retryable: transient,
+        dedup_of: null,
+      };
+    }
+  }
+}
+
+/**
+ * Parse the `status` query param — a single token or comma-separated set
+ * (#158). Returns null when absent (caller applies its own default).
+ * Throws NotFoundProblem-shaped ValidationProblem on unknown tokens.
+ */
+export function parseStatusFilter(raw: string | undefined): IngestStatus[] | null {
+  if (raw === undefined || raw.trim() === "") return null;
+  const tokens = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const out: IngestStatus[] = [];
+  for (const t of tokens) {
+    if (!(ALL_INGEST_STATUSES as readonly string[]).includes(t)) {
+      throw new ValidationProblem(
+        [
+          {
+            path: "status",
+            code: "invalid_enum_value",
+            message: `Unknown ingest status '${t}'. Allowed: ${ALL_INGEST_STATUSES.join(", ")}.`,
+          },
+        ],
+        `Unknown ingest status '${t}'`,
+      );
+    }
+    if (!out.includes(t as IngestStatus)) out.push(t as IngestStatus);
+  }
+  return out.length > 0 ? out : null;
 }
 
 export interface BatchCounts {
@@ -89,6 +214,12 @@ function toIso(v: Date | string | null | undefined): string | null {
 
 function mapIngestRow(r: typeof ingests.$inferSelect): IngestRow {
   const produced = (r.produced ?? null) as IngestRow["produced"];
+  const status = r.status as IngestStatus;
+  const { category, retryable, dedup_of } = categorizeIngest(
+    status,
+    r.error,
+    produced,
+  );
   return {
     id: r.id,
     workspace_id: r.workspaceId,
@@ -96,10 +227,13 @@ function mapIngestRow(r: typeof ingests.$inferSelect): IngestRow {
     filename: r.filename,
     mime_type: r.mimeType,
     file_path: r.filePath,
-    status: r.status as IngestRow["status"],
+    status,
     classification: r.classification,
     produced,
     error: r.error,
+    category,
+    retryable,
+    dedup_of,
     created_at: toIso(r.createdAt)!,
     completed_at: toIso(r.completedAt),
   };
@@ -565,7 +699,7 @@ export async function listIngests(params: {
   cursor?: string;
   limit?: number;
   batchId?: string;
-  status?: string;
+  statuses?: IngestStatus[];
 }): Promise<{ items: IngestRow[]; next_cursor: string | null }> {
   const limit = clampLimit(params.limit ?? DEFAULT_PAGE_LIMIT);
   const cur = decodeCursor<IngestListCursor>(params.cursor);
@@ -574,8 +708,13 @@ export async function listIngests(params: {
   ];
   if (params.batchId)
     whereParts.push(sql`batch_id = ${params.batchId}::uuid`);
-  if (params.status)
-    whereParts.push(sql`status = ${params.status}::ingest_status`);
+  if (params.statuses && params.statuses.length > 0) {
+    const list = sql.join(
+      params.statuses.map((s) => sql`${s}::ingest_status`),
+      sql`, `,
+    );
+    whereParts.push(sql`status IN (${list})`);
+  }
   if (cur) {
     whereParts.push(
       sql`(created_at, id) < (${cur.created_at}::timestamptz, ${cur.id}::uuid)`,
@@ -616,4 +755,69 @@ export async function listIngests(params: {
     });
   }
   return { items, next_cursor };
+}
+
+// ── Retry (#158) ──────────────────────────────────────────────────────
+
+/**
+ * Re-run a failed/unsupported ingest against its original stored bytes.
+ *
+ * Rather than surgically re-opening the (already terminal) batch, we route
+ * the stored bytes back through `createBatchFromFiles` — the normal upload
+ * pipeline. That reuses the full batch → worker → auto-reconcile lifecycle
+ * and, crucially, the L1 dedup "genuine restore" branch (#124): because the
+ * errored ingest produced no live transaction, `findLiveTransactionForDocument`
+ * returns null and nothing is in flight, so the byte-known input is enqueued
+ * for a real re-extract instead of being suppressed as a duplicate.
+ *
+ * The original errored ingest row is left intact as the historical record
+ * of the failure; the returned `ingest` is the freshly-created one the
+ * caller should poll.
+ *
+ * Guards: only `error` / `unsupported` are retryable. `done` already
+ * succeeded; `queued`/`processing` are still in flight; `dedup`/`near_dup`
+ * are duplicates whose canonical transaction is reachable via `dedup_of`.
+ */
+export async function retryIngest(
+  workspaceId: string,
+  id: string,
+): Promise<{
+  retried_ingest_id: string;
+  batch_id: string;
+  ingest: IngestRow;
+  poll: string;
+}> {
+  const original = await getIngest(workspaceId, id); // throws NotFound
+  if (original.status !== "error" && original.status !== "unsupported") {
+    throw new IngestNotRetryableProblem(id, original.status);
+  }
+
+  const abs = resolveUploadPath(original.file_path);
+  let bytes: Buffer;
+  try {
+    bytes = await readFile(abs);
+  } catch {
+    throw new IngestFileMissingProblem(id, original.file_path);
+  }
+
+  const { batch, items } = await createBatchFromFiles({
+    workspaceId,
+    files: [
+      {
+        originalName: original.filename,
+        mimeType: original.mime_type,
+        bytes,
+      },
+    ],
+    autoReconcile: true,
+  });
+
+  const newIngestId = items[0]!.ingestId;
+  const ingest = await getIngest(workspaceId, newIngestId);
+  return {
+    retried_ingest_id: id,
+    batch_id: batch.id,
+    ingest,
+    poll: `/v1/batches/${batch.id}`,
+  };
 }

--- a/src/routes/ingest.ts
+++ b/src/routes/ingest.ts
@@ -27,8 +27,10 @@ import {
   CreateBatchForm,
   CreateBatchResponse,
   Ingest,
+  IngestProblemsQuery,
   ListBatchesQuery,
   ListIngestsQuery,
+  RetryIngestResponse,
 } from "../schemas/v1/ingest.js";
 import {
   createBatchFromFiles,
@@ -36,6 +38,9 @@ import {
   getIngest,
   listBatches,
   listIngests,
+  parseStatusFilter,
+  retryIngest,
+  PROBLEM_INGEST_STATUSES,
 } from "./ingest.service.js";
 import { keepalive, sendEvent, setSseHeaders } from "../http/sse.js";
 import { on as busOn } from "../events/bus.js";
@@ -266,7 +271,27 @@ ingestsRouter.get(
       cursor: q.cursor,
       limit: q.limit,
       batchId: q.batch_id,
-      status: q.status,
+      statuses: parseStatusFilter(q.status) ?? undefined,
+    });
+    emitNextLink(req, res, out.next_cursor);
+    res.json(out);
+  }),
+);
+
+// Problem inbox (#158): every upload that didn't reach `done` and isn't
+// still in flight, enriched with `category` / `retryable` / `dedup_of` so a
+// client can render "retry" vs "view duplicate" vs "explain" without
+// string-parsing `error`. Registered BEFORE `/:id` so `problems` isn't
+// captured as an id param.
+ingestsRouter.get(
+  "/problems",
+  asyncHandler(async (req, res) => {
+    const q = parseOrThrow(IngestProblemsQuery, req.query);
+    const out = await listIngests({
+      workspaceId: req.ctx.workspaceId,
+      cursor: q.cursor,
+      limit: q.limit,
+      statuses: parseStatusFilter(q.status) ?? PROBLEM_INGEST_STATUSES,
     });
     emitNextLink(req, res, out.next_cursor);
     res.json(out);
@@ -282,6 +307,18 @@ ingestsRouter.get(
   }),
 );
 
+// Retry a failed/unsupported ingest against its original stored bytes
+// (#158). Returns the freshly-created ingest to poll.
+ingestsRouter.post(
+  "/:id/retry",
+  asyncHandler(async (req, res) => {
+    const { id } = parseOrThrow(IdParam, req.params);
+    const out = await retryIngest(req.ctx.workspaceId, id);
+    res.setHeader("Location", out.poll);
+    res.status(202).json(out);
+  }),
+);
+
 // ── OpenAPI registration ──────────────────────────────────────────────
 
 export function registerIngestOpenApi(registry: OpenAPIRegistry): void {
@@ -290,6 +327,7 @@ export function registerIngestOpenApi(registry: OpenAPIRegistry): void {
   registry.register("Ingest", Ingest);
   registry.register("CreateBatchForm", CreateBatchForm);
   registry.register("CreateBatchResponse", CreateBatchResponse);
+  registry.register("RetryIngestResponse", RetryIngestResponse);
 
   const problemContent = {
     "application/problem+json": { schema: ProblemDetails },
@@ -402,6 +440,31 @@ export function registerIngestOpenApi(registry: OpenAPIRegistry): void {
 
   registry.registerPath({
     method: "get",
+    path: "/v1/ingests/problems",
+    summary:
+      "List uploads needing attention (#158) — every ingest that didn't " +
+      "reach `done` and isn't still in flight (default: " +
+      "error, unsupported, dedup, near_dup). Each row carries `category`, " +
+      "`retryable`, and `dedup_of` so a client can choose the right " +
+      "affordance without string-parsing `error`.",
+    tags: ["ingest"],
+    request: { query: IngestProblemsQuery },
+    responses: {
+      200: {
+        description: "Paginated problem ingests",
+        content: {
+          "application/json": { schema: paginated(Ingest) },
+        },
+      },
+      422: {
+        description: "Unknown status token in filter",
+        content: problemContent,
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
     path: "/v1/ingests/{id}",
     summary: "Get one ingest with produced reverse-lookup",
     tags: ["ingest"],
@@ -412,6 +475,34 @@ export function registerIngestOpenApi(registry: OpenAPIRegistry): void {
         content: { "application/json": { schema: Ingest } },
       },
       404: { description: "Ingest not found", content: problemContent },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/ingests/{id}/retry",
+    summary:
+      "Retry a failed/unsupported ingest (#158). Re-runs the original " +
+      "stored bytes through the batch pipeline (genuine-restore dedup " +
+      "branch — not suppressed). Returns 202 with the freshly-created " +
+      "ingest to poll. Only `error`/`unsupported` are retryable.",
+    tags: ["ingest"],
+    request: { params: z.object({ id: Uuid }) },
+    responses: {
+      202: {
+        description: "Retry enqueued — poll the returned ingest / batch",
+        headers: { Location: { schema: { type: "string" } } },
+        content: { "application/json": { schema: RetryIngestResponse } },
+      },
+      404: { description: "Ingest not found", content: problemContent },
+      409: {
+        description: "Ingest is not in a retryable state",
+        content: problemContent,
+      },
+      422: {
+        description: "Stored source bytes missing",
+        content: problemContent,
+      },
     },
   });
 }

--- a/src/schemas/v1/ingest.ts
+++ b/src/schemas/v1/ingest.ts
@@ -36,6 +36,25 @@ export const IngestClassification = z
   ])
   .openapi("IngestClassification");
 
+// Derived reason bucket (#158) so a client can pick the right affordance
+// without string-parsing `error`:
+//   ok                  → reached `done`, produced a transaction.
+//   in_progress         → still `queued` / `processing`.
+//   transient_actionable→ `error` from auth/timeout/rate-limit/upstream 5xx;
+//                          retrying the same bytes is likely to succeed.
+//   input_problem       → `unsupported`, or an `error` that looks like a
+//                          bad/unreadable input; user should replace/correct.
+//   informational       → `dedup` / `near_dup`; not an error. See `dedup_of`.
+export const IngestCategory = z
+  .enum([
+    "ok",
+    "in_progress",
+    "transient_actionable",
+    "input_problem",
+    "informational",
+  ])
+  .openapi("IngestCategory");
+
 // ── produced provenance ───────────────────────────────────────────────
 
 export const IngestProduced = z
@@ -60,6 +79,13 @@ export const Ingest = z
     classification: IngestClassification.nullable(),
     produced: IngestProduced.nullable(),
     error: z.string().nullable(),
+    // #158 — derived reason bucket + affordance hints. `category` and
+    // `retryable` are computed from (status, error); `dedup_of` surfaces
+    // the pre-existing transaction for a `dedup`/`near_dup` row so the
+    // client can deep-link "already in your ledger → view it".
+    category: IngestCategory,
+    retryable: z.boolean(),
+    dedup_of: Uuid.nullable(),
     created_at: IsoDateTime,
     completed_at: IsoDateTime.nullable(),
   })
@@ -154,5 +180,50 @@ export const ListIngestsQuery = z.object({
   cursor: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(500).optional(),
   batch_id: Uuid.optional(),
-  status: IngestStatus.optional(),
+  // Single status OR a comma-separated set, e.g.
+  // `status=error,unsupported,dedup,near_dup` (#158). Unknown tokens are
+  // rejected 422 by the service.
+  status: z
+    .string()
+    .optional()
+    .openapi({
+      description:
+        "Filter by ingest status. Single value or comma-separated set, " +
+        "e.g. `error,unsupported,dedup,near_dup`.",
+      example: "error,unsupported",
+    }),
 });
+
+// `GET /v1/ingests/problems` — same shape minus `batch_id`. When `status`
+// is omitted the service defaults to the non-`done`, non-in-flight set
+// (`error,unsupported,dedup,near_dup`).
+export const IngestProblemsQuery = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+  status: z
+    .string()
+    .optional()
+    .openapi({
+      description:
+        "Override the default problem set. Comma-separated ingest " +
+        "statuses; defaults to `error,unsupported,dedup,near_dup`.",
+      example: "error",
+    }),
+});
+
+// ── Retry ─────────────────────────────────────────────────────────────
+
+// `POST /v1/ingests/:id/retry` re-runs the original stored bytes through
+// the normal batch pipeline. The genuine-restore branch of L1 dedup means
+// the byte-known input is NOT suppressed (the errored ingest produced no
+// live transaction). Returns the freshly-created ingest so the caller can
+// poll it; `ingest.status` is `queued` normally, or `dedup` if in the
+// meantime the same purchase was ingested another way.
+export const RetryIngestResponse = z
+  .object({
+    retried_ingest_id: Uuid,
+    batch_id: Uuid,
+    ingest: Ingest,
+    poll: z.string(),
+  })
+  .openapi("RetryIngestResponse");


### PR DESCRIPTION
Closes #158.

## Problem

Every upload creates an `ingests` row, but anything that didn't reach `status='done'` was invisible in-product — the reason lived only in `ingests.status`/`error`, readable only via a hand `psql` query. Receipts a user meant to file could fail silently. The motivating incident: the 2026-06-23 Claude-OAuth 401 outage silently dropped 6 receipts; recovery meant querying the table by hand, `docker cp`-ing each file out, and re-`POST`ing the batch manually.

## What this ships (backend slice)

- **`GET /v1/ingests/problems`** — the "needs attention" inbox: every ingest that didn't reach `done` and isn't still in flight (default `error,unsupported,dedup,near_dup`), paginated.
- **`GET /v1/ingests?status=error,unsupported,…`** — the list endpoint now accepts a **comma-separated status set** (single value still works); an unknown token → `422`.
- **Derived fields on every `Ingest`** — `category` (`ok | in_progress | transient_actionable | input_problem | informational`), `retryable`, and `dedup_of`, so a client picks the right affordance (retry / view-duplicate / explain) **without string-parsing `error`**. `dedup`/`near_dup` expose the pre-existing transaction via `dedup_of`.
- **`POST /v1/ingests/:id/retry`** — re-runs the original stored bytes through `createBatchFromFiles`, reusing the full batch → worker → auto-reconcile lifecycle and the L1-dedup **genuine-restore** branch (#124), so a byte-known errored input is re-extracted, not suppressed. Returns `202` + the freshly-created ingest to poll. Only `error`/`unsupported` are retryable (`409` otherwise); missing source bytes → `422`.

## Reason taxonomy

| status | category | retryable | affordance |
|---|---|---|---|
| `error` (401/timeout/5xx/rate-limit) | `transient_actionable` | ✅ | Retry |
| `error` (bad/illegible input) | `input_problem` | ❌ | Explain / replace |
| `unsupported` | `input_problem` | ❌ | Explain / replace |
| `dedup` / `near_dup` | `informational` | ❌ | "Already in ledger" → `dedup_of` |

## Files
- `src/schemas/v1/ingest.ts` — `IngestCategory`, derived fields on `Ingest`, comma-status query, `IngestProblemsQuery`, `RetryIngestResponse`.
- `src/routes/ingest.service.ts` — `categorizeIngest`, `parseStatusFilter`, multi-status `listIngests`, `retryIngest`.
- `src/routes/ingest.ts` — `/problems` (before `/:id`), `/:id/retry`, OpenAPI registration.
- `src/http/problem.ts` — `IngestNotRetryableProblem` (409), `IngestFileMissingProblem` (422).
- `openapi/openapi.json` — regenerated.

## Verification (live, rebuilt container)

- `GET /v1/ingests/problems` returns categorized rows; `dedup`/`near_dup` carry `dedup_of`.
- Comma multi-status filter works; unknown token → `422`.
- A simulated `401 Invalid authentication credentials` ingest → `category=transient_actionable`, `retryable=true`.
- `POST /retry`: `done` → `409 ingest-not-retryable`; unknown → `404`.
- **End-to-end retry** of the simulated 401 ingest re-enqueued the bytes (genuine-restore, not dedup), the worker ran the real agent, and it produced a **balanced `posted` transaction** (Credit Card + Food & Drinks, balance 0) with a `document_link`. All test artifacts were then removed; DB restored to pre-test state.

## Follow-ups (out of scope here)
- **Frontend**: a "Needs attention" inbox consuming this API — child issue to be filed in `receipt-assistant-frontend` and linked both ways.
- **Auto-retry** `transient_actionable` ingests once auth/health recovers (the issue's suggested companion), so a transient outage self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsgwR6kwmhi6ciJb7yw6mG