### PR TITLE
refactor(ingest): one source of truth for the extraction contract (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Postgres (managed via Drizzle migrations in `drizzle/`). The receipt-as-flat-row
 |---|---|
 | `documents` | Uploaded receipt images / PDFs. Content-deduped per workspace by `sha256`. Soft-delete column `deleted_at`. |
 | `document_links` | Many-to-many between `documents` and `transactions`. |
-| `transactions` | Ledger header. `status ∈ {draft, posted, voided, reconciled, error}`; `voided_by_id` points to the mirror reversal row. |
+| `transactions` | Ledger header. Writable `status ∈ {draft, posted, reconciled, error}` — voids were removed in #170/#173 (`voided_by_id` dropped in `drizzle/0033`; the `voided` value survives in the `txn_status` PG enum only as a vestigial leftover, and nothing writes it). Soft delete is `deleted_at`. |
 | `postings` | The individual debit/credit lines under a transaction. Sum-to-zero is enforced by a deferred check trigger. |
 | `places` | Geocoded merchant location, FK from `transactions.place_id`. |
 | `transaction_events` | Append-only audit log. |
@@ -221,8 +221,8 @@ Distinct from `transactions.metadata.extraction.model` (#88) because OCR text an
 
 ```ts
 HARD_LAYER3_TX_FIELDS = [
-  "status",            // explicit user actions (void/reconcile)
-  "voided_by_id",
+  "status",            // explicit user actions (reconcile/un-reconcile)
+  "deleted_at",        // soft delete/restore — never resurrected by extraction
   "trip_id",           // user-assigned grouping
   "narration",         // user notes
   "id",                // immutable identity
@@ -280,7 +280,7 @@ POST /v1/documents/{id}/re-extract    # re-OCR + UPDATE linked transaction
 
 ### Layer-3 shielding (the safety contract)
 
-**HARD Layer 3** (`HARD_LAYER3_TX_FIELDS` in `src/projection/layer3.ts`): `status`, `voided_by_id`, `trip_id`, `narration`, `id`, `workspace_id`, `source_ingest_id`, `created_by`, `created_at`, `version`. The prompt's UPDATE doesn't mention these columns at all (omission = perfect shielding). `version` is the lone exception — re-extract always bumps it via `version + 1` to advance optimistic-concurrency.
+**HARD Layer 3** (`HARD_LAYER3_TX_FIELDS` in `src/projection/layer3.ts`): `status`, `deleted_at`, `trip_id`, `narration`, `id`, `workspace_id`, `source_ingest_id`, `created_by`, `created_at`, `version`. The prompt's UPDATE doesn't mention these columns at all (omission = perfect shielding). `version` is the lone exception — re-extract always bumps it via `version + 1` to advance optimistic-concurrency.
 
 **SOFT Layer 3** (`SOFT_LAYER3_TX_FIELDS`): `payee`, `occurred_on`, `occurred_at`. The agent generates new values but the SQL wraps them in CASE expressions:
 
@@ -314,7 +314,7 @@ The `session_id` field in the response is the pre-allocated UUID passed to `clau
 
 ### Idempotency, sort of
 
-Re-running re-extract on the same document with the same `REEXTRACT_PROMPT_VERSION` and model should produce no Layer-2 diff in the *transaction* (the agent should produce the same payee/date). It will always produce a `metadata.extraction` diff (the `ran_at` timestamp moves) and may produce an `ocr_text` diff (vision OCR is not 100% deterministic — punctuation, line-break differences). The `derivation_events` row is written every time regardless, so the audit trail tracks every re-run.
+Re-running re-extract on the same document with the same `PROMPT_VERSION` and model should produce no Layer-2 diff in the *transaction* (the agent should produce the same payee/date). It will always produce a `metadata.extraction` diff (the `ran_at` timestamp moves) and may produce an `ocr_text` diff (vision OCR is not 100% deterministic — punctuation, line-break differences). The `derivation_events` row is written every time regardless, so the audit trail tracks every re-run.
 
 ## Known Pitfalls
 
@@ -333,11 +333,14 @@ Re-running re-extract on the same document with the same `REEXTRACT_PROMPT_VERSI
    or a 9? Given the date context…") which improves ambiguous OCR.
 
    **Current solution**: Single-call agent pipeline
-   (`src/claude.ts::processReceipt`). One `claude -p` invocation reads
-   the image, reasons in plain text, and writes the extracted fields
-   to Postgres via a `psql` tool call — **no JSON-schema coercion
-   anywhere in the flow**. A placeholder receipt row is seeded at
-   upload time and `UPDATE`d by the agent.
+   (`src/ingest/prompt.ts::buildExtractorPrompt` →
+   `src/ingest/extractor.ts::defaultClaudeExtractor`). One `claude -p`
+   invocation reads the image, reasons in plain text, and writes the
+   whole v1 ledger transaction to Postgres via `psql` tool calls —
+   **no JSON-schema coercion anywhere in the flow**. The pre-v1
+   `src/claude.ts::processReceipt` that used to own this was deleted
+   in #164; `src/claude.ts` now only exports `runClaude` /
+   `detectPsqlCommand` for `src/insights/ask.ts`.
 
    An earlier two-phase variant (Phase 1: image → plain-text OCR;
    Phase 2: separate `claude -p` call structuring the text into JSON
@@ -386,7 +389,7 @@ When you change a schema or add a new endpoint:
 4. Run `npm run openapi:generate` to regenerate `openapi/openapi.json`.
 5. Commit the schema, route registration, handler, and regenerated spec **in the same commit**. A stale `openapi.json` misleads client codegen and breaks PR diffs.
 
-**Never inline a new `z.object()` directly in `server.ts`.** Schemas defined inline don't appear in the OpenAPI spec, so frontend / macOS / future clients can't see them. The `src/schemas/` + registry layout exists so a single source describes every endpoint.
+**Never inline a new `z.object()` directly in `server.ts`.** Schemas defined inline don't appear in the OpenAPI spec, so the frontend and any future client can't see them. The `src/schemas/` + registry layout exists so a single source describes every endpoint.
 
 Pinned to `@asteasolutions/zod-to-openapi` v7 because the repo uses zod v3. v8 requires zod v4 — bump both together in a dedicated PR if/when needed.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ An open-source, AI-native receipt parsing backend that extracts structured data 
 
 ### Single-call agent pipeline
 
-`--json-schema` mode constrains Claude's output format and **degrades OCR accuracy** (4/10 dates wrong vs 0/10 with plain text), because it skips chain-of-thought reasoning. The current flow (`src/claude.ts::processReceipt`) is a **single `claude -p` invocation** that reads the image, reasons about ambiguous characters in plain text, and writes the extracted fields directly to Postgres via a `psql` tool call — no JSON-schema coercion anywhere. A placeholder receipt row is seeded at upload time and `UPDATE`d by the agent. Full A/B rationale and the prior two-phase variant (kept around for anyone benchmarking a return) live in [`CLAUDE.md`](CLAUDE.md#known-pitfalls).
+`--json-schema` mode constrains Claude's output format and **degrades OCR accuracy** (4/10 dates wrong vs 0/10 with plain text), because it skips chain-of-thought reasoning. The current flow (`src/ingest/prompt.ts::buildExtractorPrompt`, spawned by `src/ingest/extractor.ts`) is a **single `claude -p` invocation** that reads the image, reasons about ambiguous characters in plain text, and writes the whole balanced transaction directly to Postgres via `psql` tool calls — no JSON-schema coercion anywhere. Node never parses fields; it seeds the `ingests` row and waits for the agent to close it. Full A/B rationale and the prior two-phase variant (kept around for anyone benchmarking a return) live in [`CLAUDE.md`](CLAUDE.md#known-pitfalls).
+
+The rules the agent is given are **not** duplicated per prompt: `src/ingest/prompt-contract.ts`, `document-read-prompt.ts`, `line-item-prompt.ts` and `items-sql.ts` hold the single copy that both the ingest prompt and `reextract-prompt.ts` interpolate (#164).
 
 ### Quality & Business Flags
 
@@ -147,7 +149,7 @@ The machine-readable contract is `openapi/openapi.json` (committed; OpenAPI 3.1)
 
 ### OpenAPI contract (for client codegen)
 
-Frontend, macOS, and any future client generate typed bindings from `openapi/openapi.json` instead of hand-writing `fetch` / `URLSession` calls.
+The frontend, and any future client, generates typed bindings from `openapi/openapi.json` instead of hand-writing `fetch` calls.
 
 | File / command | Purpose |
 |---------------|---------|

--- a/docs/async-pipeline-rewrite.md
+++ b/docs/async-pipeline-rewrite.md
@@ -1,5 +1,9 @@
 # Async Pipeline Rewrite — Study & Reference Notes
 
+> ⚠️ **HISTORICAL — do not use as a code map.** This is a dated record of the April 2026 rewrite, kept for its A/B evidence and its bug post-mortems. The code it describes is gone: the pre-v1 `receipts` / `receipt_items` tables were replaced by the v1 double-entry ledger (#49), and `src/claude.ts::processReceipt` / `askClaude` / `getSessionJsonlPath` were **deleted in #164**. Every `processReceipt(...)` snippet below names a function that no longer exists. Today's extraction path is `src/ingest/prompt.ts::buildExtractorPrompt` → `src/ingest/extractor.ts::defaultClaudeExtractor` → the agent's own `psql` writes; `getSessionJsonlPath` lives in `src/langfuse.ts`.
+>
+> The one thing here that is still a live **invariant** is the `--json-schema` finding — never reintroduce it. See `CLAUDE.md` → Known Pitfalls.
+>
 > **Context**: Receipt Assistant backend, April 2026. This document captures the design decisions, experiments, bugs, and lessons from collapsing a 3-call Claude CLI pipeline into a single-call agent pipeline with async UX.
 >
 > **Related**: GitHub issue TINKPA/receipt-assistant#6

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -1,8 +1,5 @@
 import { spawn } from "child_process";
 import { randomUUID } from "crypto";
-import fs from "fs/promises";
-import path from "path";
-import os from "os";
 
 const DATABASE_URL = process.env.DATABASE_URL || "postgresql://postgres:postgres@localhost:5432/receipts";
 
@@ -16,16 +13,6 @@ function buildClaudeEnv(): NodeJS.ProcessEnv {
   delete env.CLAUDECODE;
   delete env.ANTHROPIC_API_KEY;
   return env;
-}
-
-/**
- * Compute the session JSONL path for a given session ID.
- * Claude Code mangles the CWD: replaces "/" and "_" with "-".
- * E.g. /Users/foo/my_project → -Users-foo-my-project
- */
-export function getSessionJsonlPath(sessionId: string): string {
-  const mangledCwd = process.cwd().replace(/[/_]/g, "-");
-  return path.join(os.homedir(), ".claude", "projects", mangledCwd, `${sessionId}.jsonl`);
 }
 
 /**
@@ -86,91 +73,4 @@ export async function detectPsqlCommand(): Promise<string> {
     // Fallback: use docker exec (local dev)
     return `docker exec langfuse-postgres-1 psql -U postgres -d receipts -c`;
   }
-}
-
-/**
- * Single-call agent pipeline: read receipt image and write to PostgreSQL.
- *
- * Claude reads the image, reasons in plain text (no --json-schema for
- * better OCR accuracy), then directly UPDATEs the receipt row and
- * INSERTs line items via psql.
- *
- * A placeholder row must already exist in the receipts table with the
- * given receiptId and status='processing'.
- *
- * Returns { sessionId } for Langfuse trace ingestion.
- */
-export async function processReceipt(imagePath: string, receiptId: string): Promise<{ sessionId: string }> {
-  const absPath = path.resolve(imagePath);
-  await fs.access(absPath);
-
-  const psqlCmd = await detectPsqlCommand();
-
-  const prompt = `You are a receipt parser agent. Read the receipt image at "${absPath}" and save extracted data to PostgreSQL.
-
-RULES:
-- merchant: Store/restaurant name from the receipt header/logo
-- date: YYYY-MM-DD format. Read from the receipt. NEVER use today's date as fallback.
-- total: FINAL amount paid (after tax, after tip). If there is a handwritten total, use that.
-- currency: USD/CNY/EUR/JPY etc. Detect from symbols ($ = USD, ¥ = context-dependent, € = EUR)
-- category: MUST be one of: food|groceries|transport|shopping|utilities|entertainment|health|education|travel|other
-- payment_method: MUST be one of: credit_card|debit_card|cash|mobile_pay|other
-- tax: tax amount if visible
-- tip: tip amount if visible (watch for handwritten tips)
-- address: full printed street address of the merchant if visible on the receipt (e.g. "11727 Olympic Blvd, Los Angeles, CA 90064"). Combine street, city, state, zip into one string. Use NULL if not visible — do NOT guess.
-- raw_text: full transcription of the receipt text
-- For each line item: name, quantity (default 1), unit_price, total_price
-
-DATABASE — run SQL via:
-${psqlCmd} "<SQL>"
-
-UPDATE the existing receipt row:
-UPDATE receipts SET merchant='...', date='...', total=<num>, currency='...', category='...', payment_method='...', tax=<num_or_null>, tip=<num_or_null>, address=<'...'_or_NULL>, raw_text='...', status='done', updated_at=NOW() WHERE id='${receiptId}';
-
-For each line item:
-INSERT INTO receipt_items (receipt_id, name, quantity, unit_price, total_price) VALUES ('${receiptId}', '...', <qty>, <price>, <total>);
-
-IMPORTANT: Escape single quotes in SQL values by doubling them ('').
-If you cannot confidently read a field, use NULL rather than guessing.`;
-
-  const args = [
-    "-p", prompt,
-    "--output-format", "text",
-    "--dangerously-skip-permissions",
-    "--model", process.env.CLAUDE_MODEL || "sonnet",
-  ];
-
-  const { sessionId } = await runClaude(args, 300_000);
-  return { sessionId };
-}
-
-/**
- * Ask Claude a free-form question about receipts (e.g. spending analysis).
- * Returns plain text response.
- */
-export async function askClaude(prompt: string): Promise<string> {
-  const args = [
-    "-p", prompt,
-    "--output-format", "text",
-    "--tools", "",
-    "--max-turns", "3",
-    "--model", process.env.CLAUDE_MODEL || "sonnet",
-  ];
-
-  const { stdout } = await runClaude(args, 60_000);
-
-  // Extract result from JSON output (single object or array)
-  try {
-    const parsed = JSON.parse(stdout);
-    const resultObj = Array.isArray(parsed)
-      ? parsed.find((m: any) => m.type === "result")
-      : (parsed.type === "result" ? parsed : null);
-    if (resultObj) {
-      return resultObj.result ?? "";
-    }
-  } catch {
-    // Fallback: return raw output
-  }
-
-  return stdout.trim();
 }

--- a/src/ingest/brand-icon-prompt.ts
+++ b/src/ingest/brand-icon-prompt.ts
@@ -7,6 +7,14 @@
  * full instructions in its prompt window. Don't reference these phases
  * by source-file path from the prompt; the agent will go looking for
  * `src/ingest/prompt.ts` and waste turns when it can't find it.
+ *
+ * PLAIN template literals, never `String.raw` (#164). These strings used
+ * to be `String.raw`, which passes escape sequences through verbatim —
+ * so the agent's window literally read `psql "\$DATABASE_URL"` and
+ * ``\`brands\``` with the backslashes still attached. When editing,
+ * remember that a plain literal DOES consume `\n` and a trailing `\`
+ * before a newline: shell line-continuations and literal `\n` format
+ * strings must be written doubled (`\\`, `\\n`).
  */
 
 /**
@@ -18,7 +26,7 @@
  * Skip silently to `metadata.icon_resolution='discovery_failed'` when
  * no domain can be found.
  */
-export const PHASE_2_6_BRAND_DISCOVERY = String.raw`── Phase 2.6 — Brand discovery & registry upsert (#101) ───────────────
+export const PHASE_2_6_BRAND_DISCOVERY = `── Phase 2.6 — Brand discovery & registry upsert (#101) ───────────────
 
 Goal: ensure every brand_id you emitted has a row in the global
 \`brands\` registry, with a canonical English name and (when
@@ -91,10 +99,11 @@ Already-cached brands cost only one SELECT. Most receipts hit cache.`;
  * loop and the cache pre-check naturally flows from 4b's classification
  * into 4c's input set.
  */
-export const PHASE_4B_4C_ICON_PIPELINE = String.raw`── Phase 4b — Mechanical icon acquisition (#101) ──────────────────────
+export const PHASE_4B_4C_ICON_PIPELINE = `── Phase 4b — Mechanical icon acquisition (#101) ──────────────────────
 
 For each unique merchant brand_id this run touched. Skip for
-\`unsupported\` and statement-row aggregates with no merchant.
+\`unsupported\` and statement-row aggregates with no merchant (ingest
+only — those classifications do not exist on the re-extract path).
 
 This phase saves every icon candidate it finds. It does NOT pick a
 winner — that's Phase 4c. The goal here is mechanical retention:
@@ -167,7 +176,7 @@ via separate Bash tool calls if you want.
 
     Skip this tier entirely if LOGODEV_SECRET_KEY is unset.
 
-    curl -sS -H "Authorization: Bearer \$LOGODEV_SECRET_KEY" \
+    curl -sS -H "Authorization: Bearer \$LOGODEV_SECRET_KEY" \\
       "https://api.logo.dev/search?q=<urlencoded canonical_name>" | jq -c '.'
 
     Iterate matches with plausible name/domain (cap 3). For each:
@@ -182,7 +191,7 @@ via separate Bash tool calls if you want.
     Compute the slug: lowercase, drop non-alphanumeric. E.g.
     "Best Buy" → "bestbuy".
 
-    curl -sS -o /tmp/si.svg -w '%{http_code} %{content_type}\n' \
+    curl -sS -o /tmp/si.svg -w '%{http_code} %{content_type}\\n' \\
       "https://cdn.simpleicons.org/<slug>"
 
     Only save if HTTP 200 AND content_type starts with "image/svg".
@@ -206,7 +215,7 @@ via separate Bash tool calls if you want.
     com.chagee.us.application on Android — the US-region variant). You
     can also reach the page from a WebSearch "<brand> google play".
 
-    curl -sSL "https://play.google.com/store/apps/details?id=<bundleId>&hl=en_US" \
+    curl -sSL "https://play.google.com/store/apps/details?id=<bundleId>&hl=en_US" \\
       -A "Mozilla/5.0" -o /tmp/gp.html
 
     The icon URL is exposed two ways — pick either:

--- a/src/ingest/document-read-prompt.ts
+++ b/src/ingest/document-read-prompt.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared "how to actually read the uploaded file" phase for the
+ * extraction and re-extraction prompts (#164).
+ *
+ * Both prompts inline this phase verbatim so the agent — which runs
+ * inside a container that doesn't have the source files — gets the
+ * full instructions in its prompt window. Don't reference this phase
+ * by source-file path from the prompt; the agent will go looking for
+ * `src/ingest/prompt.ts` and waste turns when it can't find it.
+ *
+ * Before #164 the re-extract prompt had NEITHER the PDF rasterization
+ * recipe nor the `.eml` MIME-decode one-liner — it just said "read the
+ * file", which is why email re-extracts produced empty `ocr_text`.
+ *
+ * PR #181 rewrites the PDF half of this to be text-layer-first; the
+ * text below is the pre-#181 render-first behavior, moved verbatim.
+ *
+ * Plain template literal, never `String.raw` — see `prompt-contract.ts`.
+ */
+export function phase0DocumentRead(opts: {
+  /** Container-absolute path of the file under extraction. */
+  filePath: string;
+  /** Per-run scratch directory, e.g. `/tmp/<ingestId>`. */
+  scratchDir: string;
+}): string {
+  return `── Reading the document (especially PDFs) ────────────────────────────
+
+For a PDF, do NOT hand-parse the byte structure (decompressing streams,
+mapping Form XObjects, sorting content-stream placements) — that path is
+slow and error-prone. Rasterize to an image and read the pixels, which is
+what you do best:
+
+  pdftoppm -png -r 200 "${opts.filePath}" ${opts.scratchDir}/page
+  # → ${opts.scratchDir}/page-1.png, page-2.png, …  then Read those PNGs.
+
+\`pdftoppm\` and \`pdftotext\` (poppler) plus \`gs\` (ghostscript) are
+installed. \`pdftotext -layout "${opts.filePath}" -\` gives a fast text
+layer for text-based PDFs; when the PDF is a flattened form or its text
+layer is empty/garbled, prefer the rasterized PNG. Only fall back to
+manual stream decoding if those tools are genuinely unavailable.
+
+**Decoding an \`.eml\` body.** The \`.eml\` body is MIME-encoded (quoted-printable
+or base64, sometimes with non-UTF-8 bytes). Do NOT try to read a raw
+base64 blob, and do NOT improvise your own decoder. Run exactly this
+tested one-liner (stdlib only — handles QP, base64, and charset quirks;
+note \`message_from_binary_file\` + \`policy=email.policy.default\`, both
+required):
+
+  python3 -c "import email,email.policy,sys; m=email.message_from_binary_file(open(sys.argv[1],'rb'),policy=email.policy.default); p=m.get_body(preferencelist=('html','plain')); print(p.get_content() if p else '(no text body found)')" "${opts.filePath}" > /tmp/email-body.txt
+
+then Read \`/tmp/email-body.txt\`. If (and only if) that command fails,
+fall back to reading the raw \`.eml\` directly — quoted-printable parts
+are human-readable as-is (ignore \`=3D\` and soft \`=\\n\` line-breaks).
+Try ONE approach at a time; never fire multiple decode attempts in
+parallel (see Tool discipline above).`;
+}

--- a/src/ingest/extractor.ts
+++ b/src/ingest/extractor.ts
@@ -83,6 +83,14 @@ function runClaude(
       "--session-id",
       sessionId,
     ];
+    // Only pin the model when CLAUDE_MODEL is explicitly set. Unset (the
+    // mini today) means the CLI picks its own default, and the prompt
+    // stamps `EXTRACTION_MODEL = "cli-default"` — which is the truth.
+    // Passing a hard-coded "sonnet" here would silently downgrade the
+    // model that has actually been running.
+    if (process.env.CLAUDE_MODEL) {
+      args.push("--model", process.env.CLAUDE_MODEL);
+    }
     const child = spawn("claude", args, {
       env: buildClaudeEnv(),
       stdio: ["ignore", "pipe", "pipe"],

--- a/src/ingest/items-sql.ts
+++ b/src/ingest/items-sql.ts
@@ -1,0 +1,237 @@
+/**
+ * Shared `items[]` → SQL fragments for the extraction and re-extraction
+ * prompts (#164).
+ *
+ * Both prompts inline these fragments verbatim so the agent — which runs
+ * inside a container that doesn't have the source files — gets the
+ * full instructions in its prompt window. Don't reference these
+ * fragments by source-file path from the prompt; the agent will go
+ * looking for `src/ingest/prompt.ts` and waste turns when it can't
+ * find it.
+ *
+ * Before #164 the brand FK guard, the 26-column `jsonb_to_recordset`
+ * type list, the products upsert, the `transaction_items` insert and
+ * the product-aggregate recompute existed as EIGHT hand-maintained
+ * copies across the two prompts. The only genuine deltas between the
+ * two copies are the four parameters below:
+ *
+ *   • merchant-id expression — `(SELECT id FROM m)` at ingest vs.
+ *     `(SELECT merchant_id FROM transactions WHERE id = TX)` on re-extract
+ *   • transaction-id expression — `tx.id` (a CTE) vs. a literal uuid
+ *   • extraction-run number — `1` vs. `(SELECT run FROM next_run)`
+ *   • the version constant — now shared (`prompt-contract.ts`)
+ *
+ * Plain template literals, never `String.raw` — see `prompt-contract.ts`.
+ */
+import { PROMPT_VERSION } from "./prompt-contract.js";
+
+/**
+ * The items JSON is ALWAYS embedded via PostgreSQL dollar-quoting.
+ * A single-quoted `'...'::jsonb` literal hard-fails on `McDonald's` /
+ * `12" pan` and silently rolls back the whole write — which is exactly
+ * what the re-extract path did on every apostrophe-bearing receipt
+ * before #164.
+ */
+export const ITEMS_JSON_EXPR = `$items$<ITEMS_JSON_ARRAY>$items$::jsonb`;
+
+/** The 26-column record type for `jsonb_to_recordset`. One copy. */
+const ITEM_RECORD_COLUMNS = `line_no int, parent_line_no int, raw_name text, normalized_name text,
+quantity numeric, unit text,
+unit_price_minor bigint, line_total_minor bigint, currency text,
+item_class text, durability_tier text, food_kind text,
+tags text[], confidence text,
+line_type text, product_key text, product_brand_id text,
+product_merchant_exclusive boolean, product_model text,
+product_color text, product_size text, product_variant text,
+product_sku text, product_manufacturer text,
+tax_minor bigint, tip_share_minor bigint, discount_share_minor bigint`;
+
+function indentBlock(text: string, pad: string): string {
+  return text
+    .split("\n")
+    .map((line) => (line.length > 0 ? pad + line : line))
+    .join("\n");
+}
+
+/**
+ * `jsonb_to_recordset(<items>) AS item(<26 columns>)`.
+ *
+ * @param pad leading whitespace for the continuation lines, so the
+ *            fragment lines up wherever it is spliced in.
+ */
+export function itemsRecordset(pad = ""): string {
+  return `jsonb_to_recordset(${ITEMS_JSON_EXPR}) AS item(
+${indentBlock(ITEM_RECORD_COLUMNS, `${pad}  `)}
+${pad})`;
+}
+
+/**
+ * Defensive `brands` upsert for every distinct `product_brand_id` in
+ * `items[]`. `products.brand_id` is FK into `brands`, so the products
+ * upsert fails without it (#101).
+ *
+ * Its own statement, never a sibling CTE: `WITH` sub-statements cannot
+ * see each other's effects on target tables and RI checks are AFTER-ROW.
+ */
+export function brandFkGuard(): string {
+  return `  psql "\$DATABASE_URL" <<'SQL'
+    INSERT INTO brands (brand_id, name)
+    SELECT DISTINCT product_brand_id, product_brand_id
+      FROM jsonb_to_recordset(${ITEMS_JSON_EXPR})
+        AS item(product_brand_id text)
+     WHERE product_brand_id IS NOT NULL
+    ON CONFLICT (brand_id) DO NOTHING;
+  SQL`;
+}
+
+/**
+ * The `p_upsert` CTE — #84 Phase 1 products SSOT upsert, keyed by
+ * (workspace_id, merchant_id, product_key).
+ *
+ * Returned WITHOUT a trailing comma so the call site can place it
+ * anywhere in a `WITH` list.
+ */
+export function productsUpsert(opts: {
+  workspaceId: string;
+  /** SQL expression yielding the merchant id for merchant-exclusive
+   *  products, e.g. `(SELECT id FROM m)`. */
+  merchantIdExpr: string;
+}): string {
+  return `    -- #84 Phase 1: products SSOT upsert. The agent emits a
+    -- product_key per item; this CTE upserts the catalog row keyed by
+    -- (workspace_id, merchant_id, product_key) and returns its id.
+    -- merchant_id is NULL when product_merchant_exclusive=false (the
+    -- product is portable across stores) and this receipt's merchant_id
+    -- when true (in-store private label / dish).
+    -- Non-product lines (line_type ∈ tax/tip/discount/shipping/…) get
+    -- product_key=NULL and skip this step entirely (filtered by the
+    -- WHERE clause). NULLS NOT DISTINCT in the unique index makes
+    -- merchant_id=NULL participate.
+    p_upsert AS (
+      INSERT INTO products (
+        workspace_id, merchant_id, product_key, canonical_name,
+        item_class, brand_id, model, color, size, variant, sku,
+        manufacturer
+      )
+      SELECT '${opts.workspaceId}',
+             CASE WHEN item.product_merchant_exclusive THEN ${opts.merchantIdExpr} ELSE NULL END,
+             item.product_key,
+             COALESCE(item.normalized_name, item.raw_name),
+             item.item_class, item.product_brand_id,
+             item.product_model, item.product_color, item.product_size,
+             item.product_variant, item.product_sku, item.product_manufacturer
+      FROM ${itemsRecordset("      ")}
+      WHERE COALESCE(item.line_type, 'product') = 'product' AND item.product_key IS NOT NULL
+      ON CONFLICT (workspace_id, merchant_id, product_key) DO UPDATE
+        SET updated_at = NOW(),
+            canonical_name = COALESCE(EXCLUDED.canonical_name, products.canonical_name),
+            brand_id       = COALESCE(EXCLUDED.brand_id,       products.brand_id),
+            item_class     = COALESCE(EXCLUDED.item_class,     products.item_class)
+      RETURNING id, product_key, merchant_id
+    )`;
+}
+
+/**
+ * The `transaction_items` INSERT — #81 Phase 2 + #84 relational line
+ * items with the `product_id` link and the per-line allocation columns.
+ *
+ * Returns a bare `INSERT … SELECT … FROM …` (no trailing semicolon, no
+ * CTE wrapper) so the ingest path can wrap it as `ti AS ( … )` and the
+ * re-extract path can terminate it with `;`.
+ */
+export function transactionItemsInsert(opts: {
+  workspaceId: string;
+  /** SQL expression yielding the transaction id, e.g. `tx.id`. */
+  txIdExpr: string;
+  /** SQL expression yielding the extraction_run number, e.g. `1`. */
+  runExpr: string;
+  /** SQL expression yielding the merchant id for merchant-exclusive
+   *  products — must match `productsUpsert`'s. */
+  merchantIdExpr: string;
+  /** Extra FROM-list entries placed before the recordset, e.g. `"tx,"`
+   *  when the transaction id comes from a sibling CTE. */
+  fromPrefix?: string;
+  /** RETURNING column list, when the caller wraps this in a CTE. */
+  returning?: string;
+}): string {
+  const from = opts.fromPrefix ? `${opts.fromPrefix}\n        ` : "";
+  const returning = opts.returning ? `\n      RETURNING ${opts.returning}` : "";
+  return `      INSERT INTO transaction_items (
+        id, workspace_id, transaction_id, line_no, parent_line_no,
+        raw_name, normalized_name, product_variant, quantity, unit,
+        unit_price_minor, line_total_minor, currency,
+        item_class, durability_tier, food_kind, tags, confidence,
+        line_type, product_id, tax_minor, tip_share_minor,
+        discount_share_minor, extraction_run, extraction_version
+      )
+      SELECT gen_random_uuid(), '${opts.workspaceId}', ${opts.txIdExpr}, item.line_no,
+             item.parent_line_no,
+             item.raw_name, item.normalized_name, item.product_variant,
+             item.quantity, item.unit,
+             item.unit_price_minor, item.line_total_minor, item.currency,
+             item.item_class, item.durability_tier, item.food_kind,
+             item.tags, item.confidence,
+             COALESCE(item.line_type, 'product'),
+             (SELECT pu.id FROM p_upsert pu
+                WHERE pu.product_key = item.product_key
+                  AND pu.merchant_id IS NOT DISTINCT FROM
+                      (CASE WHEN item.product_merchant_exclusive THEN ${opts.merchantIdExpr} ELSE NULL END)
+                LIMIT 1),
+             item.tax_minor, item.tip_share_minor, item.discount_share_minor,
+             ${opts.runExpr}, '${PROMPT_VERSION}'
+      FROM ${from}${itemsRecordset("        ")}${returning}`;
+}
+
+/**
+ * Recompute `products` aggregate stats for every product THIS run
+ * touched — the recompute-not-increment rule from #84.
+ *
+ * The `touched` CTE is the point: recomputing the whole workspace on
+ * every run is O(N) per receipt → O(N²) over a backfill. The re-extract
+ * copy did exactly that while its own comment claimed otherwise.
+ *
+ * `touched` deliberately does NOT filter `retired_at IS NULL` — on a
+ * re-extract, a product that dropped out of the new run must still be
+ * recomputed, and it only appears among the now-retired rows.
+ *
+ * Returns a bare statement (terminated with `;`, no heredoc wrapper).
+ */
+export function productAggregateRecompute(opts: {
+  workspaceId: string;
+  /** SQL predicate selecting the `transaction_items ti JOIN transactions t`
+   *  rows this run touched, e.g. `t.source_ingest_id = '<uuid>'`. */
+  touchedPredicate: string;
+}): string {
+  return `  WITH touched AS (
+    -- Only the products THIS run touched — recomputing the whole
+    -- workspace every time is O(N) per receipt → O(N²) over a backfill.
+    SELECT DISTINCT ti.product_id
+    FROM transaction_items ti
+    JOIN transactions t ON t.id = ti.transaction_id
+    WHERE ${opts.touchedPredicate}
+      AND ti.product_id IS NOT NULL
+  ),
+  stats AS (
+    SELECT ti.product_id,
+           MIN(t.occurred_on)          AS first_on,
+           MAX(t.occurred_on)          AS last_on,
+           COUNT(DISTINCT ti.transaction_id) AS purchases,
+           SUM(ti.effective_total_minor)    AS total_minor
+    FROM transaction_items ti
+    JOIN transactions t ON t.id = ti.transaction_id
+    WHERE ti.workspace_id = '${opts.workspaceId}'
+      AND ti.product_id IN (SELECT product_id FROM touched)
+      AND ti.retired_at IS NULL
+      AND ti.line_type = 'product'
+    GROUP BY ti.product_id
+  )
+  UPDATE products p SET
+    first_purchased_on = stats.first_on,
+    last_purchased_on  = stats.last_on,
+    purchase_count     = stats.purchases,
+    total_spent_minor  = stats.total_minor,
+    updated_at         = NOW()
+  FROM stats
+  WHERE p.id = stats.product_id
+    AND p.workspace_id = '${opts.workspaceId}';`;
+}

--- a/src/ingest/line-item-prompt.ts
+++ b/src/ingest/line-item-prompt.ts
@@ -1,0 +1,484 @@
+/**
+ * Shared line-item contract for the extraction and re-extraction
+ * prompts (#164) — the `items[]` schema, the `line_type` vocabulary,
+ * the two-level modifier rule, the coverage/arithmetic invariant, the
+ * per-line allocation logic, and the worked examples.
+ *
+ * Both prompts inline these phases verbatim so the agent — which runs
+ * inside a container that doesn't have the source files — gets the
+ * full instructions in its prompt window. Don't reference these phases
+ * by source-file path from the prompt; the agent will go looking for
+ * `src/ingest/prompt.ts` and waste turns when it can't find it.
+ *
+ * Why one module: `prompt.ts` and `reextract-prompt.ts` each carried a
+ * hand-maintained copy of this contract and they DRIFTED. Measured on
+ * production rows before #164: re-extract dropped `product_id` on 28.5%
+ * of product lines (283/396) vs 0.2% at ingest, and `tax_minor` on
+ * 94.4%, because its SQL required 11 fields its prose never named.
+ *
+ * Plain template literals, never `String.raw` — see `prompt-contract.ts`.
+ */
+
+/**
+ * The full `items[]` object shape — all 26 fields, including the #84
+ * product-catalog and per-line allocation columns the SQL requires.
+ */
+export const ITEM_SCHEMA = `── items[] shape (per line on the receipt) ───────────────────────────
+
+Each \`item\` object has these fields:
+
+  line_no            int      1-based, preserves the order printed
+                              on the receipt
+  parent_line_no     int|null  #162 CANONICAL TWO-LEVEL RULE. When this
+                              line is a PAID modifier / add-on / topping /
+                              size-upgrade that belongs to another item,
+                              set this to that owning item's line_no. NULL
+                              for top-level items and for tax/tip/discount
+                              audit rows. See the "Two-level line-items"
+                              block below — this is how a "+$3.00 Fish
+                              Cutlet" add-on attaches to its parent dish
+                              instead of floating as a peer line.
+  raw_name           text     the line as printed, verbatim (don't
+                              normalize — preserve abbreviations,
+                              brand prefixes, codes)
+  normalized_name    text|null brand-stripped human-readable form
+                              (e.g. "KS PPR TWLS 12CT" → "Paper
+                              Towels"). NULL when the raw name is
+                              already clean or impossible to clean.
+                              #162: this is the CLEAN ITEM NAME ONLY —
+                              never append a relational suffix like
+                              "(curry modifier)" / "(curry topping)".
+                              A modifier's name is just "Fish Cutlet",
+                              and parent_line_no carries the relationship.
+  quantity           num|null  2, 0.5, 1 default if unprinted
+  unit               text|null "ct", "lb", "kg", "oz", "ea", "ml",
+                              or NULL when not printed
+  unit_price_minor   int|null  minor units (cents for USD), NULL when
+                              not printed (single line items often omit)
+  line_total_minor   int       REQUIRED. Minor units. Signed —
+                              negative for line-level discounts /
+                              coupons / store-applied promos
+  currency           text      ISO 4217, same as the transaction
+  item_class         enum      one of:
+                                 durable      — expected life ≥ 1 year
+                                                (electronics, furniture,
+                                                appliances, clothing,
+                                                kitchenware, tools)
+                                 consumable   — used up in weeks/months
+                                                (cleaning supplies,
+                                                toiletries, batteries,
+                                                fuel, OTC meds, paper
+                                                products, light bulbs)
+                                 food_drink   — anything edible/potable
+                                 service      — non-physical (massage,
+                                                haircut, delivery fee,
+                                                itemized service charge)
+                                 other        — refunds, gift cards,
+                                                tax appearing as its
+                                                own line. Rare; if you
+                                                use this often, the
+                                                receipt is probably
+                                                ambiguous — flag in tags.
+  durability_tier    enum|null only when item_class='durable':
+                                 luxury   — line total > \$200 OR brand
+                                            is luxury-list (Apple
+                                            high-end, LV, Hermès, …)
+                                 standard — otherwise
+                                NULL for non-durable items.
+  food_kind          enum|null only when item_class='food_drink':
+                                 restaurant_dish — dining/cafe merchant
+                                 grocery_food    — market for home cook
+                                 beverage        — drinks bought as
+                                                   drinks (latte, water,
+                                                   beer). Alcohol →
+                                                   add "alcohol" tag.
+                                NULL for non-food items.
+  tags               text[]|null freeform low-trust signals:
+                                ["alcohol","cold","organic","sale",
+                                 "imported","handwritten","unclear"]
+  confidence         enum      one of:
+                                 high   — line crisp, totals tie
+                                 medium — readable but ambiguous
+                                 low    — thermal-paper smudge,
+                                          ink fade, partial occlusion
+
+  ── Phase 1 of #84: products SSOT + allocation fields ──
+
+  line_type          text       which KIND of money this row is
+                                (product / tax / tip / discount / …).
+                                Default 'product'. The recommended
+                                values, the open-vocabulary rule, and
+                                the naming rules live in the "line_type
+                                vocabulary + naming" block immediately
+                                after this schema — read it, it is not
+                                optional.
+
+  product_key        text|null  kebab-case canonical key. REQUIRED for
+                                line_type='product'; NULL for tax/tip/
+                                discount rows. Format: ^[a-z0-9-]+\$.
+                                Same product → same key forever.
+                                Variants get distinct keys:
+                                  iphone-15-pro-natural-titanium-256
+                                  iphone-15-pro-blue-titanium-256
+                                  kirkland-paper-towels-12ct
+                                  starbucks-grande-latte
+                                  costco-gas-regular   (NOT just "gas")
+                                Don't include the merchant id in the key
+                                — merchant scoping lives on a separate
+                                column.
+
+  product_brand_id   text|null  the manufacturer brand, NOT the seller.
+                                "apple" for iPhone, "kirkland" for KS
+                                products, "starbucks" for in-store
+                                espresso. Mirror the merchant block's
+                                brand_id rules.
+
+  product_merchant_exclusive bool|null
+                                true  → this product only exists at
+                                        this merchant (Crunchwrap @
+                                        Taco Bell, AYCE @ Sichuan Spicy
+                                        Bay, in-store private label).
+                                        Phase 4 binds product.merchant_id
+                                        to this receipt's merchant.
+                                false → portable / cross-merchant
+                                        (iPhone, Coke, brand-name goods).
+                                        product.merchant_id stays NULL
+                                        and the row shares across stores.
+
+  product_model      text|null   "M3 13\\" 256GB", "iPad Pro 11\\""
+  product_color      text|null   "Natural Titanium", "Black", "Red"
+  product_size       text|null   "L", "12 ct", "750 ml"
+  product_variant    text|null   #162 CANONICAL: a single human-readable
+                                string of THIS line's ZERO-COST
+                                customizations — free options that change
+                                the item but add no price (少糖 / 半糖 /
+                                去冰 / "Less Sugar" / "Ice Blended" /
+                                "no cilantro" / a free spice level).
+                                Join multiple with ", ". NEVER put a PAID
+                                add-on here (those become their own priced
+                                child line via parent_line_no). Also used
+                                as the catalog product's free-text variant
+                                (flavor, fit, finish). NULL when the line
+                                has no free customizations.
+  product_sku        text|null   when printed on the receipt
+  product_manufacturer text|null when the brand and the manufacturer
+                                differ ("kirkland" brand made by
+                                "georgia-pacific" manufacturer); leave
+                                NULL when they match.
+
+  tax_minor          int|null    per-line tax share allocated from the
+                                printed tax aggregate. See the per-line
+                                allocation logic below. NULL on tax/tip/
+                                discount rows themselves and on lines
+                                you decide are non-taxable.
+  tip_share_minor    int|null    per-line tip share from printed tip.
+  discount_share_minor int|null  per-line discount share. Signed
+                                positive (always reduces). NULL when
+                                no discount applies.`;
+
+/**
+ * `line_type` is an OPEN vocabulary — there is no DB enum, no zod enum
+ * and no CHECK constraint behind the column (`transaction.ts` types it
+ * `z.string()`), and production already holds 18 distinct values. A
+ * closed list in ONE prompt only guarantees the two prompts disagree.
+ *
+ * Bare `fee` is deliberately absent from the recommended list: it
+ * overlaps `service_fee` / `surcharge` and only ever existed because
+ * the two prompts disagreed.
+ */
+export const LINE_TYPE_VOCAB_AND_NAMES = `── line_type vocabulary + naming (OPEN vocabulary) ────────────────────
+
+\`line_type\` says which KIND of money a row is. These are the
+RECOMMENDED values — a starting point, not a closed enum:
+
+  product      — the default, an actual purchased line
+  tax          — printed tax aggregate row
+  tip          — printed tip aggregate row
+  discount     — store discount / promo aggregate row (negative)
+  shipping     — printed shipping / delivery charge
+  surcharge    — printed surcharge (CRV, fuel, kitchen, card fee)
+  service_fee  — printed service / convenience / platform fee
+  gift_card    — a gift card sold, or store credit applied, as its
+                 own line
+  other        — money the source would not let you itemize (the
+                 TOTAL-ONLY row below), or a printed row you genuinely
+                 cannot label
+
+Invent a snake_case label when none of these fit. There is no database
+enum and no CHECK constraint behind this column, so an honest new label
+is always better than forcing a row into a wrong one.
+
+ALWAYS emit the printed tax / tip / discount / fee / surcharge rows
+THEMSELVES as named items with the matching line_type and
+product_key=NULL — e.g. a "Snackpass Credit" −\$5.00 row is
+line_type='discount' (tags=['promo']); a "Taxes & Fees" \$0.51 row is
+line_type='tax'. Keep the printed NAME in raw_name / normalized_name.
+NEVER collapse them into the top-level tax_minor / discount_minor
+numbers only — that loses the name. parent_line_no is NULL on these
+rows. They are the audit baseline against the per-line allocations
+further below.`;
+
+/** The #162 two-level modifier rule, including BOTH the ADDITIVE and
+ *  the INCLUSIVE branch. An agent given only the INCLUSIVE branch has
+ *  exactly one directive about parent prices and it is "REDUCE" — the
+ *  direct cause of #165. */
+export const LINE_ITEM_TWO_LEVEL_RULE = `── Two-level line-items — the ONE rule for modifiers (#162) ───────────
+
+Restaurant / cafe / boba receipts print a dish or drink followed by
+its modifiers (toppings, add-ons, size upgrades, sugar/ice levels,
+spice levels). Decide each modifier's fate by ONE test — does it have
+a PRICE?
+
+  PRICED add-on  → it is a LINE.
+    Emit it as its OWN item object with a real line_total_minor, and
+    set parent_line_no = the owning dish/drink's line_no. Give it a
+    clean normalized_name ("Fish Cutlet", "Large Rice", "Soybean
+    Mousse") — NO "(curry modifier)" / "(topping)" relational suffix;
+    parent_line_no already encodes the relationship.
+    Keep item_class/food_kind consistent with the parent (a paid
+    topping on a dish is still food_drink / restaurant_dish).
+
+    ADDITIVE vs INCLUSIVE pricing — get the parent's line_total right:
+    • ADDITIVE (e.g. CoCo): the dish shows a base price and each paid
+      modifier is printed with its own price ADDED on top. Keep the
+      parent at its base; the children carry their own prices; they
+      sum naturally.
+    • INCLUSIVE (common on Snackpass / boba / combo receipts): the
+      item shows ONE all-in customized price and the modifier prices
+      are COMPONENTS of it, not charged on top. To split without
+      double-counting, REDUCE the parent's line_total to the base =
+      (displayed price − Σ priced add-ons); the children then re-add
+      up to the displayed price.
+    INVARIANT either way: parent base + Σ its child add-ons = the price
+    actually charged for that item. NEVER leave the parent at the
+    all-in price AND also emit priced children — that double-counts and
+    breaks Σ line_total = subtotal.
+
+  ZERO-COST option → it is an ATTRIBUTE.
+    Do NOT emit a separate line. Fold it into the PARENT item's
+    product_variant string ("Less Sugar", "No Ice", "Spice Level 2",
+    "no cilantro"). Multiple free options join with ", ".
+
+Never do the reverse: never bury a priced add-on inside a
+product_variant string (it would vanish from the ledger totals), and
+never spawn a peer line for a free customization (it would double the
+item count and break Σ line_total).
+
+If a modifier's price is genuinely not itemized on the source (some
+receipts bundle "Milk Tea +Boba" at one blended price with no
+breakout), you cannot invent a split: keep the add-on name in the
+parent's product_variant and add a "variant-price-unresolved" tag on
+the parent so the limitation is auditable. Prefer a priced child line
+whenever the source shows any separable price.`;
+
+/**
+ * The arithmetic invariant + the TOTAL-ONLY fallback.
+ *
+ * Coverage is summed over `line_type IN ('product','other')`, not
+ * `'product'` alone: the TOTAL-ONLY row (and, from #166 onward, the
+ * occlusion-bridge row) stands in for product lines the source would
+ * not let the agent read, so excluding it makes every receipt that
+ * needs one fail its own tie check.
+ *
+ * PR #165/#166 extends this export with the occlusion-bridge rule.
+ */
+export const LINE_ITEM_COVERAGE_AND_BRIDGE = `── Coverage + arithmetic invariant ───────────────────────────────────
+
+  Σ line_total_minor across rows with line_type IN ('product','other')
+  SHOULD approximate the receipt's printed SUBTOTAL (within \$0.01
+  rounding). 'other' counts toward coverage because the TOTAL-ONLY row
+  below stands in for product lines the source would not let you read.
+
+  The remaining rows — tax / tip / discount / shipping / surcharge /
+  service_fee / gift_card — carry the rest (discount rows are
+  negative), so Σ of ALL rows ≈ the printed GRAND TOTAL.
+
+  If the coverage sum is off by more than \$0.50, drop confidence to
+  "low" on the items that look most suspect.
+
+  Self-check before COMMIT:
+    Σ tax rows      ≈ the printed tax
+    Σ discount rows ≈ the printed discount (negative)
+    Σ product effective_total ≈ the transaction total
+
+If you cannot itemize at all (total-only receipt, unreadable item
+section, illegible thermal print) emit exactly ONE item with
+
+  line_type='other', item_class='other', confidence='low',
+  raw_name='TOTAL ONLY', line_total_minor=<TOTAL_MINOR>,
+  parent_line_no=NULL, product_key=NULL,
+  tags=['no-item-section']
+
+— one label for "money the source would not let me itemize" keeps
+every downstream product-scoped sum a two-value check instead of an
+open-ended one.`;
+
+/** Phase 2.7 — per-line tax / tip / discount allocation (#84). The
+ *  re-extract SQL writes `tax_minor` / `tip_share_minor` /
+ *  `discount_share_minor`, so re-extract needs this text too; before
+ *  #164 it did not have it and dropped `tax_minor` on 94.4% of lines. */
+export const ALLOCATION_LOGIC = `── Phase 2.7 — Per-line tax / tip / discount allocation (#84) ─────────
+
+Receipts print aggregate tax / tip / discount; users want "what did
+this specific line cost me, all-in." Allocate per-line at ingest.
+Recommended logic (apply real arithmetic; do NOT hard-code rates):
+
+Tax allocation:
+  1. Look for per-line taxability markers ("T", "T1/T2", asterisks
+     next to specific lines, "Taxable" labels).
+  2. If markers present: \`tax_minor\` for each taxable line =
+     ROUND(printed-tax-total × line_total_minor / Σ taxable lines).
+     Non-taxable lines → tax_minor = NULL.
+  3. If no markers: treat all line_type='product' rows as equally
+     taxable and allocate proportionally.
+  4. Make Σ tax_minor exactly match the printed tax (absorb the
+     rounding remainder on the largest line).
+
+Tip allocation (dining receipts):
+  Split the printed tip total proportionally across product lines
+  by \`line_total_minor\`. Tips are for the whole meal.
+
+Discount allocation:
+  Receipt names the target ("20% off Item X") → put it all on that
+  line. Whole-order ("\$5 off subtotal") → split proportionally.
+  BOGO / "buy 2 get 1 free" / promo edge cases → use judgment;
+  record the reasoning in transactions.metadata.allocation_audit.
+
+The printed tax / tip / discount rows themselves are emitted as items
+per the line_type vocabulary above. Their tax_minor /
+tip_share_minor / discount_share_minor stay NULL — a tax line is not
+itself taxed.
+
+Final self-check before COMMIT:
+  Σ effective_total_minor (line_type='product') ≈ transactions.total
+  Σ tax_minor      ≈ items where line_type='tax'
+  Σ tip_share_minor ≈ items where line_type='tip'
+  Σ discount_share_minor ≈ items where line_type='discount'
+Discrepancies > 1¢ → record in transactions.metadata.allocation_audit
+(structured object: \`{kind, expected, got, delta}\`). Don't block
+ingest — just log.`;
+
+/**
+ * Worked examples, anchored to real fixtures.
+ *
+ * The CoCo example is the ADDITIVE anchor at **\$14.64 base, line_no 3**,
+ * with "Less Sauce" presented as a counterfactual. The re-extract copy
+ * that drifted to \$9.00 / line 1 / an actual "Less Sauce" was a
+ * hand-retyped corruption and is gone.
+ */
+export const LINE_ITEM_WORKED_EXAMPLES = `── Worked examples ───────────────────────────────────────────────────
+
+Two-level dish with paid modifiers (#162) — real CoCo Ichibanya order:
+two plain dishes, then a "Fried Chicken Curry" $14.64 base with three
+separately-PRICED modifiers (Large Rice $1.00, Level 4 spice $0.80,
+Fish Cutlet $3.00). Every modifier here is priced, so every one is its
+own child line (none go to product_variant); if any had been free
+("Less Sauce", "No Onion") it would instead ride on line 3's
+product_variant string:
+  items = [
+    {"line_no":1, "raw_name":"Naan Bread", "normalized_name":"Naan Bread",
+     "parent_line_no":null, "quantity":1, "unit":"ea",
+     "unit_price_minor":250, "line_total_minor":250, "currency":"USD",
+     "item_class":"food_drink", "food_kind":"restaurant_dish",
+     "confidence":"high"},
+    {"line_no":2, "raw_name":"Garlic Naan", "normalized_name":"Garlic Naan",
+     "parent_line_no":null, "quantity":1, "unit":"ea",
+     "unit_price_minor":300, "line_total_minor":300, "currency":"USD",
+     "item_class":"food_drink", "food_kind":"restaurant_dish",
+     "confidence":"high"},
+    {"line_no":3, "raw_name":"Fried Chicken Curry",
+     "normalized_name":"Fried Chicken Curry", "parent_line_no":null,
+     "quantity":1, "unit":"ea", "unit_price_minor":1464,
+     "line_total_minor":1464, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"restaurant_dish", "confidence":"high"},
+    {"line_no":4, "raw_name":"Large Rice", "normalized_name":"Large Rice",
+     "parent_line_no":3, "quantity":1, "unit":"ea",
+     "unit_price_minor":100, "line_total_minor":100, "currency":"USD",
+     "item_class":"food_drink", "food_kind":"restaurant_dish",
+     "confidence":"high"},
+    {"line_no":5, "raw_name":"Level 4", "normalized_name":"Spice Level 4",
+     "parent_line_no":3, "quantity":1, "unit":"ea",
+     "unit_price_minor":80, "line_total_minor":80, "currency":"USD",
+     "item_class":"food_drink", "food_kind":"restaurant_dish",
+     "confidence":"high"},
+    {"line_no":6, "raw_name":"Fish Cutlet", "normalized_name":"Fish Cutlet",
+     "parent_line_no":3, "quantity":1, "unit":"ea",
+     "unit_price_minor":300, "line_total_minor":300, "currency":"USD",
+     "item_class":"food_drink", "food_kind":"restaurant_dish",
+     "confidence":"high"}
+    // + a tax line ($1.93) with line_type='tax'. Σ product lines = $24.94
+    // subtotal. Modifiers are children of line 3, NOT peers named
+    // "Fish Cutlet (curry topping)", NOT folded into product_variant.
+  ]
+
+Boba drink, free customizations only (#162)
+(3CAT "Brown Sugar Milk Tea" $5.50, Less Sugar + Ice Blended, both free):
+  items = [
+    {"line_no":1, "raw_name":"Brown Sugar Milk Tea",
+     "normalized_name":"Brown Sugar Milk Tea", "parent_line_no":null,
+     "product_variant":"Less Sugar, Ice Blended",
+     "quantity":1, "unit":"ea", "unit_price_minor":550,
+     "line_total_minor":550, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"beverage", "confidence":"high"}
+  ]
+  If that same drink instead showed "+Soybean Mousse $0.75" printed
+  with a price, Soybean Mousse becomes line_no 2 with parent_line_no=1
+  and line_total_minor=75. If the price is NOT itemized, keep
+  "+Soybean Mousse" in product_variant and tag line 1
+  "variant-price-unresolved".
+
+Boba drink, INCLUSIVE paid add-ons (#162)
+(3CAT "Avomango Sweet Dew" shown at ONE all-in $9.49; its +Soybean
+Mousse ($1.25) and +Agar Boba ($0.75) are COMPONENTS of that $9.49,
+and Less Sugar / Ice Blended are free). Reduce the parent to base
+$7.49 so base + add-ons re-sum to the $9.49 actually charged:
+  items = [
+    {"line_no":1, "raw_name":"Avomango Sweet Dew",
+     "normalized_name":"Avomango Sweet Dew", "parent_line_no":null,
+     "product_variant":"Less Sugar, Ice Blended",
+     "quantity":1, "unit":"ea", "unit_price_minor":749,
+     "line_total_minor":749, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"beverage", "confidence":"high"},
+    {"line_no":2, "raw_name":"Soybean Mousse",
+     "normalized_name":"Soybean Mousse", "parent_line_no":1,
+     "quantity":1, "unit":"ea", "unit_price_minor":125,
+     "line_total_minor":125, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"beverage", "confidence":"high"},
+    {"line_no":3, "raw_name":"Agar Boba", "normalized_name":"Agar Boba",
+     "parent_line_no":1, "quantity":1, "unit":"ea",
+     "unit_price_minor":75, "line_total_minor":75, "currency":"USD",
+     "item_class":"food_drink", "food_kind":"beverage", "confidence":"high"}
+    // base 749 + 125 + 75 = 949 = the price charged for the drink.
+    // Do NOT emit the parent at 949 AND these children — that is 1074,
+    // double-counting $1.25+$0.75. If the add-on prices were NOT shown,
+    // keep them in product_variant + "variant-price-unresolved" instead.
+  ]
+
+Costco gas (single line):
+  items = [
+    {"line_no":1, "raw_name":"GAS REG", "normalized_name":"Regular Gas",
+     "quantity":12.345, "unit":"gal", "unit_price_minor":419,
+     "line_total_minor":5176, "currency":"USD",
+     "item_class":"consumable", "tags":["fuel"], "confidence":"high"}
+  ]
+
+AYCE sushi dinner ($46.20):
+  items = [
+    {"line_no":1, "raw_name":"AYCE Lunch", "normalized_name":"All-You-Can-Eat Lunch",
+     "quantity":2, "unit":"ea", "unit_price_minor":2199,
+     "line_total_minor":4398, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"restaurant_dish", "confidence":"high"},
+    {"line_no":2, "raw_name":"Hot Tea", "normalized_name":"Hot Tea",
+     "quantity":2, "unit":"ea", "unit_price_minor":150,
+     "line_total_minor":300, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"beverage", "confidence":"high"}
+  ]
+
+Best Buy laptop ($1,599):
+  items = [
+    {"line_no":1, "raw_name":"MBA M3 13 256GB", "normalized_name":"MacBook Air M3 13\" 256GB",
+     "quantity":1, "unit":"ea", "unit_price_minor":159900,
+     "line_total_minor":159900, "currency":"USD",
+     "item_class":"durable", "durability_tier":"luxury",
+     "tags":["electronics","apple"], "confidence":"high"}
+  ]`;

--- a/src/ingest/prompt-contract.ts
+++ b/src/ingest/prompt-contract.ts
@@ -1,0 +1,281 @@
+/**
+ * Shared extraction-contract constants and agent-hygiene phases for the
+ * extraction and re-extraction prompts (#164).
+ *
+ * Both prompts inline these phases verbatim so the agent — which runs
+ * inside a container that doesn't have the source files — gets the
+ * full instructions in its prompt window. Don't reference these phases
+ * by source-file path from the prompt; the agent will go looking for
+ * `src/ingest/prompt.ts` and waste turns when it can't find it.
+ *
+ * Prompt strings here are PLAIN template literals, never `String.raw`.
+ * Inside `String.raw` a `` \` `` / `\$` survives into the agent's window
+ * as a literal backslash, which corrupts every shell snippet that
+ * mentions `$DATABASE_URL` or a markdown code span.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The ONE prompt-version stamp, written into
+ * `transactions.metadata.extraction.prompt_version` and
+ * `transaction_items.extraction_version` by BOTH the ingest and the
+ * re-extract path. Bump on meaningful prompt changes only — typo fixes
+ * and whitespace edits do not warrant a new version. The string becomes
+ * the gate for `POST /v1/documents/:id/re-extract` (#91): rows whose
+ * `extraction.prompt_version` ≠ `PROMPT_VERSION` are eligible to be
+ * re-derived. See #80 / #88 for the 3-layer data model rationale.
+ *
+ * There is deliberately NO separate re-extract version constant (#164):
+ * two number lines in one column (`1.8` sorting "newer" than `2.19`) is
+ * pure liability, and nothing reads or compares either value. The path
+ * is distinguished by `metadata.extraction.source ∈ {'ingest','re-extract'}`.
+ */
+export const PROMPT_VERSION = "3.0";
+
+/**
+ * The model identifier stamped into `transactions.metadata.extraction.model`
+ * and `documents.ocr_model_version`.
+ *
+ * `claude -p` is spawned WITHOUT a `--model` flag unless `CLAUDE_MODEL`
+ * is set (see `extractor.ts::runClaude`), in which case the CLI picks its
+ * own default — so `"cli-default"` is the truthful stamp for an unset
+ * env var. The old `"sonnet"` fallback was a lie: the container CLI has
+ * been running opus while the column read `sonnet`.
+ */
+export const EXTRACTION_MODEL = process.env.CLAUDE_MODEL ?? "cli-default";
+
+/** Reason-in-plain-text rule. Structured-output coercion measurably
+ *  degrades OCR (4/10 dates wrong on an early A/B set) because it skips
+ *  chain-of-thought. Never add `--json-schema` / `--output-format json`. */
+export const NO_JSON_SCHEMA_RULE = `Reason in plain text first. Chain-of-thought measurably improves OCR.
+Do NOT use \`--json-schema\`-style structured output.`;
+
+/** The psql connection + heredoc form. Both prompts write via psql and
+ *  both need the multi-statement heredoc shape. */
+export const PSQL_DISCIPLINE = `DB connection: \`psql "\$DATABASE_URL"\` — the env var is set. Use it for
+every SQL call. If you want a multi-statement block, use a heredoc:
+  psql "\$DATABASE_URL" <<'SQL'
+    BEGIN;
+    ...
+    COMMIT;
+  SQL`;
+
+/**
+ * Scratch-file discipline (#143) + sequential tool discipline (#126) +
+ * the priority / effort-budget preamble.
+ *
+ * Parameterized rather than a bare const because the scratch directory
+ * and the source file path differ per run; the text is otherwise moved
+ * verbatim from `prompt.ts`.
+ *
+ * `brand-icon-prompt.ts` cross-references "the extractor's Priority &
+ * effort-budget preamble" — that reference resolves from BOTH prompts
+ * only because this block is inlined by both.
+ */
+export function agentHygiene(opts: {
+  /** Per-run scratch directory, e.g. `/tmp/<ingestId>`. */
+  scratchDir: string;
+  /** Container-absolute path of the file under extraction. */
+  filePath: string;
+}): string {
+  return `Scratch files — PER-INGEST DIRECTORY ONLY. Several extractions run
+concurrently in this container and /tmp is shared: a generic name like
+/tmp/receipt_rot.jpg WILL be overwritten by a sibling agent mid-run,
+and you will silently read someone else's receipt (#143 — this
+happened: an agent extracted the neighbor's Trader Joe's receipt under
+a Kelly's Coffee ingest and rationalized the mismatch as a stale EXIF
+preview). Rules:
+  - First command before any image work:
+      mkdir -p ${opts.scratchDir}
+    and create EVERY scratch file inside that directory.
+  - If a crop/rotation ever shows a DIFFERENT merchant than your first
+    read of the original upload, do NOT rationalize it (no "stale
+    preview" theories). Re-read the ORIGINAL file at
+    ${opts.filePath} and trust only what it shows.
+
+Tool discipline — SEQUENTIAL Bash calls only. Issue Bash tool calls one
+at a time and wait for each result before deciding the next command.
+NEVER batch multiple Bash invocations into one parallel tool-call block:
+if any one errors, every sibling call is cancelled mid-flight, and the
+cascade of cancellations is disorienting enough to corrupt your own
+extraction state (#126). One command, one result, then the next.
+
+── Priority & effort budget — READ FIRST, governs everything below ────
+
+This job has ONE required deliverable plus a best-effort tail. Keep them
+straight, or you will burn minutes on polish while the core sits unfinished.
+Trace evidence: routine receipts finish in ~7 tool calls, but some balloon
+to 40+ turns — and the extra 30 turns are almost always merchant enrichment
+(Google fetches, storefront photos, brand icons), NOT harder extraction.
+
+CORE — required. Do this and commit it no matter what:
+  classify → extract fields → write the balanced double-entry transaction
+  (+ postings + line items + document link) → close the ingest in Phase 5.
+  A run that commits a correct, balanced transaction and closes the ingest
+  is a SUCCESS even if it did zero enrichment.
+
+ENRICHMENT — best-effort, SECONDARY. You may abbreviate or SKIP any of it:
+  Phase 3 (Google place resolve / multilingual fetch / storefront photos)
+  and the brand-icon resolution pipeline. These are polish and a cache.
+  You have full authority to skip them. They must NEVER:
+    • block, delay, or fail the core write;
+    • trigger a self-correction loop — if a step errors or a column/table
+      surprises you, do NOT grind on it; record it briefly and move on;
+    • keep you working once the core is committed and marginal value is low.
+
+Spend effort PROPORTIONAL to difficulty and value. A routine receipt from
+an obvious merchant should finish in a handful of tool calls. If you notice
+you are many turns deep and the core is already committed, STOP enriching
+and go close the ingest.
+
+Skip heuristics — YOUR judgment, examples not an exhaustive rulebook:
+  • Place already cached (Phase 3b hit) → make zero outbound Google calls.
+  • Globally English-first brand with no CJK anywhere on the receipt →
+    skip storefront-photo OCR AND skip downloading photos; there is nothing
+    Chinese to find, so the fetch is pure waste.
+  • Storefront photos are only worth downloading when you actually need
+    them for CJK OCR (Phase 3d). Otherwise skip the download entirely —
+    they are a nice-to-have cache, not part of a complete extraction.
+  • Brand-icon resolution is optional visual polish. Do it when it is quick
+    and the asset is readily found; skip it when the core is done and it is
+    not. Never chase an icon across many fallback providers.
+  • The FREE checks stay ON: receipt-OCR CJK (Phase 3e) and the date
+    self-check (Phase 3.5 Checks A/B) cost no extra calls — always do them.
+    (Phase 3.5 Check C reuses an existing geocode, so it is naturally
+    skipped whenever you skipped Phase 3 — it never forces a new call.)
+
+When you deliberately skip an enrichment step, record it so the trace shows
+a decision, not a failure:
+  metadata.enrichment_skipped = ['photos','brand_icon', ...]   -- reasons ok`;
+}
+
+/**
+ * Phase 3.5 Checks A + B — the two evidence-proven date self-checks.
+ *
+ * Check C (payee cross-check via Google) is NOT here: it depends on a
+ * Phase 3 geocode that only the ingest path performs, so it stays in
+ * `prompt.ts`.
+ */
+export const DATE_SELF_CHECK = `── Phase 3.5 — Targeted OCR self-check (date + payee only) ────────────
+
+Round 1 + Round 2 (40 receipts total) showed that **failures cluster
+on two axes**: (a) date OCR errors (wrong year, day/month digit swaps)
+and (b) payee OCR errors when a merchant name is ambiguous. Generic
+"re-read the receipt" verification is net-zero — it adds prompt length
+without improving digit accuracy. So this phase is **narrow and
+evidence-driven**: only the two checks that provably help.
+
+### Check A — Year sanity (30-second check, catches #27 regression)
+
+Before committing your YYYY-MM-DD:
+
+  1. What year did you extract? Say it out loud: "I extracted year YYYY."
+  2. Today's date (from \`date\` command if needed) is 2026-04-20.
+  3. Is your extracted year more than 12 months before today? Receipts
+     are almost always from the current or previous calendar year.
+  4. If your year is 2023 or earlier AND today is 2026: **LOOK AGAIN**
+     at the year digit on the receipt. It is statistically extremely
+     unlikely that a receipt processed today is 2+ years old.
+     Common misread: "2025" rendered as "2023" on faint thermal paper;
+     the middle digit is usually '2' with the last digit 5 vs 3.
+
+### Check B — Multi-candidate date enumeration (catches day-digit swaps)
+
+Receipts often have multiple date-like strings: header print date,
+transaction date, auth code timestamp, rewards expiry. They're NOT
+all the same date.
+
+Before picking ONE \`occurred_on\`:
+
+  1. List every date-like string you can see on the receipt. Examples:
+       - "09/30/2025 14:22:07" (top, likely transaction time)
+       - "Valid through 12/31/2025" (bottom coupon)
+       - "Auth code 092525" (middle, could be date-embedded)
+  2. Identify which is the transaction date. It's usually:
+       - Near the top (header), OR
+       - Adjacent to total/payment line, OR
+       - Labeled "Date:" / "Trans Date:" / "Sale Date:"
+  3. If only ONE date appears, use it. If multiple, pick by label
+     proximity to total/tender.
+  4. For the chosen date, verify DAY digits specifically — in US
+     MM/DD/YYYY format, day digits can be transposed (30↔03, 28↔82).
+     Day must be 1–31; month must be 1–12. If either violates, the
+     digits are swapped.
+
+Emit your date-candidate list in metadata:
+
+  "date_candidates": ["09/30/2025", "12/31/2025"],
+  "chosen_date_reason": "top of receipt adjacent to transaction time"`;
+
+/** The mandatory `metadata.ocr_audit` provenance key. */
+export const OCR_AUDIT_REQUIREMENT = `### REQUIRED metadata.ocr_audit shape
+
+You MUST populate this key on every receipt ingest (not optional):
+
+  "ocr_audit": {
+    "ocr_raw_payee": "<what you read from the receipt header>",
+    "google_name": "<what Google returned, or null if no geocode>",
+    "correction_applied": true | false,
+    "date_candidates": [ "...", "..." ],
+    "chosen_date_reason": "...",
+    "year_sanity_ok": true | false,
+    "note": "optional freeform observation (e.g., thermal-paper faded, bilingual name, etc.)"
+  }
+
+An ingest without this key is considered incomplete. Emit it even
+when no corrections were needed (correction_applied=false,
+note="clean extraction").`;
+
+/**
+ * Curated self-evolution loop (#prompt-lessons).
+ *
+ * Two files, two homes, by design:
+ *   • `lessons.md` — the curated, human-reviewed lesson set. VERSION-
+ *     CONTROLLED: it lives next to this module (`src/ingest/lessons.md`,
+ *     baked into the image at `dist/ingest/lessons.md`) and ships with the
+ *     prompt. It is small, non-sensitive, non-PII, and hand-curated —
+ *     irreplaceable knowledge that belongs in git with a review trail, so
+ *     the data-tiering "keep out of git" rule (which guards sensitive /
+ *     PII / regenerable state) does not apply. Read fresh per call; lines
+ *     starting with `#` are comments and are NOT injected.
+ *   • `lessons.proposed.md` — the agent's raw per-run PROPOSALS (Phase 6).
+ *     RUNTIME-ONLY on the mini (`/data/prompt-lessons/`, a bind-mount):
+ *     ephemeral, unvetted agent output, appended to and never read back.
+ *     Its path lives in `prompt.ts` (only the ingest prompt runs Phase 6).
+ *
+ * Flow: the agent appends a proposal → a human (via the agent-evolver
+ * skill) promotes good ones into `lessons.md` as a normal repo change +
+ * deploy. "agent proposes → human gatekeeps", so the prompt improves only
+ * via vetted lessons, never self-poisons. Missing/empty/unreadable →
+ * inject nothing (local dev without the file is fine).
+ */
+const ACTIVE_LESSONS_PATH =
+  process.env.PROMPT_LESSONS_FILE ??
+  fileURLToPath(new URL("./lessons.md", import.meta.url));
+
+export function renderActiveLessons(): string {
+  let raw = "";
+  try {
+    raw = readFileSync(ACTIVE_LESSONS_PATH, "utf8");
+  } catch {
+    return "";
+  }
+  // Drop comment lines (start with '#') and blanks; keep only lesson lines.
+  const body = raw
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .join("\n")
+    .trim();
+  if (!body) return "";
+  return `
+── Learned lessons (curated, human-reviewed — apply these) ────────────
+
+Short lessons distilled from past extractions and approved by a human.
+They encode real mistakes and wins from earlier runs; treat them as
+high-priority guidance that overrides your default habits where they
+conflict. (These are vetted rules, NOT your own proposals.)
+
+${body}
+`;
+}

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -7,23 +7,37 @@
  * See `receipt-assistant#49` for the architectural move from Phase 1
  * (Node-side coerce + service-layer writes) to Phase 2.
  */
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { buildInfo } from "../generated/build-info.js";
 import {
   PHASE_2_6_BRAND_DISCOVERY,
   PHASE_4B_4C_ICON_PIPELINE,
 } from "./brand-icon-prompt.js";
-
-/**
- * Manual prompt-version stamp written into `transactions.metadata.extraction`
- * for every ingest. Bump on meaningful prompt changes only — typo fixes
- * and whitespace edits do not warrant a new version. The string becomes
- * the gate for `POST /v1/documents/:id/re-extract` (#91): rows whose
- * `extraction.prompt_version` ≠ `PROMPT_VERSION` are eligible to be
- * re-derived. See #80 / #88 for the 3-layer data model rationale.
- */
-export const PROMPT_VERSION = "2.25";
+import {
+  PROMPT_VERSION,
+  EXTRACTION_MODEL,
+  NO_JSON_SCHEMA_RULE,
+  PSQL_DISCIPLINE,
+  DATE_SELF_CHECK,
+  OCR_AUDIT_REQUIREMENT,
+  agentHygiene,
+  renderActiveLessons,
+} from "./prompt-contract.js";
+import { phase0DocumentRead } from "./document-read-prompt.js";
+import {
+  ITEM_SCHEMA,
+  LINE_TYPE_VOCAB_AND_NAMES,
+  LINE_ITEM_TWO_LEVEL_RULE,
+  LINE_ITEM_COVERAGE_AND_BRIDGE,
+  ALLOCATION_LOGIC,
+  LINE_ITEM_WORKED_EXAMPLES,
+} from "./line-item-prompt.js";
+import {
+  ITEMS_JSON_EXPR,
+  brandFkGuard,
+  productsUpsert,
+  transactionItemsInsert,
+  productAggregateRecompute,
+} from "./items-sql.js";
 
 export interface ExtractorPromptContext {
   /** Absolute path inside the container where the file was staged. */
@@ -63,63 +77,21 @@ upload. The SQL candidate check below still applies.)`;
 }
 
 /**
- * Curated self-evolution loop (#prompt-lessons).
+ * Append-only proposal file the agent writes (Phase 6); never read back.
+ * Runtime-only bind-mount on the mini (`/data/prompt-lessons/`):
+ * ephemeral, unvetted agent output, appended to and never read back.
  *
- * Two files, two homes, by design:
- *   • `lessons.md` — the curated, human-reviewed lesson set. VERSION-
- *     CONTROLLED: it lives next to this module (`src/ingest/lessons.md`,
- *     baked into the image at `dist/ingest/lessons.md`) and ships with the
- *     prompt. It is small, non-sensitive, non-PII, and hand-curated —
- *     irreplaceable knowledge that belongs in git with a review trail, so
- *     the data-tiering "keep out of git" rule (which guards sensitive /
- *     PII / regenerable state) does not apply. Read fresh per call; lines
- *     starting with `#` are comments and are NOT injected.
- *   • `lessons.proposed.md` — the agent's raw per-run PROPOSALS (Phase 6).
- *     RUNTIME-ONLY on the mini (`/data/prompt-lessons/`, a bind-mount):
- *     ephemeral, unvetted agent output, appended to and never read back.
- *
- * Flow: the agent appends a proposal → a human (via the agent-evolver
- * skill) promotes good ones into `lessons.md` as a normal repo change +
- * deploy. "agent proposes → human gatekeeps", so the prompt improves only
- * via vetted lessons, never self-poisons. Missing/empty/unreadable →
- * inject nothing (local dev without the file is fine).
+ * Its counterpart — the curated, human-reviewed `lessons.md` that gets
+ * injected INTO the prompt — lives with `renderActiveLessons()` in
+ * `prompt-contract.ts`, because both prompts inject it. Only the ingest
+ * prompt runs Phase 6, so the proposal path stays here.
  */
-const ACTIVE_LESSONS_PATH =
-  process.env.PROMPT_LESSONS_FILE ??
-  fileURLToPath(new URL("./lessons.md", import.meta.url));
-/** Append-only proposal file the agent writes (Phase 6); never read back.
- *  Runtime-only bind-mount on the mini. */
 const PROPOSED_LESSONS_PATH =
   process.env.PROMPT_LESSONS_PROPOSED ??
   "/data/prompt-lessons/lessons.proposed.md";
 
-function renderActiveLessons(): string {
-  let raw = "";
-  try {
-    raw = readFileSync(ACTIVE_LESSONS_PATH, "utf8");
-  } catch {
-    return "";
-  }
-  // Drop comment lines (start with '#') and blanks; keep only lesson lines.
-  const body = raw
-    .split("\n")
-    .filter((line) => !line.trimStart().startsWith("#"))
-    .join("\n")
-    .trim();
-  if (!body) return "";
-  return `
-── Learned lessons (curated, human-reviewed — apply these) ────────────
-
-Short lessons distilled from past extractions and approved by a human.
-They encode real mistakes and wins from earlier runs; treat them as
-high-priority guidance that overrides your default habits where they
-conflict. (These are vetted rules, NOT your own proposals.)
-
-${body}
-`;
-}
-
 export function buildExtractorPrompt(ctx: ExtractorPromptContext): string {
+  const scratchDir = `/tmp/${ctx.ingestId}`;
   return `You are a v1 double-entry ledger extractor. You will classify a
 financial document, extract its fields, optionally geocode the merchant,
 and **write the result directly into Postgres** via the psql Bash tool.
@@ -136,103 +108,15 @@ Context variables for SQL:
   DOCUMENT_ID   = '${ctx.documentId}'
   USER_ID       = '${ctx.userId}'
 
-DB connection: \`psql "\$DATABASE_URL"\` — the env var is set. Use it for
-every SQL call. If you want a multi-statement block, use a heredoc:
-  psql "\$DATABASE_URL" <<'SQL'
-    BEGIN;
-    ...
-    COMMIT;
-  SQL
+${PSQL_DISCIPLINE}
 
 Optional: if you want to discover schema details, \`\\d\` works:
   psql "\$DATABASE_URL" -c "\\d transactions"
   psql "\$DATABASE_URL" -c "SELECT id, name, type FROM accounts WHERE workspace_id = '${ctx.workspaceId}' ORDER BY type, name"
 
-Scratch files — PER-INGEST DIRECTORY ONLY. Several extractions run
-concurrently in this container and /tmp is shared: a generic name like
-/tmp/receipt_rot.jpg WILL be overwritten by a sibling agent mid-run,
-and you will silently read someone else's receipt (#143 — this
-happened: an agent extracted the neighbor's Trader Joe's receipt under
-a Kelly's Coffee ingest and rationalized the mismatch as a stale EXIF
-preview). Rules:
-  - First command before any image work:
-      mkdir -p /tmp/${ctx.ingestId}
-    and create EVERY scratch file inside that directory.
-  - If a crop/rotation ever shows a DIFFERENT merchant than your first
-    read of the original upload, do NOT rationalize it (no "stale
-    preview" theories). Re-read the ORIGINAL file at
-    ${ctx.filePath} and trust only what it shows.
-
-Tool discipline — SEQUENTIAL Bash calls only. Issue Bash tool calls one
-at a time and wait for each result before deciding the next command.
-NEVER batch multiple Bash invocations into one parallel tool-call block:
-if any one errors, every sibling call is cancelled mid-flight, and the
-cascade of cancellations is disorienting enough to corrupt your own
-extraction state (#126). One command, one result, then the next.
-
-── Priority & effort budget — READ FIRST, governs everything below ────
-
-This job has ONE required deliverable plus a best-effort tail. Keep them
-straight, or you will burn minutes on polish while the core sits unfinished.
-Trace evidence: routine receipts finish in ~7 tool calls, but some balloon
-to 40+ turns — and the extra 30 turns are almost always merchant enrichment
-(Google fetches, storefront photos, brand icons), NOT harder extraction.
-
-CORE — required. Do this and commit it no matter what:
-  classify → extract fields → write the balanced double-entry transaction
-  (+ postings + line items + document link) → close the ingest in Phase 5.
-  A run that commits a correct, balanced transaction and closes the ingest
-  is a SUCCESS even if it did zero enrichment.
-
-ENRICHMENT — best-effort, SECONDARY. You may abbreviate or SKIP any of it:
-  Phase 3 (Google place resolve / multilingual fetch / storefront photos)
-  and the brand-icon resolution pipeline. These are polish and a cache.
-  You have full authority to skip them. They must NEVER:
-    • block, delay, or fail the core write;
-    • trigger a self-correction loop — if a step errors or a column/table
-      surprises you, do NOT grind on it; record it briefly and move on;
-    • keep you working once the core is committed and marginal value is low.
-
-Spend effort PROPORTIONAL to difficulty and value. A routine receipt from
-an obvious merchant should finish in a handful of tool calls. If you notice
-you are many turns deep and the core is already committed, STOP enriching
-and go close the ingest.
-
-Skip heuristics — YOUR judgment, examples not an exhaustive rulebook:
-  • Place already cached (Phase 3b hit) → make zero outbound Google calls.
-  • Globally English-first brand with no CJK anywhere on the receipt →
-    skip storefront-photo OCR AND skip downloading photos; there is nothing
-    Chinese to find, so the fetch is pure waste.
-  • Storefront photos are only worth downloading when you actually need
-    them for CJK OCR (Phase 3d). Otherwise skip the download entirely —
-    they are a nice-to-have cache, not part of a complete extraction.
-  • Brand-icon resolution is optional visual polish. Do it when it is quick
-    and the asset is readily found; skip it when the core is done and it is
-    not. Never chase an icon across many fallback providers.
-  • The FREE checks stay ON: receipt-OCR CJK (Phase 3e) and the date
-    self-check (Phase 3.5 Checks A/B) cost no extra calls — always do them.
-    (Phase 3.5 Check C reuses an existing geocode, so it is naturally
-    skipped whenever you skipped Phase 3 — it never forces a new call.)
-
-When you deliberately skip an enrichment step, record it so the trace shows
-a decision, not a failure:
-  metadata.enrichment_skipped = ['photos','brand_icon', ...]   -- reasons ok
+${agentHygiene({ scratchDir, filePath: ctx.filePath })}
 ${renderActiveLessons()}
-── Reading the document (especially PDFs) ────────────────────────────
-
-For a PDF, do NOT hand-parse the byte structure (decompressing streams,
-mapping Form XObjects, sorting content-stream placements) — that path is
-slow and error-prone. Rasterize to an image and read the pixels, which is
-what you do best:
-
-  pdftoppm -png -r 200 "${ctx.filePath}" /tmp/${ctx.ingestId}/page
-  # → /tmp/${ctx.ingestId}/page-1.png, page-2.png, …  then Read those PNGs.
-
-\`pdftoppm\` and \`pdftotext\` (poppler) plus \`gs\` (ghostscript) are
-installed. \`pdftotext -layout "${ctx.filePath}" -\` gives a fast text
-layer for text-based PDFs; when the PDF is a flattened form or its text
-layer is empty/garbled, prefer the rasterized PNG. Only fall back to
-manual stream decoding if those tools are genuinely unavailable.
+${phase0DocumentRead({ filePath: ctx.filePath, scratchDir })}
 
 ── Phase 1 — Classify ─────────────────────────────────────────────────
 
@@ -244,8 +128,7 @@ Read the file (image / pdf / html / .eml) and decide which category:
   statement_pdf   credit-card or bank statement with many line items
   unsupported     anything else (W-2, menu, junk, illegible, non-financial)
 
-Reason in plain text first. Chain-of-thought measurably improves OCR.
-Do NOT use \`--json-schema\`-style structured output.
+${NO_JSON_SCHEMA_RULE}
 
 ── Phase 2 — Extract ──────────────────────────────────────────────────
 
@@ -255,6 +138,8 @@ For receipt_image / receipt_email / receipt_pdf, pull out:
   occurred_on   : date in YYYY-MM-DD form (read from the document —
                   NEVER fall back to today's date). If year is missing,
                   infer from nearby context (statement period etc.).
+  occurred_at   : timestamp YYYY-MM-DD HH:MM:SS+TZ if a time is
+                  printed; NULL otherwise
   total_minor   : the receipt's FINAL "Grand Total" — the amount actually
                   charged — in the currency's minor unit (integer cents for
                   USD, whole units for JPY). Include handwritten tips.
@@ -280,386 +165,23 @@ For receipt_image / receipt_email / receipt_pdf, pull out:
                   receipt_email / receipt_pdf. Statement PDFs
                   continue to skip items (each statement row IS a
                   transaction, no sub-itemization possible).
-  raw_text      : optional full transcription (helps debugging)
+  raw_text      : full transcription (written to \`documents.ocr_text\`)
 
-── items[] shape (per line on the receipt) ───────────────────────────
+${ITEM_SCHEMA}
 
-Each \`item\` object has these fields:
+${LINE_TYPE_VOCAB_AND_NAMES}
 
-  line_no            int      1-based, preserves the order printed
-                              on the receipt
-  parent_line_no     int|null  #162 CANONICAL TWO-LEVEL RULE. When this
-                              line is a PAID modifier / add-on / topping /
-                              size-upgrade that belongs to another item,
-                              set this to that owning item's line_no. NULL
-                              for top-level items and for tax/tip/discount
-                              audit rows. See the "Two-level line-items"
-                              block below — this is how a "+$3.00 Fish
-                              Cutlet" add-on attaches to its parent dish
-                              instead of floating as a peer line.
-  raw_name           text     the line as printed, verbatim (don't
-                              normalize — preserve abbreviations,
-                              brand prefixes, codes)
-  normalized_name    text|null brand-stripped human-readable form
-                              (e.g. "KS PPR TWLS 12CT" → "Paper
-                              Towels"). NULL when the raw name is
-                              already clean or impossible to clean.
-                              #162: this is the CLEAN ITEM NAME ONLY —
-                              never append a relational suffix like
-                              "(curry modifier)" / "(curry topping)".
-                              A modifier's name is just "Fish Cutlet",
-                              and parent_line_no carries the relationship.
-  quantity           num|null  2, 0.5, 1 default if unprinted
-  unit               text|null "ct", "lb", "kg", "oz", "ea", "ml",
-                              or NULL when not printed
-  unit_price_minor   int|null  minor units (cents for USD), NULL when
-                              not printed (single line items often omit)
-  line_total_minor   int       REQUIRED. Minor units. Signed —
-                              negative for line-level discounts /
-                              coupons / store-applied promos
-  currency           text      ISO 4217, same as the transaction
-  item_class         enum      one of:
-                                 durable      — expected life ≥ 1 year
-                                                (electronics, furniture,
-                                                appliances, clothing,
-                                                kitchenware, tools)
-                                 consumable   — used up in weeks/months
-                                                (cleaning supplies,
-                                                toiletries, batteries,
-                                                fuel, OTC meds, paper
-                                                products, light bulbs)
-                                 food_drink   — anything edible/potable
-                                 service      — non-physical (massage,
-                                                haircut, delivery fee,
-                                                itemized service charge)
-                                 other        — refunds, gift cards,
-                                                tax appearing as its
-                                                own line. Rare; if you
-                                                use this often, the
-                                                receipt is probably
-                                                ambiguous — flag in tags.
-  durability_tier    enum|null only when item_class='durable':
-                                 luxury   — line total > \$200 OR brand
-                                            is luxury-list (Apple
-                                            high-end, LV, Hermès, …)
-                                 standard — otherwise
-                                NULL for non-durable items.
-  food_kind          enum|null only when item_class='food_drink':
-                                 restaurant_dish — dining/cafe merchant
-                                 grocery_food    — market for home cook
-                                 beverage        — drinks bought as
-                                                   drinks (latte, water,
-                                                   beer). Alcohol →
-                                                   add "alcohol" tag.
-                                NULL for non-food items.
-  tags               text[]|null freeform low-trust signals:
-                                ["alcohol","cold","organic","sale",
-                                 "imported","handwritten","unclear"]
-  confidence         enum      one of:
-                                 high   — line crisp, totals tie
-                                 medium — readable but ambiguous
-                                 low    — thermal-paper smudge,
-                                          ink fade, partial occlusion
+${LINE_ITEM_COVERAGE_AND_BRIDGE}
 
-  ── Phase 1 of #84: products SSOT + allocation fields ──
+${LINE_ITEM_TWO_LEVEL_RULE}
 
-  line_type          text       prompt-recommended values:
-                                 product  — the default, an actual line
-                                 tax      — printed tax aggregate row
-                                 tip      — printed tip aggregate row
-                                 discount — store discount aggregate row
-                                 shipping | surcharge | service_fee |
-                                 gift_card | …
-                                Invent a snake_case label when none fit.
-                                tax/tip/discount rows MUST appear if
-                                printed — they're the audit baseline
-                                against the per-line allocations below.
-
-  product_key        text|null  kebab-case canonical key. REQUIRED for
-                                line_type='product'; NULL for tax/tip/
-                                discount rows. Format: ^[a-z0-9-]+\$.
-                                Same product → same key forever.
-                                Variants get distinct keys:
-                                  iphone-15-pro-natural-titanium-256
-                                  iphone-15-pro-blue-titanium-256
-                                  kirkland-paper-towels-12ct
-                                  starbucks-grande-latte
-                                  costco-gas-regular   (NOT just "gas")
-                                Don't include the merchant id in the key
-                                — merchant scoping lives on a separate
-                                column.
-
-  product_brand_id   text|null  the manufacturer brand, NOT the seller.
-                                "apple" for iPhone, "kirkland" for KS
-                                products, "starbucks" for in-store
-                                espresso. Mirror the merchant block's
-                                brand_id rules.
-
-  product_merchant_exclusive bool|null
-                                true  → this product only exists at
-                                        this merchant (Crunchwrap @
-                                        Taco Bell, AYCE @ Sichuan Spicy
-                                        Bay, in-store private label).
-                                        Phase 4 binds product.merchant_id
-                                        to this receipt's merchant.
-                                false → portable / cross-merchant
-                                        (iPhone, Coke, brand-name goods).
-                                        product.merchant_id stays NULL
-                                        and the row shares across stores.
-
-  product_model      text|null   "M3 13\\" 256GB", "iPad Pro 11\\""
-  product_color      text|null   "Natural Titanium", "Black", "Red"
-  product_size       text|null   "L", "12 ct", "750 ml"
-  product_variant    text|null   #162 CANONICAL: a single human-readable
-                                string of THIS line's ZERO-COST
-                                customizations — free options that change
-                                the item but add no price (少糖 / 半糖 /
-                                去冰 / "Less Sugar" / "Ice Blended" /
-                                "no cilantro" / a free spice level).
-                                Join multiple with ", ". NEVER put a PAID
-                                add-on here (those become their own priced
-                                child line via parent_line_no). Also used
-                                as the catalog product's free-text variant
-                                (flavor, fit, finish). NULL when the line
-                                has no free customizations.
-  product_sku        text|null   when printed on the receipt
-  product_manufacturer text|null when the brand and the manufacturer
-                                differ ("kirkland" brand made by
-                                "georgia-pacific" manufacturer); leave
-                                NULL when they match.
-
-  tax_minor          int|null    per-line tax share allocated from the
-                                printed tax aggregate. See Phase 2.7
-                                allocation logic. NULL on tax/tip/
-                                discount rows themselves and on lines
-                                you decide are non-taxable.
-  tip_share_minor    int|null    per-line tip share from printed tip.
-  discount_share_minor int|null  per-line discount share. Signed
-                                positive (always reduces). NULL when
-                                no discount applies.
-
-Arithmetic invariant — Σ line_total_minor across all items SHOULD
-approximate the receipt's printed subtotal (within \$0.01 rounding;
-tax/tip/discount lines are themselves items or excluded — see
-Examples). When the sum is off by more than \$0.50, drop confidence
-to "low" on the items that look most suspect.
-
-If you cannot itemize at all (total-only receipt, unreadable item
-section, illegible thermal print) emit ONE item with
-item_class='other', confidence='low', raw_name='TOTAL ONLY',
-line_total_minor=<TOTAL_MINOR>, and a tags entry explaining why
-("unreadable", "no-item-section").
-
-── Two-level line-items — the ONE rule for modifiers (#162) ───────────
-
-Restaurant / cafe / boba receipts print a dish or drink followed by
-its modifiers (toppings, add-ons, size upgrades, sugar/ice levels,
-spice levels). Decide each modifier's fate by ONE test — does it have
-a PRICE?
-
-  PRICED add-on  → it is a LINE.
-    Emit it as its OWN item object with a real line_total_minor, and
-    set parent_line_no = the owning dish/drink's line_no. Give it a
-    clean normalized_name ("Fish Cutlet", "Large Rice", "Soybean
-    Mousse") — NO "(curry modifier)" / "(topping)" relational suffix;
-    parent_line_no already encodes the relationship.
-    Keep item_class/food_kind consistent with the parent (a paid
-    topping on a dish is still food_drink / restaurant_dish).
-
-    ADDITIVE vs INCLUSIVE pricing — get the parent's line_total right:
-    • ADDITIVE (e.g. CoCo): the dish shows a base price and each paid
-      modifier is printed with its own price ADDED on top. Keep the
-      parent at its base; the children carry their own prices; they
-      sum naturally.
-    • INCLUSIVE (common on Snackpass / boba / combo receipts): the
-      item shows ONE all-in customized price and the modifier prices
-      are COMPONENTS of it, not charged on top. To split without
-      double-counting, REDUCE the parent's line_total to the base =
-      (displayed price − Σ priced add-ons); the children then re-add
-      up to the displayed price.
-    INVARIANT either way: parent base + Σ its child add-ons = the price
-    actually charged for that item. NEVER leave the parent at the
-    all-in price AND also emit priced children — that double-counts and
-    breaks Σ line_total = subtotal.
-
-  ZERO-COST option → it is an ATTRIBUTE.
-    Do NOT emit a separate line. Fold it into the PARENT item's
-    product_variant string ("Less Sugar", "No Ice", "Spice Level 2",
-    "no cilantro"). Multiple free options join with ", ".
-
-Never do the reverse: never bury a priced add-on inside a
-product_variant string (it would vanish from the ledger totals), and
-never spawn a peer line for a free customization (it would double the
-item count and break Σ line_total).
-
-If a modifier's price is genuinely not itemized on the source (some
-receipts bundle "Milk Tea +Boba" at one blended price with no
-breakout), you cannot invent a split: keep the add-on name in the
-parent's product_variant and add a "variant-price-unresolved" tag on
-the parent so the limitation is auditable. Prefer a priced child line
-whenever the source shows any separable price.
-
-── Worked examples ───────────────────────────────────────────────────
-
-Two-level dish with paid modifiers (#162) — real CoCo Ichibanya order:
-two plain dishes, then a "Fried Chicken Curry" $14.64 base with three
-separately-PRICED modifiers (Large Rice $1.00, Level 4 spice $0.80,
-Fish Cutlet $3.00). Every modifier here is priced, so every one is its
-own child line (none go to product_variant); if any had been free
-("Less Sauce", "No Onion") it would instead ride on line 3's
-product_variant string:
-  items = [
-    {"line_no":1, "raw_name":"Naan Bread", "normalized_name":"Naan Bread",
-     "parent_line_no":null, "quantity":1, "unit":"ea",
-     "unit_price_minor":250, "line_total_minor":250, "currency":"USD",
-     "item_class":"food_drink", "food_kind":"restaurant_dish",
-     "confidence":"high"},
-    {"line_no":2, "raw_name":"Garlic Naan", "normalized_name":"Garlic Naan",
-     "parent_line_no":null, "quantity":1, "unit":"ea",
-     "unit_price_minor":300, "line_total_minor":300, "currency":"USD",
-     "item_class":"food_drink", "food_kind":"restaurant_dish",
-     "confidence":"high"},
-    {"line_no":3, "raw_name":"Fried Chicken Curry",
-     "normalized_name":"Fried Chicken Curry", "parent_line_no":null,
-     "quantity":1, "unit":"ea", "unit_price_minor":1464,
-     "line_total_minor":1464, "currency":"USD", "item_class":"food_drink",
-     "food_kind":"restaurant_dish", "confidence":"high"},
-    {"line_no":4, "raw_name":"Large Rice", "normalized_name":"Large Rice",
-     "parent_line_no":3, "quantity":1, "unit":"ea",
-     "unit_price_minor":100, "line_total_minor":100, "currency":"USD",
-     "item_class":"food_drink", "food_kind":"restaurant_dish",
-     "confidence":"high"},
-    {"line_no":5, "raw_name":"Level 4", "normalized_name":"Spice Level 4",
-     "parent_line_no":3, "quantity":1, "unit":"ea",
-     "unit_price_minor":80, "line_total_minor":80, "currency":"USD",
-     "item_class":"food_drink", "food_kind":"restaurant_dish",
-     "confidence":"high"},
-    {"line_no":6, "raw_name":"Fish Cutlet", "normalized_name":"Fish Cutlet",
-     "parent_line_no":3, "quantity":1, "unit":"ea",
-     "unit_price_minor":300, "line_total_minor":300, "currency":"USD",
-     "item_class":"food_drink", "food_kind":"restaurant_dish",
-     "confidence":"high"}
-    // + a tax line ($1.93) with line_type='tax'. Σ product lines = $24.94
-    // subtotal. Modifiers are children of line 3, NOT peers named
-    // "Fish Cutlet (curry topping)", NOT folded into product_variant.
-  ]
-
-Boba drink, free customizations only (#162)
-(3CAT "Brown Sugar Milk Tea" $5.50, Less Sugar + Ice Blended, both free):
-  items = [
-    {"line_no":1, "raw_name":"Brown Sugar Milk Tea",
-     "normalized_name":"Brown Sugar Milk Tea", "parent_line_no":null,
-     "product_variant":"Less Sugar, Ice Blended",
-     "quantity":1, "unit":"ea", "unit_price_minor":550,
-     "line_total_minor":550, "currency":"USD", "item_class":"food_drink",
-     "food_kind":"beverage", "confidence":"high"}
-  ]
-  If that same drink instead showed "+Soybean Mousse $0.75" printed
-  with a price, Soybean Mousse becomes line_no 2 with parent_line_no=1
-  and line_total_minor=75. If the price is NOT itemized, keep
-  "+Soybean Mousse" in product_variant and tag line 1
-  "variant-price-unresolved".
-
-Boba drink, INCLUSIVE paid add-ons (#162)
-(3CAT "Avomango Sweet Dew" shown at ONE all-in $9.49; its +Soybean
-Mousse ($1.25) and +Agar Boba ($0.75) are COMPONENTS of that $9.49,
-and Less Sugar / Ice Blended are free). Reduce the parent to base
-$7.49 so base + add-ons re-sum to the $9.49 actually charged:
-  items = [
-    {"line_no":1, "raw_name":"Avomango Sweet Dew",
-     "normalized_name":"Avomango Sweet Dew", "parent_line_no":null,
-     "product_variant":"Less Sugar, Ice Blended",
-     "quantity":1, "unit":"ea", "unit_price_minor":749,
-     "line_total_minor":749, "currency":"USD", "item_class":"food_drink",
-     "food_kind":"beverage", "confidence":"high"},
-    {"line_no":2, "raw_name":"Soybean Mousse",
-     "normalized_name":"Soybean Mousse", "parent_line_no":1,
-     "quantity":1, "unit":"ea", "unit_price_minor":125,
-     "line_total_minor":125, "currency":"USD", "item_class":"food_drink",
-     "food_kind":"beverage", "confidence":"high"},
-    {"line_no":3, "raw_name":"Agar Boba", "normalized_name":"Agar Boba",
-     "parent_line_no":1, "quantity":1, "unit":"ea",
-     "unit_price_minor":75, "line_total_minor":75, "currency":"USD",
-     "item_class":"food_drink", "food_kind":"beverage", "confidence":"high"}
-    // base 749 + 125 + 75 = 949 = the price charged for the drink.
-    // Do NOT emit the parent at 949 AND these children — that is 1074,
-    // double-counting $1.25+$0.75. If the add-on prices were NOT shown,
-    // keep them in product_variant + "variant-price-unresolved" instead.
-  ]
-
-Costco gas (single line):
-  items = [
-    {"line_no":1, "raw_name":"GAS REG", "normalized_name":"Regular Gas",
-     "quantity":12.345, "unit":"gal", "unit_price_minor":419,
-     "line_total_minor":5176, "currency":"USD",
-     "item_class":"consumable", "tags":["fuel"], "confidence":"high"}
-  ]
-
-AYCE sushi dinner ($46.20):
-  items = [
-    {"line_no":1, "raw_name":"AYCE Lunch", "normalized_name":"All-You-Can-Eat Lunch",
-     "quantity":2, "unit":"ea", "unit_price_minor":2199,
-     "line_total_minor":4398, "currency":"USD", "item_class":"food_drink",
-     "food_kind":"restaurant_dish", "confidence":"high"},
-    {"line_no":2, "raw_name":"Hot Tea", "normalized_name":"Hot Tea",
-     "quantity":2, "unit":"ea", "unit_price_minor":150,
-     "line_total_minor":300, "currency":"USD", "item_class":"food_drink",
-     "food_kind":"beverage", "confidence":"high"}
-  ]
-
-Best Buy laptop ($1,599):
-  items = [
-    {"line_no":1, "raw_name":"MBA M3 13 256GB", "normalized_name":"MacBook Air M3 13\" 256GB",
-     "quantity":1, "unit":"ea", "unit_price_minor":159900,
-     "line_total_minor":159900, "currency":"USD",
-     "item_class":"durable", "durability_tier":"luxury",
-     "tags":["electronics","apple"], "confidence":"high"}
-  ]
+${LINE_ITEM_WORKED_EXAMPLES}
 
 For statement_pdf, pull rows: { date, payee, amount_minor }.
 
 For unsupported, record a short reason.
 
-── Phase 2.7 — Per-line tax / tip / discount allocation (#84) ─────────
-
-Receipts print aggregate tax / tip / discount; users want "what did
-this specific line cost me, all-in." Allocate per-line at ingest.
-Recommended logic (apply real arithmetic; do NOT hard-code rates):
-
-Tax allocation:
-  1. Look for per-line taxability markers ("T", "T1/T2", asterisks
-     next to specific lines, "Taxable" labels).
-  2. If markers present: \`tax_minor\` for each taxable line =
-     ROUND(printed-tax-total × line_total_minor / Σ taxable lines).
-     Non-taxable lines → tax_minor = NULL.
-  3. If no markers: treat all line_type='product' rows as equally
-     taxable and allocate proportionally.
-  4. Make Σ tax_minor exactly match the printed tax (absorb the
-     rounding remainder on the largest line).
-
-Tip allocation (dining receipts):
-  Split the printed tip total proportionally across product lines
-  by \`line_total_minor\`. Tips are for the whole meal.
-
-Discount allocation:
-  Receipt names the target ("20% off Item X") → put it all on that
-  line. Whole-order ("\$5 off subtotal") → split proportionally.
-  BOGO / "buy 2 get 1 free" / promo edge cases → use judgment;
-  record the reasoning in transactions.metadata.allocation_audit.
-
-Always emit the printed tax / tip / discount rows themselves as
-items with line_type ∈ ('tax','tip','discount') and product_key=NULL.
-Their tax_minor / tip_share_minor / discount_share_minor stay NULL
-— a tax line is not itself taxed.
-
-Final self-check before COMMIT:
-  Σ effective_total_minor (line_type='product') ≈ transactions.total
-  Σ tax_minor      ≈ items where line_type='tax'
-  Σ tip_share_minor ≈ items where line_type='tip'
-  Σ discount_share_minor ≈ items where line_type='discount'
-Discrepancies > 1¢ → record in transactions.metadata.allocation_audit
-(structured object: \`{kind, expected, got, delta}\`). Don't block
-ingest — just log.
+${ALLOCATION_LOGIC}
 
 ── Phase 2.5 — Merchant canonicalization (#64) ────────────────────────
 
@@ -1008,56 +530,7 @@ Also record provenance in metadata:
 This phase is FREE — it uses OCR you've already done. Always run
 it before giving up on the Chinese name.
 
-── Phase 3.5 — Targeted OCR self-check (date + payee only) ────────────
-
-Round 1 + Round 2 (40 receipts total) showed that **failures cluster
-on two axes**: (a) date OCR errors (wrong year, day/month digit swaps)
-and (b) payee OCR errors when a merchant name is ambiguous. Generic
-"re-read the receipt" verification is net-zero — it adds prompt length
-without improving digit accuracy. So this phase is **narrow and
-evidence-driven**: only the two checks that provably help.
-
-### Check A — Year sanity (30-second check, catches #27 regression)
-
-Before committing your YYYY-MM-DD:
-
-  1. What year did you extract? Say it out loud: "I extracted year YYYY."
-  2. Today's date (from \`date\` command if needed) is 2026-04-20.
-  3. Is your extracted year more than 12 months before today? Receipts
-     are almost always from the current or previous calendar year.
-  4. If your year is 2023 or earlier AND today is 2026: **LOOK AGAIN**
-     at the year digit on the receipt. It is statistically extremely
-     unlikely that a receipt processed today is 2+ years old.
-     Common misread: "2025" rendered as "2023" on faint thermal paper;
-     the middle digit is usually '2' with the last digit 5 vs 3.
-
-### Check B — Multi-candidate date enumeration (catches day-digit swaps)
-
-Receipts often have multiple date-like strings: header print date,
-transaction date, auth code timestamp, rewards expiry. They're NOT
-all the same date.
-
-Before picking ONE \`occurred_on\`:
-
-  1. List every date-like string you can see on the receipt. Examples:
-       - "09/30/2025 14:22:07" (top, likely transaction time)
-       - "Valid through 12/31/2025" (bottom coupon)
-       - "Auth code 092525" (middle, could be date-embedded)
-  2. Identify which is the transaction date. It's usually:
-       - Near the top (header), OR
-       - Adjacent to total/payment line, OR
-       - Labeled "Date:" / "Trans Date:" / "Sale Date:"
-  3. If only ONE date appears, use it. If multiple, pick by label
-     proximity to total/tender.
-  4. For the chosen date, verify DAY digits specifically — in US
-     MM/DD/YYYY format, day digits can be transposed (30↔03, 28↔82).
-     Day must be 1–31; month must be 1–12. If either violates, the
-     digits are swapped.
-
-Emit your date-candidate list in metadata:
-
-  "date_candidates": ["09/30/2025", "12/31/2025"],
-  "chosen_date_reason": "top of receipt adjacent to transaction time"
+${DATE_SELF_CHECK}
 
 ### Check C — Payee cross-check via Google (KEEP — evidence-proven)
 
@@ -1082,23 +555,7 @@ Compare Google's \`name\` with your OCR'd payee:
     Wall Supermarket"): prefer the receipt's printed English/full
     form; record Google's in metadata.ocr_audit.note as context.
 
-### REQUIRED metadata.ocr_audit shape
-
-You MUST populate this key on every receipt ingest (not optional):
-
-  "ocr_audit": {
-    "ocr_raw_payee": "<what you read from the receipt header>",
-    "google_name": "<what Google returned, or null if no geocode>",
-    "correction_applied": true | false,
-    "date_candidates": [ "...", "..." ],
-    "chosen_date_reason": "...",
-    "year_sanity_ok": true | false,
-    "note": "optional freeform observation (e.g., thermal-paper faded, bilingual name, etc.)"
-  }
-
-An ingest without this key is considered incomplete. Emit it even
-when no corrections were needed (correction_applied=false,
-note="clean extraction").
+${OCR_AUDIT_REQUIREMENT}
 
 ### REQUIRED metadata.extraction shape (provenance stamp — #88 / #80)
 
@@ -1110,7 +567,7 @@ prompt/model under which extraction actually ran:
   "extraction": {
     "prompt_version": "${PROMPT_VERSION}",     // bumped manually on meaningful prompt edits
     "prompt_git_sha": "${buildInfo.gitSha}",    // build-time git rev
-    "model":          "${process.env.CLAUDE_MODEL ?? "sonnet"}",
+    "model":          "${EXTRACTION_MODEL}",
     "ran_at":         NOW()                                                    // wall-clock at COMMIT
   }
 
@@ -1129,7 +586,7 @@ v1 schema primer (workspace_id is required on every row):
                      liability: Credit Card
                      asset: Cash, Checking, Savings
   transactions    — one per receipt (or one per statement row)
-                   status IN (draft|posted|voided|reconciled|error)
+                   status IN (draft|posted|reconciled|error)
                    set status='posted' for completed receipts.
   postings        — ≥2 per transaction; SUM(amount_minor) PER currency
                    MUST EQUAL 0. Debit expense = positive; credit
@@ -1181,20 +638,8 @@ exact bracket-free form in BOTH the dedup pre-check query AND when you store
 querying the other silently breaks dedup → duplicate transactions. One form,
 everywhere.
 
-**Decoding the body.** The \`.eml\` body is MIME-encoded (quoted-printable
-or base64, sometimes with non-UTF-8 bytes). Do NOT try to read a raw
-base64 blob, and do NOT improvise your own decoder. Run exactly this
-tested one-liner (stdlib only — handles QP, base64, and charset quirks;
-note \`message_from_binary_file\` + \`policy=email.policy.default\`, both
-required):
-
-  python3 -c "import email,email.policy,sys; m=email.message_from_binary_file(open(sys.argv[1],'rb'),policy=email.policy.default); p=m.get_body(preferencelist=('html','plain')); print(p.get_content() if p else '(no text body found)')" "${ctx.filePath}" > /tmp/email-body.txt
-
-then Read \`/tmp/email-body.txt\`. If (and only if) that command fails,
-fall back to reading the raw \`.eml\` directly — quoted-printable parts
-are human-readable as-is (ignore \`=3D\` and soft \`=\\n\` line-breaks).
-Try ONE approach at a time; never fire multiple decode attempts in
-parallel (see Tool discipline above).
+(Decode the body with the tested MIME one-liner from the "Reading the
+document" phase above before reading it.)
 
 1. **Dedup pre-check — skip the WHOLE ingest if this email was already
    ingested.** A re-forwarded copy has different bytes (so the sha256
@@ -1230,14 +675,7 @@ merchant brand = "best-buy"). \`products.brand_id\` is FK into
 \`brands\`, so before the BEGIN below, run one defensive UPSERT for
 every distinct product_brand_id present in items[]:
 
-  psql "\$DATABASE_URL" <<'SQL'
-    INSERT INTO brands (brand_id, name)
-    SELECT DISTINCT product_brand_id, product_brand_id
-      FROM jsonb_to_recordset($items$<ITEMS_JSON_ARRAY>$items$::jsonb)
-        AS item(product_brand_id text)
-     WHERE product_brand_id IS NOT NULL
-    ON CONFLICT (brand_id) DO NOTHING;
-  SQL
+${brandFkGuard()}
 
 This is a stub row (domain NULL); we don't run Phase 2.6 discovery
 for product brand_ids in v1. Phase 4b will skip them at the
@@ -1350,10 +788,12 @@ them first):
     ),
     tx AS (
       INSERT INTO transactions (
-        id, workspace_id, occurred_on, payee, status,
+        id, workspace_id, occurred_on, occurred_at, payee, status,
         source_ingest_id, merchant_id, metadata, created_by
       ) VALUES (
-        gen_random_uuid(), '${ctx.workspaceId}', '<YYYY-MM-DD>', '<PAYEE>', 'posted',
+        gen_random_uuid(), '${ctx.workspaceId}', '<YYYY-MM-DD>',
+        <'<YYYY-MM-DD HH:MM:SS+TZ>'::timestamptz | NULL>,
+        '<PAYEE>', 'posted',
         '${ctx.ingestId}',
         (SELECT id FROM m),
         jsonb_build_object(
@@ -1369,13 +809,14 @@ them first):
           'extraction', jsonb_build_object(
             'prompt_version', '${PROMPT_VERSION}',
             'prompt_git_sha', '${buildInfo.gitSha}',
-            'model',          '${process.env.CLAUDE_MODEL ?? "sonnet"}',
-            'ran_at',         NOW()
+            'model',          '${EXTRACTION_MODEL}',
+            'ran_at',         NOW(),
+            'source',         'ingest'
           ),
           -- items[] is REQUIRED for receipt_image / receipt_email /
-          -- receipt_pdf per #81 / PROMPT_VERSION 2.6. Statement_pdf
-          -- omits this key. Each object follows the schema in Phase 2.
-          'items', $items$<ITEMS_JSON_ARRAY>$items$::jsonb
+          -- receipt_pdf per #81. Statement_pdf omits this key. Each
+          -- object follows the schema in Phase 2.
+          'items', ${ITEMS_JSON_EXPR}
           -- add tax/tip/raw_text here if useful, as extra JSONB keys
         ),
         '${ctx.userId}'
@@ -1400,91 +841,20 @@ them first):
       ON CONFLICT DO NOTHING
       RETURNING transaction_id
     ),
-    -- #84 Phase 1: products SSOT upsert. The agent emits a
-    -- product_key per item; this CTE upserts the catalog row keyed by
-    -- (workspace_id, merchant_id, product_key) and returns its id.
-    -- merchant_id is NULL when product_merchant_exclusive=false (the
-    -- product is portable across stores) and the receipt's
-    -- merchant_id when true (in-store private label / dish).
-    -- Non-product lines (line_type ∈ tax/tip/discount/shipping/…) get
-    -- product_key=NULL and skip this step entirely (filtered by the
-    -- WHERE clause). NULLS NOT DISTINCT in the unique index makes
-    -- merchant_id=NULL participate.
-    p_upsert AS (
-      INSERT INTO products (
-        workspace_id, merchant_id, product_key, canonical_name,
-        item_class, brand_id, model, color, size, variant, sku,
-        manufacturer
-      )
-      SELECT '${ctx.workspaceId}',
-             CASE WHEN item.product_merchant_exclusive THEN (SELECT id FROM m) ELSE NULL END,
-             item.product_key,
-             COALESCE(item.normalized_name, item.raw_name),
-             item.item_class, item.product_brand_id,
-             item.product_model, item.product_color, item.product_size,
-             item.product_variant, item.product_sku, item.product_manufacturer
-      FROM jsonb_to_recordset($items$<ITEMS_JSON_ARRAY>$items$::jsonb) AS item(
-        line_no int, parent_line_no int, raw_name text, normalized_name text,
-        quantity numeric, unit text,
-        unit_price_minor bigint, line_total_minor bigint, currency text,
-        item_class text, durability_tier text, food_kind text,
-        tags text[], confidence text,
-        line_type text, product_key text, product_brand_id text,
-        product_merchant_exclusive boolean, product_model text,
-        product_color text, product_size text, product_variant text,
-        product_sku text, product_manufacturer text,
-        tax_minor bigint, tip_share_minor bigint, discount_share_minor bigint
-      )
-      WHERE COALESCE(item.line_type, 'product') = 'product' AND item.product_key IS NOT NULL
-      ON CONFLICT (workspace_id, merchant_id, product_key) DO UPDATE
-        SET updated_at = NOW(),
-            canonical_name = COALESCE(EXCLUDED.canonical_name, products.canonical_name),
-            brand_id       = COALESCE(EXCLUDED.brand_id,       products.brand_id),
-            item_class     = COALESCE(EXCLUDED.item_class,     products.item_class)
-      RETURNING id, product_key, merchant_id
-    ),
+${productsUpsert({ workspaceId: ctx.workspaceId, merchantIdExpr: "(SELECT id FROM m)" })},
     -- #81 Phase 2 + #84: relational line-items with product_id link
     -- and per-line allocation columns. Re-extract on the same tx
     -- bumps extraction_run and soft-deletes the prior run; this
     -- ingest path always writes the first run (run=1, retired_at=NULL).
     ti AS (
-      INSERT INTO transaction_items (
-        id, workspace_id, transaction_id, line_no, parent_line_no,
-        raw_name, normalized_name, product_variant, quantity, unit,
-        unit_price_minor, line_total_minor, currency,
-        item_class, durability_tier, food_kind, tags, confidence,
-        line_type, product_id, tax_minor, tip_share_minor,
-        discount_share_minor, extraction_run, extraction_version
-      )
-      SELECT gen_random_uuid(), '${ctx.workspaceId}', tx.id, item.line_no,
-             item.parent_line_no,
-             item.raw_name, item.normalized_name, item.product_variant,
-             item.quantity, item.unit,
-             item.unit_price_minor, item.line_total_minor, item.currency,
-             item.item_class, item.durability_tier, item.food_kind,
-             item.tags, item.confidence,
-             COALESCE(item.line_type, 'product'),
-             (SELECT pu.id FROM p_upsert pu
-                WHERE pu.product_key = item.product_key
-                  AND pu.merchant_id IS NOT DISTINCT FROM
-                      (CASE WHEN item.product_merchant_exclusive THEN (SELECT id FROM m) ELSE NULL END)
-                LIMIT 1),
-             item.tax_minor, item.tip_share_minor, item.discount_share_minor,
-             1, '${PROMPT_VERSION}'
-      FROM tx,
-        jsonb_to_recordset($items$<ITEMS_JSON_ARRAY>$items$::jsonb) AS item(
-          line_no int, parent_line_no int, raw_name text, normalized_name text,
-          quantity numeric, unit text,
-          unit_price_minor bigint, line_total_minor bigint, currency text,
-          item_class text, durability_tier text, food_kind text,
-          tags text[], confidence text,
-          line_type text, product_key text, product_brand_id text,
-          product_merchant_exclusive boolean, product_model text,
-          product_color text, product_size text, product_variant text,
-          product_sku text, product_manufacturer text,
-          tax_minor bigint, tip_share_minor bigint, discount_share_minor bigint
-        )
-      RETURNING id, product_id
+${transactionItemsInsert({
+  workspaceId: ctx.workspaceId,
+  txIdExpr: "tx.id",
+  runExpr: "1",
+  merchantIdExpr: "(SELECT id FROM m)",
+  fromPrefix: "tx,",
+  returning: "id, product_id",
+})}
     )
   SELECT tx.id AS tx_id FROM tx;
   COMMIT;
@@ -1498,38 +868,7 @@ optional; use the workspace base currency snapshot already on
 \`postings.amount_base_minor\` for total_spent_minor:
 
   psql "\$DATABASE_URL" <<'SQL'
-  WITH touched AS (
-    -- Only the products THIS ingest touched — recomputing the whole
-    -- workspace every ingest is O(N) per receipt → O(N²) over a backfill.
-    SELECT DISTINCT ti.product_id
-    FROM transaction_items ti
-    JOIN transactions t ON t.id = ti.transaction_id
-    WHERE t.source_ingest_id = '${ctx.ingestId}'
-      AND ti.product_id IS NOT NULL
-  ),
-  stats AS (
-    SELECT ti.product_id,
-           MIN(t.occurred_on)          AS first_on,
-           MAX(t.occurred_on)          AS last_on,
-           COUNT(DISTINCT ti.transaction_id) AS purchases,
-           SUM(ti.effective_total_minor)    AS total_minor
-    FROM transaction_items ti
-    JOIN transactions t ON t.id = ti.transaction_id
-    WHERE ti.workspace_id = '${ctx.workspaceId}'
-      AND ti.product_id IN (SELECT product_id FROM touched)
-      AND ti.retired_at IS NULL
-      AND ti.line_type = 'product'
-    GROUP BY ti.product_id
-  )
-  UPDATE products p SET
-    first_purchased_on = stats.first_on,
-    last_purchased_on  = stats.last_on,
-    purchase_count     = stats.purchases,
-    total_spent_minor  = stats.total_minor,
-    updated_at         = NOW()
-  FROM stats
-  WHERE p.id = stats.product_id
-    AND p.workspace_id = '${ctx.workspaceId}';
+${productAggregateRecompute({ workspaceId: ctx.workspaceId, touchedPredicate: `t.source_ingest_id = '${ctx.ingestId}'` })}
   SQL
 
 If you have a geocode result, run this AFTER the main transaction
@@ -1657,9 +996,20 @@ record \`file_path\` accordingly:
     "
   done
 
-Also stamp the document row (ties it back to this ingest):
+Also stamp the document row — it ties the file back to this ingest AND
+stores the OCR text, so \`documents.ocr_text\` is populated by BOTH the
+ingest and the re-extract path (it used to be re-extract only, which
+made every "what did the agent actually read?" question unanswerable
+for ingest-only documents):
 
-  psql "\$DATABASE_URL" -c "UPDATE documents SET source_ingest_id = '${ctx.ingestId}' WHERE id = '${ctx.documentId}';"
+  psql "\$DATABASE_URL" <<'SQL'
+    UPDATE documents
+       SET source_ingest_id  = '${ctx.ingestId}',
+           ocr_text          = '<RAW_TEXT, single-quote-escaped>',
+           ocr_model_version = '${EXTRACTION_MODEL}',
+           updated_at        = NOW()
+     WHERE id = '${ctx.documentId}';
+  SQL
 
 ### 4a-bis. owned_items judgment (#84 Phase 2)
 

--- a/src/ingest/reextract-prompt.ts
+++ b/src/ingest/reextract-prompt.ts
@@ -4,8 +4,12 @@
  *
  * Scope decision (Phase 4c of #80 / #91 MVP):
  *   - Re-extract = re-OCR the receipt against the **current** prompt
- *     and model. Refines payee, occurred_on, occurred_at, currency,
- *     total_minor on the existing transaction; refreshes `documents.ocr_text`.
+ *     and model. Refines payee, occurred_on, occurred_at and the
+ *     `items[]` line-item set on the existing transaction; refreshes
+ *     `documents.ocr_text`. It deliberately does NOT extract a
+ *     transaction total or currency — `transactions` has no such
+ *     columns (they live on `postings`, which are out of scope), so
+ *     asking for them was pure dead work.
  *   - It does NOT touch postings — re-running extraction could change
  *     category/amount and risk the double-entry sum-to-zero invariant.
  *     If category drift matters, edit postings explicitly via the
@@ -24,31 +28,45 @@
  *     reading `metadata.user_edited.<field>` so a user override survives
  *     re-extract verbatim.
  *
- * The prompt itself stays short because the heavy lifting (classify,
- * postings, place resolution) is gone. ~70 lines of prose vs.
- * `src/ingest/prompt.ts`'s ~800.
+ * The extraction CONTRACT — item schema, line_type vocabulary,
+ * two-level modifier rule, coverage invariant, allocation logic,
+ * worked examples, date self-check, psql/agent hygiene, and every
+ * items-related SQL fragment — is NOT restated here. It is imported
+ * from the shared modules (#164) that `prompt.ts` interpolates too,
+ * because the two hand-maintained copies had already drifted apart in
+ * ways that measurably degraded re-extract output.
  */
 import { buildInfo } from "../generated/build-info.js";
 import {
   PHASE_2_6_BRAND_DISCOVERY,
   PHASE_4B_4C_ICON_PIPELINE,
 } from "./brand-icon-prompt.js";
-
-/**
- * Bumped on meaningful re-extract prompt edits. Separate from
- * `PROMPT_VERSION` in `src/ingest/prompt.ts` because the two prompts
- * can drift independently — re-extract has a narrower job. Stamped
- * into `transactions.metadata.extraction.prompt_version` on every run
- * (overwriting the prior value), and into `derivation_events.prompt_version`.
- */
-export const REEXTRACT_PROMPT_VERSION = "1.8";
-
-/**
- * The model identifier we stamp into `documents.ocr_model_version`.
- * Matches the `--model` flag we pass to `claude -p`; kept in sync
- * with the env var fallback in `extractor.ts`.
- */
-export const REEXTRACT_MODEL = process.env.CLAUDE_MODEL || "sonnet";
+import {
+  PROMPT_VERSION,
+  EXTRACTION_MODEL,
+  NO_JSON_SCHEMA_RULE,
+  PSQL_DISCIPLINE,
+  DATE_SELF_CHECK,
+  OCR_AUDIT_REQUIREMENT,
+  agentHygiene,
+  renderActiveLessons,
+} from "./prompt-contract.js";
+import { phase0DocumentRead } from "./document-read-prompt.js";
+import {
+  ITEM_SCHEMA,
+  LINE_TYPE_VOCAB_AND_NAMES,
+  LINE_ITEM_TWO_LEVEL_RULE,
+  LINE_ITEM_COVERAGE_AND_BRIDGE,
+  ALLOCATION_LOGIC,
+  LINE_ITEM_WORKED_EXAMPLES,
+} from "./line-item-prompt.js";
+import {
+  ITEMS_JSON_EXPR,
+  brandFkGuard,
+  productsUpsert,
+  transactionItemsInsert,
+  productAggregateRecompute,
+} from "./items-sql.js";
 
 export interface ReExtractPromptContext {
   /** Absolute path inside the container where the original upload lives. */
@@ -65,6 +83,8 @@ export interface ReExtractPromptContext {
 }
 
 export function buildReExtractPrompt(ctx: ReExtractPromptContext): string {
+  const scratchDir = `/tmp/reextract-${ctx.transactionId}`;
+  const merchantIdExpr = `(SELECT merchant_id FROM transactions WHERE id = '${ctx.transactionId}')`;
   return `You are re-running extraction on a previously-ingested receipt.
 The transaction row already exists; your job is to refresh the
 receipt-readable fields against the current prompt/model. You will
@@ -80,17 +100,20 @@ Context variables for SQL (use as-is):
   WORKSPACE_ID  = '${ctx.workspaceId}'
   DOCUMENT_ID   = '${ctx.documentId}'
   USER_ID       = '${ctx.userId}'
-  PROMPT_VERSION   = '${REEXTRACT_PROMPT_VERSION}'
+  PROMPT_VERSION   = '${PROMPT_VERSION}'
   PROMPT_GIT_SHA   = '${buildInfo.gitSha}'
-  MODEL            = '${REEXTRACT_MODEL}'
+  MODEL            = '${EXTRACTION_MODEL}'
 
-DB connection: \`psql "\$DATABASE_URL"\` — the env var is set.
+${PSQL_DISCIPLINE}
+
+${agentHygiene({ scratchDir, filePath: ctx.filePath })}
+${renderActiveLessons()}
+${phase0DocumentRead({ filePath: ctx.filePath, scratchDir })}
 
 ── Phase 1 — Extract ──────────────────────────────────────────────────
 
 Read the file at the path above (same image / pdf / .eml the original
-ingest read). Reason in plain text first — chain-of-thought measurably
-improves OCR. Do NOT use \`--json-schema\`-style structured output.
+ingest read). ${NO_JSON_SCHEMA_RULE}
 
 Pull these fields. Use NULL when the field is not visible — never
 guess, never fall back to today's date.
@@ -99,106 +122,25 @@ guess, never fall back to today's date.
   occurred_on   : date in YYYY-MM-DD form (read from the document)
   occurred_at   : timestamp YYYY-MM-DD HH:MM:SS+TZ if a time is
                   printed; NULL otherwise
-  total_minor   : FINAL amount in the currency's minor unit (integer
-                  cents for USD, whole units for JPY). Include
-                  handwritten tips if visible.
-  currency      : ISO 4217 (USD, CNY, EUR, JPY, …)
   raw_text      : full transcription (for \`documents.ocr_text\`)
-  items         : REQUIRED structured line-item array per #81 / REEXTRACT_PROMPT_VERSION 1.1.
-                  Each item is one object with these fields:
-                    line_no            int (1-based, preserves order)
-                    parent_line_no     int|null #162 — when this line is a
-                                       PAID modifier/add-on/topping/size-
-                                       upgrade of another item, set to that
-                                       owning item's line_no; NULL for top-
-                                       level items and tax/tip/discount rows.
-                    raw_name           text (verbatim line)
-                    normalized_name    text|null (brand-stripped) — #162:
-                                       CLEAN ITEM NAME ONLY, never append a
-                                       relational suffix like "(curry
-                                       modifier)"/"(topping)".
-                    product_variant    text|null #162 — one string of THIS
-                                       line's ZERO-COST customizations
-                                       (少糖/去冰/"Less Sugar"/"no cilantro"/
-                                       free spice level), joined by ", ".
-                                       NEVER a paid add-on (that is its own
-                                       priced child line). NULL when none.
-                    quantity           num|null
-                    unit               text|null ("ct","lb","ea",…)
-                    unit_price_minor   int|null (minor units)
-                    line_total_minor   int REQUIRED (signed; negative for discounts)
-                    currency           ISO 4217 (same as transaction)
-                    item_class         enum:
-                                         durable    — life ≥ 1 year
-                                         consumable — used in weeks/months (fuel, paper, batteries)
-                                         food_drink — edible/potable
-                                         service    — non-physical (massage, delivery fee)
-                                         other      — refunds, gift cards, rare
-                    durability_tier    enum|null (only if durable): luxury|standard
-                                       (luxury when single-line total > \$200 OR known
-                                        luxury brand: Apple high-end, LV, Hermès, …)
-                    food_kind          enum|null (only if food_drink):
-                                         restaurant_dish|grocery_food|beverage
-                    tags               text[]|null (freeform: alcohol, cold, organic,
-                                                   sale, imported, handwritten, unclear)
-                    confidence         enum: high|medium|low
-                    line_type          enum: product|tax|tip|discount|
-                                       shipping|fee (default 'product'). #162:
-                                       ALWAYS emit the printed tax / tip /
-                                       discount / fee rows THEMSELVES as named
-                                       items with the matching line_type and
-                                       product_key=NULL — e.g. a "Snackpass
-                                       Credit" −\$5.00 row is line_type=
-                                       'discount' (tags=['promo']); a "Taxes &
-                                       Fees" \$0.51 row is line_type='tax'. Keep
-                                       the printed NAME in raw_name /
-                                       normalized_name. NEVER collapse them into
-                                       the top-level tax_minor/discount_minor
-                                       numbers only — that loses the name.
-                                       parent_line_no NULL for these rows.
+  items         : REQUIRED structured line-item array (#81). Each item
+                  is one object with the exact shape below.
 
-                  Σ line_total_minor across line_type='product' items SHOULD
-                  approximate the receipt's subtotal (within \$0.01); the tax /
-                  tip / discount / fee rows carry the rest (discount rows are
-                  negative), so Σ of ALL rows ≈ the final total. If the product
-                  sum is off by >\$0.50, drop confidence='low' on suspect items.
-                  Self-check before COMMIT: Σ tax rows ≈ printed tax, Σ discount
-                  rows ≈ printed discount, Σ product effective ≈ transaction total.
+${ITEM_SCHEMA}
 
-                  If you cannot itemize at all (total-only receipt, illegible
-                  thermal print), emit ONE item with item_class='other',
-                  confidence='low', raw_name='TOTAL ONLY',
-                  line_total_minor=<TOTAL_MINOR>, tags=['no-item-section'].
+${LINE_TYPE_VOCAB_AND_NAMES}
 
-                  #162 TWO-LEVEL RULE (modifiers). One test: does the
-                  modifier have a PRICE?
-                    PRICED add-on → its OWN item object with a real
-                      line_total_minor and parent_line_no = the owning
-                      dish/drink's line_no. Clean normalized_name (e.g.
-                      "Fish Cutlet", "Large Rice"), NO "(curry modifier)"
-                      suffix. Keep item_class/food_kind like the parent.
-                    ZERO-COST option → NOT a line; fold into the parent's
-                      product_variant string ("Less Sugar, No Ice").
-                  Never bury a priced add-on in product_variant (it would
-                  vanish from totals); never spawn a peer line for a free
-                  option. If a paid add-on's price is not itemized on the
-                  source, keep its name in the parent's product_variant and
-                  add a 'variant-price-unresolved' tag on the parent.
-                  ADDITIVE vs INCLUSIVE: if the item shows ONE all-in price
-                  that already CONTAINS its add-ons (Snackpass / boba /
-                  combo), REDUCE the parent's line_total to base =
-                  (displayed − Σ priced add-ons) so base + children re-sum
-                  to the charged price. INVARIANT: parent base + Σ children
-                  = price charged; never keep the parent at the all-in price
-                  AND emit priced children (double-counts, breaks Σ=subtotal).
-                  E.g. 3CAT "Avomango Sweet Dew" all-in $9.49 incl. +Soybean
-                  Mousse $1.25 + +Agar Boba $0.75 → parent base $7.49 + two
-                  child lines ($1.25, $0.75), free "Less Sugar, Ice Blended"
-                  in product_variant.
-                  Example: CoCo "Fried Chicken Curry" (line 1, $9.00,
-                  product_variant="Less Sauce") with +Large Rice $1.00,
-                  +Spice Level 4 $0.80, +Fish Cutlet $3.00 → three extra
-                  items, each parent_line_no=1, clean names, own prices.
+${LINE_ITEM_COVERAGE_AND_BRIDGE}
+
+${LINE_ITEM_TWO_LEVEL_RULE}
+
+${LINE_ITEM_WORKED_EXAMPLES}
+
+${ALLOCATION_LOGIC}
+
+${DATE_SELF_CHECK}
+
+${OCR_AUDIT_REQUIREMENT}
 
 Place resolution and merchant canonicalization are OUT OF SCOPE for
 re-extract — those have their own endpoints (\`POST /v1/places/:id/refresh\`
@@ -207,22 +149,16 @@ and the merchant enrichment loop). Do NOT touch \`place_id\`,
 
 Postings (the double-entry debit/credit rows under the transaction) are
 also OUT OF SCOPE — re-extract does not rewrite them. Do NOT touch
-\`postings\` or \`document_links\`.
+\`postings\` or \`document_links\`. The transaction's total and currency
+live there, so you do not extract them at all.
 
 ── Phase 2 — Write ────────────────────────────────────────────────────
 
 **Brand FK guard (#101).** Items may carry product_brand_id, which is
-FK into \`brands\`. Re-extract products UPSERT below would fail if the
-brand row doesn't exist. Run this defensively BEFORE the main block:
+FK into \`brands\`. The products UPSERT below would fail if the brand
+row doesn't exist. Run this defensively BEFORE the main block:
 
-  psql "\$DATABASE_URL" <<'SQL'
-    INSERT INTO brands (brand_id, name)
-    SELECT DISTINCT product_brand_id, product_brand_id
-      FROM jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb)
-        AS item(product_brand_id text)
-     WHERE product_brand_id IS NOT NULL
-    ON CONFLICT (brand_id) DO NOTHING;
-  SQL
+${brandFkGuard()}
 
 Run exactly ONE psql block. Substitute your extracted values for the
 placeholders; the CASE statements consult \`metadata.user_edited\` so a
@@ -244,35 +180,49 @@ user override survives this re-extract.
       WHEN (metadata->'user_edited'->>'payee')::boolean IS TRUE THEN payee
       ELSE '<PAYEE>'
     END,
-    metadata = jsonb_set(
-      jsonb_set(
-        jsonb_set(
-          COALESCE(metadata, '{}'::jsonb),
-          '{extraction}',
-          jsonb_build_object(
-            'prompt_version', '${REEXTRACT_PROMPT_VERSION}',
-            'prompt_git_sha', '${buildInfo.gitSha}',
-            'model',          '${REEXTRACT_MODEL}',
-            'ran_at',         NOW()::text,
-            'source',         're-extract'
-          )
-        ),
-        '{items}',
-        '<ITEMS_JSON_ARRAY>'::jsonb
+    -- Top-level jsonb merge. The extraction_history term MUST be
+    -- evaluated from the OLD metadata (it is, inside UPDATE ... SET),
+    -- so it captures the stamp this run is about to overwrite.
+    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+      -- Never destroy the previous provenance stamp: push the CURRENT
+      -- extraction object onto extraction_history, keeping the newest 5.
+      'extraction_history', (
+        SELECT COALESCE(jsonb_agg(h.elem ORDER BY h.ord), '[]'::jsonb)
+          FROM (
+            SELECT elem, ord
+              FROM jsonb_array_elements(
+                     COALESCE(metadata->'extraction_history', '[]'::jsonb)
+                     || CASE WHEN metadata->'extraction' IS NOT NULL
+                             THEN jsonb_build_array(metadata->'extraction')
+                             ELSE '[]'::jsonb END
+                   ) WITH ORDINALITY AS t(elem, ord)
+             ORDER BY ord DESC
+             LIMIT 5
+          ) h
       ),
-      '{re_extracted_at}',
-      to_jsonb(NOW()::text)
+      'extraction', jsonb_build_object(
+        'prompt_version', '${PROMPT_VERSION}',
+        'prompt_git_sha', '${buildInfo.gitSha}',
+        'model',          '${EXTRACTION_MODEL}',
+        'ran_at',         NOW()::text,
+        'source',         're-extract'
+      ),
+      'items', ${ITEMS_JSON_EXPR},
+      'ocr_audit', $audit$<OCR_AUDIT_JSON>$audit$::jsonb,
+      're_extracted_at', to_jsonb(NOW()::text)
     ),
     version = version + 1
-  WHERE id = '${ctx.transactionId}' AND workspace_id = '${ctx.workspaceId}';
+  WHERE id = '${ctx.transactionId}'
+    AND workspace_id = '${ctx.workspaceId}'
+    AND deleted_at IS NULL;
 
   UPDATE documents SET
     ocr_text          = '<RAW_TEXT, single-quote-escaped>',
-    ocr_model_version = '${REEXTRACT_MODEL}',
+    ocr_model_version = '${EXTRACTION_MODEL}',
     updated_at        = NOW()
   WHERE id = '${ctx.documentId}' AND workspace_id = '${ctx.workspaceId}';
 
-  -- #84 Phase 1: re-extract is now versioned (extraction_run counter
+  -- #84 Phase 1: re-extract is versioned (extraction_run counter
   -- bumps; old run rows soft-deleted via retired_at). Live aggregates
   -- read WHERE retired_at IS NULL, so old purchases drop out and new
   -- ones count immediately — purchase_count stays correct, no drift.
@@ -283,114 +233,26 @@ user override survives this re-extract.
     AND retired_at IS NULL;
 
   -- Insert the freshly extracted rows under run = MAX(prev)+1.
-  -- Capture the run number in a temp var via WITH ... SELECT, then
-  -- INSERT. The agent computes this run number inline below.
   WITH next_run AS (
     SELECT COALESCE(MAX(extraction_run), 0) + 1 AS run
     FROM transaction_items
     WHERE transaction_id = '${ctx.transactionId}'
   ),
-  p_upsert AS (
-    INSERT INTO products (
-      workspace_id, merchant_id, product_key, canonical_name,
-      item_class, brand_id, model, color, size, variant, sku,
-      manufacturer
-    )
-    SELECT '${ctx.workspaceId}',
-           CASE WHEN item.product_merchant_exclusive THEN
-             (SELECT merchant_id FROM transactions WHERE id = '${ctx.transactionId}')
-           ELSE NULL END,
-           item.product_key,
-           COALESCE(item.normalized_name, item.raw_name),
-           item.item_class, item.product_brand_id,
-           item.product_model, item.product_color, item.product_size,
-           item.product_variant, item.product_sku, item.product_manufacturer
-    FROM jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb) AS item(
-      line_no int, parent_line_no int, raw_name text, normalized_name text,
-      quantity numeric, unit text,
-      unit_price_minor bigint, line_total_minor bigint, currency text,
-      item_class text, durability_tier text, food_kind text,
-      tags text[], confidence text,
-      line_type text, product_key text, product_brand_id text,
-      product_merchant_exclusive boolean, product_model text,
-      product_color text, product_size text, product_variant text,
-      product_sku text, product_manufacturer text,
-      tax_minor bigint, tip_share_minor bigint, discount_share_minor bigint
-    )
-    WHERE COALESCE(item.line_type, 'product') = 'product' AND item.product_key IS NOT NULL
-    ON CONFLICT (workspace_id, merchant_id, product_key) DO UPDATE
-      SET updated_at = NOW(),
-          canonical_name = COALESCE(EXCLUDED.canonical_name, products.canonical_name),
-          brand_id       = COALESCE(EXCLUDED.brand_id,       products.brand_id),
-          item_class     = COALESCE(EXCLUDED.item_class,     products.item_class)
-    RETURNING id, product_key, merchant_id
-  )
-  INSERT INTO transaction_items (
-    id, workspace_id, transaction_id, line_no, parent_line_no,
-    raw_name, normalized_name, product_variant, quantity, unit,
-    unit_price_minor, line_total_minor, currency,
-    item_class, durability_tier, food_kind, tags, confidence,
-    line_type, product_id, tax_minor, tip_share_minor,
-    discount_share_minor, extraction_run, extraction_version
-  )
-  SELECT gen_random_uuid(), '${ctx.workspaceId}', '${ctx.transactionId}', item.line_no,
-         item.parent_line_no,
-         item.raw_name, item.normalized_name, item.product_variant,
-         item.quantity, item.unit,
-         item.unit_price_minor, item.line_total_minor, item.currency,
-         item.item_class, item.durability_tier, item.food_kind,
-         item.tags, item.confidence,
-         COALESCE(item.line_type, 'product'),
-         (SELECT pu.id FROM p_upsert pu
-            WHERE pu.product_key = item.product_key
-              AND pu.merchant_id IS NOT DISTINCT FROM
-                  (CASE WHEN item.product_merchant_exclusive THEN
-                     (SELECT merchant_id FROM transactions WHERE id = '${ctx.transactionId}')
-                   ELSE NULL END)
-            LIMIT 1),
-         item.tax_minor, item.tip_share_minor, item.discount_share_minor,
-         (SELECT run FROM next_run),
-         '${REEXTRACT_PROMPT_VERSION}'
-  FROM jsonb_to_recordset('<ITEMS_JSON_ARRAY>'::jsonb) AS item(
-    line_no int, parent_line_no int, raw_name text, normalized_name text,
-    quantity numeric, unit text,
-    unit_price_minor bigint, line_total_minor bigint, currency text,
-    item_class text, durability_tier text, food_kind text,
-    tags text[], confidence text,
-    line_type text, product_key text, product_brand_id text,
-    product_merchant_exclusive boolean, product_model text,
-    product_color text, product_size text, product_variant text,
-    product_sku text, product_manufacturer text,
-    tax_minor bigint, tip_share_minor bigint, discount_share_minor bigint
-  );
+${productsUpsert({ workspaceId: ctx.workspaceId, merchantIdExpr })}
+${transactionItemsInsert({
+  workspaceId: ctx.workspaceId,
+  txIdExpr: `'${ctx.transactionId}'`,
+  runExpr: "(SELECT run FROM next_run)",
+  merchantIdExpr,
+})};
 
-  -- #84: recompute aggregate stats for every product whose live
-  -- transaction_items set just changed. The WHERE clause unions
-  -- old-touched + new-touched products by reading the live set,
-  -- which now reflects the post-soft-delete state.
-  WITH stats AS (
-    SELECT ti.product_id,
-           MIN(t.occurred_on) AS first_on,
-           MAX(t.occurred_on) AS last_on,
-           COUNT(DISTINCT ti.transaction_id) AS purchases,
-           SUM(ti.effective_total_minor) AS total_minor
-    FROM transaction_items ti
-    JOIN transactions t ON t.id = ti.transaction_id
-    WHERE ti.workspace_id = '${ctx.workspaceId}'
-      AND ti.product_id IS NOT NULL
-      AND ti.retired_at IS NULL
-      AND ti.line_type = 'product'
-    GROUP BY ti.product_id
-  )
-  UPDATE products p SET
-    first_purchased_on = stats.first_on,
-    last_purchased_on  = stats.last_on,
-    purchase_count     = stats.purchases,
-    total_spent_minor  = stats.total_minor,
-    updated_at         = NOW()
-  FROM stats
-  WHERE p.id = stats.product_id
-    AND p.workspace_id = '${ctx.workspaceId}';
+  -- #84: recompute aggregate stats for every product this run touched.
+  -- Scoped by transaction, and deliberately NOT filtered on retired_at,
+  -- so a product that dropped OUT of the new run still gets recomputed.
+${productAggregateRecompute({
+  workspaceId: ctx.workspaceId,
+  touchedPredicate: `ti.transaction_id = '${ctx.transactionId}'`,
+})}
 
   INSERT INTO transaction_events (
     id, workspace_id, transaction_id, event_type, actor_id, payload
@@ -398,8 +260,8 @@ user override survives this re-extract.
     gen_random_uuid(), '${ctx.workspaceId}', '${ctx.transactionId}',
     're_extracted', '${ctx.userId}',
     jsonb_build_object(
-      'prompt_version', '${REEXTRACT_PROMPT_VERSION}',
-      'model',          '${REEXTRACT_MODEL}'
+      'prompt_version', '${PROMPT_VERSION}',
+      'model',          '${EXTRACTION_MODEL}'
     )
   );
 
@@ -409,6 +271,11 @@ user override survives this re-extract.
 IMPORTANT escaping rule: SQL single quotes inside values must be
 doubled (\`O''Brien\`). Newlines inside \`raw_text\` are fine inside a
 single-quoted SQL literal as long as no single quote is unescaped.
+The items JSON and the ocr_audit JSON are dollar-quoted instead
+(\`$items$…$items$\`, \`$audit$…$audit$\`), so drop those payloads in
+between the markers with NO surrounding single quotes and NO escaping
+— that is what keeps apostrophes in product titles ("World's", 12" pan)
+from breaking the write. Never revert them to single-quoted literals.
 
 ── Phase 3 — Refresh brand identity & icons (#101) ────────────────────
 
@@ -427,7 +294,7 @@ transaction's merchant row:
 
   psql "\$DATABASE_URL" -c "SELECT m.brand_id, m.canonical_name FROM transactions t JOIN merchants m ON m.id = t.merchant_id WHERE t.id = '${ctx.transactionId}';"
 
-If the SELECT returns NULL (voided / orphaned tx), skip Phase 3.
+If the SELECT returns NULL (soft-deleted / orphaned tx), skip Phase 3.
 
 Step 2: substitute the returned brand_id for <bid> and the
 canonical_name for <canonical_name> in the inlined phases that
@@ -446,7 +313,7 @@ no new fetch) is the next most common; full Case D (mechanical fetch
 
 After the psql block exits 0, print ONE line:
 
-  DONE re_extracted tx=${ctx.transactionId} prompt_version=${REEXTRACT_PROMPT_VERSION}
+  DONE re_extracted tx=${ctx.transactionId} prompt_version=${PROMPT_VERSION}
 
 If you cannot read the receipt at all (unsupported / illegible /
 corrupted), do NOT write anything to the database. Print:

--- a/src/routes/documents.service.ts
+++ b/src/routes/documents.service.ts
@@ -26,9 +26,9 @@ import {
   type ReExtractor,
 } from "../ingest/extractor.js";
 import {
-  REEXTRACT_PROMPT_VERSION,
-  REEXTRACT_MODEL,
-} from "../ingest/reextract-prompt.js";
+  PROMPT_VERSION,
+  EXTRACTION_MODEL,
+} from "../ingest/prompt-contract.js";
 import { buildInfo } from "../generated/build-info.js";
 
 export type DocumentKindValue =
@@ -840,9 +840,9 @@ export async function reExtractDocument(
       workspaceId,
       entityType: "document",
       entityId: documentId,
-      promptVersion: REEXTRACT_PROMPT_VERSION,
+      promptVersion: PROMPT_VERSION,
       promptGitSha: buildInfo.gitSha,
-      model: REEXTRACT_MODEL,
+      model: EXTRACTION_MODEL,
       ranAt: new Date(),
       before: beforeSnapshot as unknown as Record<string, unknown>,
       after: afterSnapshot as unknown as Record<string, unknown>,

--- a/src/routes/places.service.ts
+++ b/src/routes/places.service.ts
@@ -23,7 +23,7 @@ import {
   type ProjectedPlaceFields,
   type RawResponseV1,
 } from "../projection/derive.js";
-import { PROMPT_VERSION } from "../ingest/prompt.js";
+import { PROMPT_VERSION } from "../ingest/prompt-contract.js";
 import { buildInfo } from "../generated/build-info.js";
 import { NoRawResponseProblem } from "../http/problem.js";
 import { placeSnapshots } from "../schema/place_snapshots.js";

--- a/src/routes/products.ts
+++ b/src/routes/products.ts
@@ -25,7 +25,7 @@ import {
   derivationEvents,
 } from "../schema/index.js";
 import { buildInfo } from "../generated/build-info.js";
-import { PROMPT_VERSION } from "../ingest/prompt.js";
+import { PROMPT_VERSION } from "../ingest/prompt-contract.js";
 import { parseOrThrow } from "../http/validate.js";
 import {
   Product,


### PR DESCRIPTION
Closes #164. **Foundation PR** — #181, #165/#166 and #167 all build on this and should merge after it.

## Problem

The extraction contract existed as two hand-maintained rewrites (`buildExtractorPrompt`, `buildReExtractPrompt`) plus a third stale copy in dead code. The two had already diverged — on the `line_type` vocabulary, on the arithmetic invariant, and on whether the ADDITIVE pricing branch exists at all.

## What moved

Four new modules that **both** builders interpolate, extending the pattern `brand-icon-prompt.ts` already established:

| Module | Holds |
|---|---|
| `prompt-contract.ts` | versions, model, agent hygiene, psql discipline, date self-check, OCR audit, active lessons |
| `document-read-prompt.ts` | Phase 0 — how to read a PDF / image / `.eml` |
| `line-item-prompt.ts` | item schema, `line_type` vocabulary, two-level modifier rule, pricing logic, worked examples |
| `items-sql.ts` | the parameterized SQL fragments, killing 8 copy sites |

`prompt.ts` 1875 → 1225 lines; `reextract-prompt.ts` 458 → 325.

The **rendered** re-extract prompt goes the other way — 458 → 1226 lines — because it was missing most of the contract: no document-read phase, no worked examples, no date self-check, and an item schema whose SQL required 11 fields its prose never named. Measured consequence: re-extract drops `product_id` on **28.5%** of product lines (283/396) versus **0.2%** at ingest, and `tax_minor` on **94.4%**.

## Drift reconciled deliberately

18 divergences were each decided rather than blindly merged. The load-bearing ones:

| Drift | Decision | Why |
|---|---|---|
| `line_type` | Open vocabulary; bare `fee` dropped as recommended | No DB enum, no CHECK — prod already holds 18 values. `fee` overlapped `surcharge`/`service_fee` and existed only because the prompts disagreed. A closed list in one prompt only guarantees they diverge again. |
| Arithmetic invariant | Take re-extract's wording | `prompt.ts` was self-contradictory: "Σ across all items ≈ subtotal" while also mandating tax rows as items |
| ADDITIVE vs INCLUSIVE | Take `prompt.ts`'s both-branch text | re-extract defined **only** INCLUSIVE, so its single directive about parent prices was "REDUCE" — the direct cause of #165 |
| items JSON quoting | `$items$` dollar-quoting at all 8 sites | Single quotes hard-fail on `McDonald's` and silently roll the whole re-extract back |
| Versions | One `PROMPT_VERSION = "3.0"`; `REEXTRACT_PROMPT_VERSION` deleted | Nothing read it, and two number lines in one column had `1.8` sorting newer than `2.19` |
| `metadata.extraction` | Append prior block to `extraction_history` | Re-extract was destroying the original `prompt_git_sha`/`model`/`ran_at` on 91 live transactions |

## Dead code removed

`processReceipt` (targeted the pre-v1 `receipts` tables, zero importers), `askClaude`, and `getSessionJsonlPath` (a duplicate of the one in `langfuse.ts` that callers actually import). `runClaude` and `detectPsqlCommand` stay — `src/insights/ask.ts` imports them.

## Verification

**No behavior change is intended.** No new extraction rules — those are #165/#166, which now get written once.

- `tsc --noEmit` clean.
- Both prompts rendered to disk and diffed against the originals: **489/511** distinctive instruction lines survive verbatim. All 22 differences traced individually — each is either a deliberate decision above or a `String.raw` escaping artifact (moving off `String.raw` is part of this change; it was leaking literal backslashes like `` \` `` and `\$` into the agent's context window).
- Rendered output contains no `undefined`, no `[object Object]`, no unresolved `${` (the 3 remaining are legitimate shell vars — `${L}`, `${RANK}`, `${WH%x*}`).
- `$items$` present at 6 + 5 sites; single-quoted items JSON at none.
- `grep` confirms `REEXTRACT_PROMPT_VERSION` and `processReceipt` are gone from `src/` and from the docs.

Live re-extract verification is deliberately deferred to the end of the chain, so the three production transactions approved for re-extraction are spent once, against all four PRs, rather than once per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ssDbfdur7JHRCLfZSQsyx