### PR TITLE
fix(ingest): token burn, AYCE/occlusion shaping, and email-only re-extract (#181, #165, #166, #167)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,31 +515,43 @@ the auth pool, and harness poll timeouts will fire while queued.
 
 ### Manual Verification Flow
 
-No verify script. Three curl calls are the contract:
+No verify script. Three curl calls are the contract. The pre-v1
+`POST /receipt` → `GET /jobs/:id` → `GET /receipt/:id` recipe that used
+to live here is **gone** — `src/app.ts` mounts only `/v1/*`, so those
+three paths 404. Point at the **mini** (production); `localhost` is the
+dev box and lands in the wrong DB.
 
 ```bash
+BASE=http://100.84.82.96:3000
+
 # 1. Upload
-JOB=$(curl -sS -X POST http://localhost:3000/receipt \
-  -F "image=@$HOME/Desktop/RECEIPT/IMG.jpeg" | jq -r .jobId)
+BATCH=$(curl -sS -X POST "$BASE/v1/ingest/batch" \
+  -F "file=@/path/to/receipt.jpeg" | jq -r .batchId)
 
-# 2. Poll until status=done
-while :; do
-  s=$(curl -sS http://localhost:3000/jobs/$JOB | jq -r .status)
-  [[ "$s" == "done" || "$s" == "error" ]] && break
-  sleep 2
-done
-RECEIPT=$(curl -sS http://localhost:3000/jobs/$JOB | jq -r .receiptId)
+# 2. Poll until the batch reaches a terminal state
+until [[ "$(curl -sS "$BASE/v1/batches/$BATCH" | jq -r .status)" \
+         =~ ^(extracted|reconciled|failed)$ ]]; do sleep 3; done
+curl -sS "$BASE/v1/batches/$BATCH" | jq '.items[] | {id,status,error,produced}'
 
-# 3. Inspect the receipt record (the data of record — merchant/date/
-#    total/tip/items are all here)
-curl -sS http://localhost:3000/receipt/$RECEIPT | jq .
+# 3. Inspect the transaction (the data of record — payee/date/total/
+#    postings/items are all here)
+TX=$(curl -sS "$BASE/v1/batches/$BATCH" | jq -r '.items[0].produced.transaction_id')
+curl -sS "$BASE/v1/transactions/$TX" | jq .
 ```
 
 For the Langfuse trace, query the API directly (see
 "Query Langfuse" above). Never trust a wrapper script's display —
-go to `/receipt/:id` for ground truth. (Earlier `verify-receipt.sh`
-printed all-None while the DB had correct data; deleted to avoid
-that trap.)
+go to `/v1/transactions/:id` for ground truth. (Earlier
+`verify-receipt.sh` printed all-None while the DB had correct data;
+deleted to avoid that trap.)
+
+Re-extract is a single synchronous call — it bypasses
+`MAX_CLAUDE_CONCURRENCY`, so run these strictly one at a time:
+
+```bash
+curl -sS --max-time 1000 -X POST "$BASE/v1/documents/$DOC/re-extract" | jq .
+# PASS: changed_keys contains "metadata_extraction".
+```
 
 ### Why API over UI
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4655,6 +4655,15 @@
             "type": "string",
             "format": "uuid",
             "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+          },
+          "outcome": {
+            "type": "string",
+            "enum": [
+              "written",
+              "no_change",
+              "agent_error"
+            ],
+            "description": "What the run actually did (#167). `written` = the agent's psql block moved something. `no_change` = it demonstrably wrote NOTHING (the metadata UPDATE always rewrites `extraction.ran_at`, so empty `changed_keys` means no write happened, NOT that the output was identical). `agent_error` is part of the vocabulary but never appears on a 200 — the agent's `ERROR` line surfaces as a 422 `re-extract-agent-error`. Batch tooling MUST key on this field, never on whether `re_extracted_at` advanced."
           }
         },
         "required": [
@@ -4663,7 +4672,8 @@
           "derivation_event_id",
           "changed_keys",
           "ocr_text_changed",
-          "session_id"
+          "session_id",
+          "outcome"
         ]
       },
       "UpdatePlaceRequest": {
@@ -8557,7 +8567,7 @@
     "/v1/documents/{id}/re-extract": {
       "post": {
         "summary": "Re-OCR the receipt and UPDATE the linked transaction in place.",
-        "description": "Phase 4c of the 3-layer rollout (#80 / #91). Spawns `claude -p` with a narrow re-extract prompt; the agent reads the cached image bytes and refreshes `transactions.{payee, occurred_on, occurred_at, metadata.extraction}` plus `documents.{ocr_text, ocr_model_version}`. **Out of scope**: postings, place_id, merchant_id, document_links — those have their own paths. **Layer-3 shielded**: HARD fields (status, narration, trip_id, identity columns) never touched; SOFT fields (occurred_on, occurred_at, payee) protected by `metadata.user_edited.<field>` CASE expressions, so user PATCH overrides survive. Returns 422 if the document has zero or >1 linked transactions.",
+        "description": "Phase 4c of the 3-layer rollout (#80 / #91). Spawns `claude -p` with a narrow re-extract prompt; the agent reads the cached image bytes and refreshes `transactions.{payee, occurred_on, occurred_at, metadata.extraction}` plus `documents.{ocr_text, ocr_model_version}`. **Out of scope**: postings, place_id, merchant_id, document_links — those have their own paths. **Layer-3 shielded**: HARD fields (status, narration, trip_id, identity columns) never touched; SOFT fields (occurred_on, occurred_at, payee) protected by `metadata.user_edited.<field>` CASE expressions, so user PATCH overrides survive. For `.eml` / `text/html` documents the body is MIME-decoded and linearized server-side and inlined into the prompt (#167) — the agent does not decode it itself. The response's `outcome` field is the completion signal; do NOT infer success from `re_extracted_at` advancing.",
         "tags": [
           "documents"
         ],
@@ -8571,6 +8581,17 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Which linked transaction to re-derive. Required only when the document links to more than one transaction; without it such a document 422s with `document-multiple-transactions`.",
+              "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
+            },
+            "required": false,
+            "name": "transaction_id",
+            "in": "query"
           }
         ],
         "responses": {
@@ -8595,7 +8616,7 @@
             }
           },
           "422": {
-            "description": "Document not linked to exactly one transaction, or has no file_path",
+            "description": "`document-no-file-path` (row has no file_path), `document-file-missing` (file_path does not resolve on disk — checked BEFORE spawning the agent), `document-no-transaction` (zero linked transactions), `document-multiple-transactions` (more than one and no `?transaction_id=`), or `re-extract-agent-error` (the agent printed `ERROR <reason>` and wrote nothing; `detail` carries its reason).",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/scripts/smoke-v1-ingest.ts
+++ b/scripts/smoke-v1-ingest.ts
@@ -19,6 +19,9 @@
  *
  * Run:   npx tsx scripts/smoke-v1-ingest.ts
  * Args:  --files=<glob>           Override file selection (unquoted glob)
+ *        --fixtures=<dir>         Directory holding the receipt corpus
+ *                                 (or set RECEIPT_FIXTURE_DIR). Required
+ *                                 unless --files is given.
  *        --base=<url>             API base URL (default http://localhost:3000)
  *        --concurrency=<n>        Parallel workers (default 3)
  *        --limit=<n>              Cap processed count (default 15)
@@ -47,11 +50,24 @@ function parseArgs(argv: string[]): Args {
   const concurrency = Number(args.concurrency ?? "3");
   const limit = Number(args.limit ?? "15");
 
-  const files = args.files
-    ? expandGlob(args.files)
-    : DEFAULT_SELECTION.map((f) =>
-        path.resolve("/Users/danieltang/Desktop/RECEIPT", f),
-      );
+  // The fixture directory is NOT hard-coded: `~/Desktop/RECEIPT` used to
+  // be baked in here and exists on neither machine, so a bare run silently
+  // processed zero files (#181 cleanup). Point it with --fixtures=<dir> or
+  // RECEIPT_FIXTURE_DIR; --files=<glob> still overrides everything.
+  const fixtureDir = args.fixtures ?? process.env.RECEIPT_FIXTURE_DIR;
+  let files: string[];
+  if (args.files) {
+    files = expandGlob(args.files);
+  } else if (fixtureDir) {
+    files = DEFAULT_SELECTION.map((f) => path.resolve(fixtureDir, f)).filter(
+      (f) => fs.existsSync(f),
+    );
+  } else {
+    throw new Error(
+      "No fixtures given. Pass --files=<glob>, or --fixtures=<dir> / " +
+        "RECEIPT_FIXTURE_DIR=<dir> pointing at the receipt corpus.",
+    );
+  }
 
   return { files: files.slice(0, limit), base, concurrency, limit };
 }

--- a/scripts/tx-restore.sh
+++ b/scripts/tx-restore.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# tx-restore.sh — put a transaction back the way `tx-snapshot.sh` found it.
+#
+# Usage:
+#   ssh mini 'bash -s' -- <TX_UUID> dryrun < scripts/tx-restore.sh
+#   ssh mini 'bash -s' -- <TX_UUID> commit < scripts/tx-restore.sh
+#
+# `dryrun` runs the whole restore inside a transaction and ROLLBACKs. Run
+# it on one transaction BEFORE the campaign begins, not after a failure.
+#
+# Four things this has to get right, each learned the hard way:
+#
+#   1. `SET LOCAL session_replication_role = replica` suppresses the
+#      `transactions_version_bump` and `transactions_updated_at` triggers,
+#      so `version` / `updated_at` restore byte-exactly instead of drifting
+#      forward on every restore.
+#   2. Replica mode ALSO disables FK cascades, so children must be deleted
+#      EXPLICITLY, in FK order. Skipping this is what produced a
+#      `postings_pkey` duplicate on the first attempt at this script.
+#   3. `transaction_items.effective_total_minor` is GENERATED — it cannot
+#      appear in an INSERT column list, so the item insert names its
+#      columns explicitly rather than using `jsonb_populate_record`'s
+#      full row shape.
+#   4. `SET CONSTRAINTS ALL IMMEDIATE` fires before COMMIT/ROLLBACK, so a
+#      dry run actually exercises `postings_balance_ck`. Without it a plain
+#      ROLLBACK gives false confidence — the deferred trigger never ran.
+#
+# Scope: restores the transaction and the rows that belong to it. It does
+# NOT restore `products` aggregate columns (they are derived; re-run the
+# recompute) and it does NOT restore `documents.ocr_text` unless
+# RESTORE_DOCS=1, because ocr_text is usually what you WANT to keep.
+set -euo pipefail
+
+TX="${1:?usage: tx-restore.sh <TX_UUID> dryrun|commit}"
+MODE="${2:?usage: tx-restore.sh <TX_UUID> dryrun|commit}"
+case "$MODE" in
+  dryrun) FINAL="ROLLBACK;" ;;
+  commit) FINAL="COMMIT;"   ;;
+  *) echo "tx-restore: mode must be dryrun or commit" >&2; exit 2 ;;
+esac
+
+SNAP="${SNAPSHOT_DIR:-$HOME/receipt-snapshots}/$TX.json"
+PG_CONTAINER="${PG_CONTAINER:-receipts-postgres}"
+PG_USER="${PG_USER:-postgres}"
+PG_DB="${PG_DB:-receipts}"
+RESTORE_DOCS="${RESTORE_DOCS:-0}"
+
+[ -s "$SNAP" ] || { echo "tx-restore: no snapshot at $SNAP" >&2; exit 1; }
+
+DOC_RESTORE=""
+if [ "$RESTORE_DOCS" = "1" ]; then
+  DOC_RESTORE=$(cat <<'DOCSQL'
+  UPDATE documents d SET
+    ocr_text          = s.ocr_text,
+    ocr_model_version = s.ocr_model_version,
+    updated_at        = s.updated_at
+  FROM (
+    SELECT * FROM jsonb_to_recordset((SELECT snap->'documents' FROM snapshot))
+      AS x(id uuid, ocr_text text, ocr_model_version text, updated_at timestamptz)
+  ) s
+  WHERE d.id = s.id;
+DOCSQL
+)
+fi
+
+# The snapshot travels as a psql variable so no shell quoting touches the
+# JSON body; :'snap' expands to a correctly-quoted SQL literal.
+docker exec -i "$PG_CONTAINER" psql -v ON_ERROR_STOP=1 -U "$PG_USER" -d "$PG_DB" \
+  -v "snap=$(cat "$SNAP")" -v "tx=$TX" <<SQL
+BEGIN;
+SET LOCAL session_replication_role = replica;
+
+CREATE TEMP TABLE snapshot ON COMMIT DROP AS SELECT :'snap'::jsonb AS snap;
+
+-- (2) explicit deletes, in FK order — replica mode disables cascades.
+DELETE FROM owned_items         WHERE transaction_item_id IN (SELECT id FROM transaction_items WHERE transaction_id = :'tx');
+DELETE FROM wish_items          WHERE transaction_item_id IN (SELECT id FROM transaction_items WHERE transaction_id = :'tx');
+DELETE FROM transaction_parties WHERE transaction_id = :'tx';
+DELETE FROM transaction_items   WHERE transaction_id = :'tx';
+DELETE FROM transaction_events  WHERE transaction_id = :'tx';
+DELETE FROM document_links      WHERE transaction_id = :'tx';
+DELETE FROM postings            WHERE transaction_id = :'tx';
+DELETE FROM transactions        WHERE id = :'tx';
+
+INSERT INTO transactions
+SELECT * FROM jsonb_populate_recordset(NULL::transactions, (SELECT snap->'transactions' FROM snapshot));
+
+INSERT INTO postings
+SELECT * FROM jsonb_populate_recordset(NULL::postings, (SELECT snap->'postings' FROM snapshot));
+
+-- (3) effective_total_minor is GENERATED — explicit column list only.
+INSERT INTO transaction_items (
+  id, workspace_id, transaction_id, line_no, parent_line_no,
+  raw_name, normalized_name, product_variant, quantity, unit,
+  unit_price_minor, line_total_minor, currency,
+  item_class, durability_tier, food_kind, tags, confidence,
+  line_type, product_id, tax_minor, tip_share_minor, discount_share_minor,
+  extraction_run, extraction_version, retired_at, created_at, updated_at
+)
+SELECT id, workspace_id, transaction_id, line_no, parent_line_no,
+       raw_name, normalized_name, product_variant, quantity, unit,
+       unit_price_minor, line_total_minor, currency,
+       item_class, durability_tier, food_kind, tags, confidence,
+       line_type, product_id, tax_minor, tip_share_minor, discount_share_minor,
+       extraction_run, extraction_version, retired_at, created_at, updated_at
+  FROM jsonb_to_recordset(COALESCE((SELECT snap->'transaction_items' FROM snapshot), '[]'::jsonb))
+    AS x(id uuid, workspace_id uuid, transaction_id uuid, line_no int, parent_line_no int,
+         raw_name text, normalized_name text, product_variant text, quantity numeric, unit text,
+         unit_price_minor bigint, line_total_minor bigint, currency text,
+         item_class text, durability_tier text, food_kind text, tags text[], confidence text,
+         line_type text, product_id uuid, tax_minor bigint, tip_share_minor bigint,
+         discount_share_minor bigint, extraction_run int, extraction_version text,
+         retired_at timestamptz, created_at timestamptz, updated_at timestamptz);
+
+INSERT INTO document_links
+SELECT * FROM jsonb_populate_recordset(NULL::document_links, COALESCE((SELECT snap->'document_links' FROM snapshot), '[]'::jsonb));
+
+INSERT INTO transaction_events
+SELECT * FROM jsonb_populate_recordset(NULL::transaction_events, COALESCE((SELECT snap->'transaction_events' FROM snapshot), '[]'::jsonb));
+
+INSERT INTO transaction_parties
+SELECT * FROM jsonb_populate_recordset(NULL::transaction_parties, COALESCE((SELECT snap->'transaction_parties' FROM snapshot), '[]'::jsonb));
+
+INSERT INTO owned_items
+SELECT * FROM jsonb_populate_recordset(NULL::owned_items, COALESCE((SELECT snap->'owned_items' FROM snapshot), '[]'::jsonb));
+
+INSERT INTO wish_items
+SELECT * FROM jsonb_populate_recordset(NULL::wish_items, COALESCE((SELECT snap->'wish_items' FROM snapshot), '[]'::jsonb));
+
+$DOC_RESTORE
+
+-- (4) force the DEFERRABLE balance triggers so a dry run means something.
+SET CONSTRAINTS ALL IMMEDIATE;
+
+SELECT (SELECT count(*) FROM postings WHERE transaction_id = :'tx')          AS postings,
+       (SELECT sum(amount_base_minor) FROM postings WHERE transaction_id = :'tx') AS base_sum,
+       (SELECT count(*) FROM transaction_items WHERE transaction_id = :'tx') AS items;
+
+$FINAL
+SQL
+
+echo "tx-restore: $MODE complete for $TX"
+if [ "$MODE" = "commit" ]; then
+  echo "tx-restore: products aggregates are DERIVED and were not restored —"
+  echo "            re-run the product recompute if any stat matters."
+fi

--- a/scripts/tx-snapshot.sh
+++ b/scripts/tx-snapshot.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# tx-snapshot.sh — capture EVERYTHING that hangs off one transaction as a
+# single jsonb blob, so a re-extract can be undone.
+#
+# A re-extract rewrites production rows in place and there is no undo. Take
+# a snapshot before touching any production transaction, and dry-run the
+# restore (`tx-restore.sh <TX> dryrun`) at least once BEFORE the campaign
+# begins — not after something has already gone wrong.
+#
+# Usage (from the repo, targeting the mini):
+#   ssh mini 'bash -s' < scripts/tx-snapshot.sh <TX_UUID>
+#   scp mini:'~/receipt-snapshots/<TX_UUID>.json' ./snapshots/
+#
+# The mini's ~/receipt-snapshots is NOT backed up. Copy the file off the
+# box before you rely on it.
+#
+# Requires: docker (OrbStack) on PATH — an ssh command must
+# `source ~/.zprofile` first or docker is not found.
+set -euo pipefail
+
+TX="${1:?usage: tx-snapshot.sh <TX_UUID>}"
+OUT_DIR="${SNAPSHOT_DIR:-$HOME/receipt-snapshots}"
+PG_CONTAINER="${PG_CONTAINER:-receipts-postgres}"
+PG_USER="${PG_USER:-postgres}"
+PG_DB="${PG_DB:-receipts}"
+
+mkdir -p "$OUT_DIR"
+OUT="$OUT_DIR/$TX.json"
+
+read -r -d '' SQL <<SQL || true
+SELECT jsonb_pretty(jsonb_build_object(
+  'transaction_id', '$TX'::text,
+  'captured_at',    NOW()::text,
+  'transactions',        (SELECT jsonb_agg(to_jsonb(t))  FROM transactions t        WHERE t.id = '$TX'),
+  'postings',            (SELECT jsonb_agg(to_jsonb(p))  FROM postings p            WHERE p.transaction_id = '$TX'),
+  'transaction_items',   (SELECT jsonb_agg(to_jsonb(ti)) FROM transaction_items ti  WHERE ti.transaction_id = '$TX'),
+  'document_links',      (SELECT jsonb_agg(to_jsonb(dl)) FROM document_links dl     WHERE dl.transaction_id = '$TX'),
+  'transaction_events',  (SELECT jsonb_agg(to_jsonb(te)) FROM transaction_events te WHERE te.transaction_id = '$TX'),
+  'transaction_parties', (SELECT jsonb_agg(to_jsonb(tp)) FROM transaction_parties tp WHERE tp.transaction_id = '$TX'),
+  'wish_items',          (SELECT jsonb_agg(to_jsonb(w))  FROM wish_items w
+                            WHERE w.transaction_item_id IN (SELECT id FROM transaction_items WHERE transaction_id = '$TX')),
+  'owned_items',         (SELECT jsonb_agg(to_jsonb(o))  FROM owned_items o
+                            WHERE o.transaction_item_id IN (SELECT id FROM transaction_items WHERE transaction_id = '$TX')),
+  'documents',           (SELECT jsonb_agg(to_jsonb(d))  FROM documents d
+                            WHERE d.id IN (SELECT document_id FROM document_links WHERE transaction_id = '$TX')),
+  'products',            (SELECT jsonb_agg(to_jsonb(pr)) FROM products pr
+                            WHERE pr.id IN (SELECT DISTINCT product_id FROM transaction_items
+                                             WHERE transaction_id = '$TX' AND product_id IS NOT NULL))
+));
+SQL
+
+docker exec -i "$PG_CONTAINER" psql -v ON_ERROR_STOP=1 -U "$PG_USER" -d "$PG_DB" -tA -c "$SQL" > "$OUT"
+
+if [ ! -s "$OUT" ] || ! grep -q '"transactions"' "$OUT"; then
+  echo "tx-snapshot: EMPTY or malformed snapshot for $TX — refusing to claim success" >&2
+  exit 1
+fi
+
+echo "tx-snapshot: wrote $OUT ($(wc -c < "$OUT") bytes)"
+echo "tx-snapshot: copy it OFF the box — $OUT_DIR is not backed up."

--- a/src/ingest/brand-icon-prompt.ts
+++ b/src/ingest/brand-icon-prompt.ts
@@ -43,8 +43,12 @@ discovery work. When unsure, prefer skipping over spending turns.
 
 Steps (run once per unique merchant brand_id in this document):
 
-  1. Cache check — read the registry first:
-       psql "\$DATABASE_URL" -c "SELECT brand_id, name, domain, metadata->>'icon_resolution' AS icon_resolution FROM brands WHERE brand_id = '<bid>';"
+  1. Cache check — read the registry first. ONE read covers both this
+     step and the Phase 4b icon pre-check further down; do not query
+     \`brands\` twice. (Ingest path: this IS result set (1) of Turn A —
+     you already have it, do not run it again here.)
+
+       psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" -c "SELECT b.brand_id, b.name, b.domain, b.user_chose_at, b.preferred_asset_id, b.metadata->>'icon_resolution' AS icon_resolution, (SELECT count(*) FROM brand_assets a WHERE a.brand_id = b.brand_id AND a.retired_at IS NULL) AS live_count FROM brands b WHERE b.brand_id = '<bid>';"
 
      - Row exists with non-null domain → done. Move on.
      - Row exists with null domain AND metadata.icon_resolution =
@@ -71,8 +75,12 @@ Steps (run once per unique merchant brand_id in this document):
        mainland chain. Geo from receipt printed address helps
        disambiguate.
 
-  3. UPSERT:
-       psql "\$DATABASE_URL" <<'SQL'
+  3. UPSERT. (Ingest path: do NOT run this as its own call — it is
+     statement (1) of Turn B, where it also serves as the FK parent for
+     \`merchants.brand_id\`. Carry the name/domain you just discovered
+     into that statement.)
+
+       psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" <<'SQL'
          INSERT INTO brands (brand_id, name, domain)
          VALUES ('<bid>', '<canonical_name>', '<domain or NULL>')
          ON CONFLICT (brand_id) DO UPDATE
@@ -111,9 +119,11 @@ winner — that's Phase 4c. The goal here is mechanical retention:
 saved to disk, recorded in \`brand_assets\`". Tier is provenance, not
 priority.
 
-Cache pre-check (token saver — read before fetching anything):
-
-  psql "\$DATABASE_URL" -c "SELECT b.preferred_asset_id, b.user_chose_at, b.domain, b.metadata->>'icon_resolution' AS icon_resolution, (SELECT count(*) FROM brand_assets WHERE brand_id = '<bid>' AND retired_at IS NULL) AS live_count FROM brands b WHERE brand_id = '<bid>';"
+Cache pre-check (token saver — read before fetching anything). You
+ALREADY have this row: Phase 2.6 step 1's registry read returns
+\`preferred_asset_id\`, \`user_chose_at\`, \`domain\`, \`icon_resolution\`
+and \`live_count\` for exactly this purpose. Re-read that output — do
+NOT issue another \`brands\` SELECT here.
 
   Case A — preferred_asset_id IS NOT NULL:
     Already resolved. Skip Phase 4b AND 4c for this brand. Move on.
@@ -280,20 +290,24 @@ source URL, or filename. Score axes:
   - Quality: dimensions (bigger is better for raster), padding
     (over-cropped is bad), transparency present, color accuracy.
 
-Step 3: write the judgment back per candidate:
+Steps 3-5 are ONE psql invocation. Batch every per-candidate UPDATE
+plus the winner-pick into a single heredoc; do not spend a Bash call
+per candidate.
 
-  psql "\$DATABASE_URL" <<SQL
+Step 3: write the judgment back per candidate — one UPDATE per
+candidate, all inside that one heredoc:
+
+  psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" <<SQL
     UPDATE brand_assets
        SET agent_relevance    = <0..100>,
            agent_notes        = '<one-line judgment>',
            extraction_version = extraction_version + 1
            <, retired_at = NOW() if letter-fallback or otherwise unusable>
      WHERE id = '<candidate_id>';
-  SQL
 
-Step 4: pick the winner (Layer-3-safe):
+Step 4: pick the winner (Layer-3-safe) — next statement in the SAME
+heredoc:
 
-  psql "\$DATABASE_URL" <<SQL
     UPDATE brands
        SET preferred_asset_id = (
              SELECT id FROM brand_assets
@@ -306,16 +320,16 @@ Step 4: pick the winner (Layer-3-safe):
            updated_at = NOW()
      WHERE brand_id = '<bid>'
        AND user_chose_at IS NULL;
-  SQL
+  SQL   -- close the heredoc only after Step 4 OR Step 5, not both
 
 The \`user_chose_at IS NULL\` clause is the Layer-3 lock — if the
 user has manually picked an icon via PATCH /v1/brands/:id, never
 overwrite it.
 
 Step 5: if no candidate scored ≥ 30, the agent rejected every
-candidate. Record that:
+candidate. Record that INSTEAD of Step 4's winner-pick — same heredoc,
+same invocation:
 
-  psql "\$DATABASE_URL" <<SQL
     UPDATE brands
        SET preferred_asset_id = NULL,
            metadata = metadata || jsonb_build_object(

--- a/src/ingest/document-read-prompt.ts
+++ b/src/ingest/document-read-prompt.ts
@@ -12,8 +12,16 @@
  * recipe nor the `.eml` MIME-decode one-liner — it just said "read the
  * file", which is why email re-extracts produced empty `ocr_text`.
  *
- * PR #181 rewrites the PDF half of this to be text-layer-first; the
- * text below is the pre-#181 render-first behavior, moved verbatim.
+ * #181 flipped the PDF half from render-first to TEXT-first. The old
+ * text told the agent to `pdftoppm -png -r 200` every PDF with no page
+ * cap and mentioned `pdftotext` only as a subordinate clause, which
+ * meant a 3-page text-layer PDF entered the context as three 200-DPI
+ * images and every later turn re-read them from cache — the single
+ * biggest term in the 2.7M-token measurement on #181. The escape hatch
+ * (rasterize when the text layer is empty / mojibake / a flattened
+ * scan / internally inconsistent) is what keeps accuracy; DPI is 150
+ * and the page cap is 3 because past that point a receipt PDF is a
+ * statement, not a receipt.
  *
  * Plain template literal, never `String.raw` — see `prompt-contract.ts`.
  */
@@ -23,34 +31,53 @@ export function phase0DocumentRead(opts: {
   /** Per-run scratch directory, e.g. `/tmp/<ingestId>`. */
   scratchDir: string;
 }): string {
-  return `── Reading the document (especially PDFs) ────────────────────────────
+  return `── Reading the document ───────────────────────────────────────────────
 
-For a PDF, do NOT hand-parse the byte structure (decompressing streams,
-mapping Form XObjects, sorting content-stream placements) — that path is
-slow and error-prone. Rasterize to an image and read the pixels, which is
-what you do best:
+PDFs — TEXT FIRST. Always try the text layer before rasterizing.
+Rasterized pages cost ~1500x more context than the same page as text,
+and every later turn re-reads them from cache.
 
-  pdftoppm -png -r 200 "${opts.filePath}" ${opts.scratchDir}/page
-  # → ${opts.scratchDir}/page-1.png, page-2.png, …  then Read those PNGs.
+  mkdir -p ${opts.scratchDir}
+  pdftotext -layout "${opts.filePath}" ${opts.scratchDir}/text.txt
+  wc -c ${opts.scratchDir}/text.txt
 
-\`pdftoppm\` and \`pdftotext\` (poppler) plus \`gs\` (ghostscript) are
-installed. \`pdftotext -layout "${opts.filePath}" -\` gives a fast text
-layer for text-based PDFs; when the PDF is a flattened form or its text
-layer is empty/garbled, prefer the rasterized PNG. Only fall back to
-manual stream decoding if those tools are genuinely unavailable.
+  Then Read ${opts.scratchDir}/text.txt.
 
-**Decoding an \`.eml\` body.** The \`.eml\` body is MIME-encoded (quoted-printable
-or base64, sometimes with non-UTF-8 bytes). Do NOT try to read a raw
-base64 blob, and do NOT improvise your own decoder. Run exactly this
-tested one-liner (stdlib only — handles QP, base64, and charset quirks;
-note \`message_from_binary_file\` + \`policy=email.policy.default\`, both
+  If that file is >= 200 bytes AND contains a recognizable merchant
+  name, a date, and a total, you are DONE reading. Do NOT rasterize.
+  Do NOT "double-check against the image". The text layer IS the
+  source of truth for a text-based PDF.
+
+  Rasterize ONLY when the text layer genuinely fails: the file is
+  empty / under 200 bytes, or it is mojibake, or it is a flattened
+  scanned form with no extractable text, or the totals it shows do
+  not tie to each other:
+
+    pdftoppm -png -r 150 -f 1 -l 3 "${opts.filePath}" ${opts.scratchDir}/page
+    # -> page-1.png … page-3.png. Read those, first page first, and
+    #    STOP as soon as you have merchant + date + total + items.
+    #    Do not Read pages you do not need.
+
+  Never hand-parse the PDF byte structure (decompressing streams,
+  mapping Form XObjects, sorting content-stream placements) — poppler
+  (\`pdftotext\`, \`pdftoppm\`) and ghostscript (\`gs\`) are installed;
+  only fall back to manual decoding if those tools are truly missing.
+
+Images (.jpg/.png/.heic) — Read the file directly. One Read.
+
+Email (.eml) — NEVER Read the raw \`.eml\` blindly and never Read it as
+a PDF. The body is MIME-encoded (quoted-printable or base64, sometimes
+with non-UTF-8 bytes), so a raw Read gives you a base64 blob. Do NOT
+improvise your own decoder. Run exactly this tested one-liner (stdlib
+only — handles QP, base64, and charset quirks; note
+\`message_from_binary_file\` + \`policy=email.policy.default\`, both
 required):
 
-  python3 -c "import email,email.policy,sys; m=email.message_from_binary_file(open(sys.argv[1],'rb'),policy=email.policy.default); p=m.get_body(preferencelist=('html','plain')); print(p.get_content() if p else '(no text body found)')" "${opts.filePath}" > /tmp/email-body.txt
+  python3 -c "import email,email.policy,sys; m=email.message_from_binary_file(open(sys.argv[1],'rb'),policy=email.policy.default); p=m.get_body(preferencelist=('html','plain')); print(p.get_content() if p else '(no text body found)')" "${opts.filePath}" > ${opts.scratchDir}/email-body.txt
 
-then Read \`/tmp/email-body.txt\`. If (and only if) that command fails,
-fall back to reading the raw \`.eml\` directly — quoted-printable parts
-are human-readable as-is (ignore \`=3D\` and soft \`=\\n\` line-breaks).
-Try ONE approach at a time; never fire multiple decode attempts in
-parallel (see Tool discipline above).`;
+then Read \`${opts.scratchDir}/email-body.txt\`. If (and only if) that
+command fails, fall back to reading the raw \`.eml\` directly —
+quoted-printable parts are human-readable as-is (ignore \`=3D\` and soft
+\`=\\n\` line-breaks). Try ONE approach at a time; never fire multiple
+decode attempts in parallel (see Tool discipline above).`;
 }

--- a/src/ingest/extractor.ts
+++ b/src/ingest/extractor.ts
@@ -161,6 +161,11 @@ export interface ReExtractorInput {
   transactionId: string;
   /** Owner user id, recorded in `transaction_events`. */
   userId: string;
+  /** Pre-decoded plain text of the source, for documents the agent
+   *  cannot usefully open on its own — `.eml` bodies (MIME-encoded, with
+   *  the itemization usually only in the `text/html` part) and raw HTML
+   *  files (#167). NULL for images and PDFs, which the agent reads. */
+  ocrText?: string | null;
 }
 
 export interface ReExtractorResult {
@@ -184,6 +189,7 @@ export const defaultClaudeReExtractor: ReExtractor = async (input) => {
     documentId: input.documentId,
     transactionId: input.transactionId,
     userId: input.userId,
+    ocrText: input.ocrText ?? null,
   };
   const prompt = buildReExtractPrompt(ctx);
   console.log(

--- a/src/ingest/items-sql.ts
+++ b/src/ingest/items-sql.ts
@@ -21,6 +21,12 @@
  *   • extraction-run number — `1` vs. `(SELECT run FROM next_run)`
  *   • the version constant — now shared (`prompt-contract.ts`)
  *
+ * #181 added `itemsCte()`: the `<ITEMS_JSON_ARRAY>` placeholder and the
+ * 26-column type list now appear ONCE per statement instead of once per
+ * fragment. `productsUpsert` and `transactionItemsInsert` read the
+ * resulting `item` CTE and must not be spliced into a statement that
+ * lacks it.
+ *
  * Plain template literals, never `String.raw` — see `prompt-contract.ts`.
  */
 import { PROMPT_VERSION } from "./prompt-contract.js";
@@ -54,15 +60,33 @@ function indentBlock(text: string, pad: string): string {
 }
 
 /**
- * `jsonb_to_recordset(<items>) AS item(<26 columns>)`.
+ * The `raw` + `item` leading CTEs (#181).
  *
- * @param pad leading whitespace for the continuation lines, so the
- *            fragment lines up wherever it is spliced in.
+ * Before #181 every fragment that needed the line items pasted the
+ * whole `<ITEMS_JSON_ARRAY>` placeholder AND the 26-column
+ * `jsonb_to_recordset` type list of its own — four array copies and two
+ * type lists in the ingest write, three and two on re-extract. The array
+ * is the agent's OUTPUT, so each duplicate is retyped in full.
+ *
+ * CTEs are per-STATEMENT in PostgreSQL, so this dedups within one
+ * statement only: the brand FK guard stays a separate statement (RI
+ * checks are AFTER-ROW and `WITH` sub-statements cannot see each
+ * other's effects on target tables) and keeps its own one-column
+ * recordset.
+ *
+ * Place these FIRST in the `WITH` list; everything downstream reads
+ * `item`.
  */
-export function itemsRecordset(pad = ""): string {
-  return `jsonb_to_recordset(${ITEMS_JSON_EXPR}) AS item(
-${indentBlock(ITEM_RECORD_COLUMNS, `${pad}  `)}
-${pad})`;
+export function itemsCte(): string {
+  return `    -- #181: the items[] array enters this statement EXACTLY ONCE, here.
+    -- Every CTE below reads \`item\` — do NOT paste the array again.
+    raw AS (SELECT ${ITEMS_JSON_EXPR} AS j),
+    item AS (
+      SELECT i.*
+        FROM raw, jsonb_to_recordset(raw.j) AS i(
+${indentBlock(ITEM_RECORD_COLUMNS, "          ")}
+        )
+    )`;
 }
 
 /**
@@ -72,21 +96,31 @@ ${pad})`;
  *
  * Its own statement, never a sibling CTE: `WITH` sub-statements cannot
  * see each other's effects on target tables and RI checks are AFTER-ROW.
+ *
+ * `bare: true` drops the `psql … <<'SQL'` wrapper so the caller can
+ * batch it into a larger heredoc (#181 Turn B). It keeps its own
+ * one-column recordset either way — CTEs are per-statement, so it
+ * cannot read `itemsCte()`'s `item`.
  */
-export function brandFkGuard(): string {
-  return `  psql "\$DATABASE_URL" <<'SQL'
-    INSERT INTO brands (brand_id, name)
-    SELECT DISTINCT product_brand_id, product_brand_id
-      FROM jsonb_to_recordset(${ITEMS_JSON_EXPR})
-        AS item(product_brand_id text)
-     WHERE product_brand_id IS NOT NULL
-    ON CONFLICT (brand_id) DO NOTHING;
+export function brandFkGuard(opts: { bare?: boolean } = {}): string {
+  const stmt = `INSERT INTO brands (brand_id, name)
+SELECT DISTINCT product_brand_id, product_brand_id
+  FROM jsonb_to_recordset(${ITEMS_JSON_EXPR})
+    AS item(product_brand_id text)
+ WHERE product_brand_id IS NOT NULL
+ON CONFLICT (brand_id) DO NOTHING;`;
+  if (opts.bare) return indentBlock(stmt, "  ");
+  return `  psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" <<'SQL'
+${indentBlock(stmt, "    ")}
   SQL`;
 }
 
 /**
  * The `p_upsert` CTE — #84 Phase 1 products SSOT upsert, keyed by
  * (workspace_id, merchant_id, product_key).
+ *
+ * Requires `itemsCte()` earlier in the same `WITH` list — it reads
+ * `item`, it does not paste the array itself (#181).
  *
  * Returned WITHOUT a trailing comma so the call site can place it
  * anywhere in a `WITH` list.
@@ -107,21 +141,29 @@ export function productsUpsert(opts: {
     -- product_key=NULL and skip this step entirely (filtered by the
     -- WHERE clause). NULLS NOT DISTINCT in the unique index makes
     -- merchant_id=NULL participate.
+    -- DISTINCT ON (#181): two lines on one receipt may legitimately
+    -- share a product_key (the same dish ordered twice). Feeding both
+    -- to ON CONFLICT DO UPDATE raises PG 21000 "command cannot affect
+    -- row a second time" and rolls back the whole write. This dedups
+    -- the CATALOG upsert source only — transaction_items below still
+    -- gets one row per printed line.
     p_upsert AS (
       INSERT INTO products (
         workspace_id, merchant_id, product_key, canonical_name,
         item_class, brand_id, model, color, size, variant, sku,
         manufacturer
       )
-      SELECT '${opts.workspaceId}',
+      SELECT DISTINCT ON (item.product_key, COALESCE(item.product_merchant_exclusive, false))
+             '${opts.workspaceId}',
              CASE WHEN item.product_merchant_exclusive THEN ${opts.merchantIdExpr} ELSE NULL END,
              item.product_key,
              COALESCE(item.normalized_name, item.raw_name),
              item.item_class, item.product_brand_id,
              item.product_model, item.product_color, item.product_size,
              item.product_variant, item.product_sku, item.product_manufacturer
-      FROM ${itemsRecordset("      ")}
+      FROM item
       WHERE COALESCE(item.line_type, 'product') = 'product' AND item.product_key IS NOT NULL
+      ORDER BY item.product_key, COALESCE(item.product_merchant_exclusive, false), item.line_no
       ON CONFLICT (workspace_id, merchant_id, product_key) DO UPDATE
         SET updated_at = NOW(),
             canonical_name = COALESCE(EXCLUDED.canonical_name, products.canonical_name),
@@ -134,6 +176,9 @@ export function productsUpsert(opts: {
 /**
  * The `transaction_items` INSERT — #81 Phase 2 + #84 relational line
  * items with the `product_id` link and the per-line allocation columns.
+ *
+ * Requires `itemsCte()` earlier in the same `WITH` list — it selects
+ * `FROM item` rather than re-pasting the array (#181).
  *
  * Returns a bare `INSERT … SELECT … FROM …` (no trailing semicolon, no
  * CTE wrapper) so the ingest path can wrap it as `ti AS ( … )` and the
@@ -154,7 +199,7 @@ export function transactionItemsInsert(opts: {
   /** RETURNING column list, when the caller wraps this in a CTE. */
   returning?: string;
 }): string {
-  const from = opts.fromPrefix ? `${opts.fromPrefix}\n        ` : "";
+  const from = opts.fromPrefix ? `${opts.fromPrefix} ` : "";
   const returning = opts.returning ? `\n      RETURNING ${opts.returning}` : "";
   return `      INSERT INTO transaction_items (
         id, workspace_id, transaction_id, line_no, parent_line_no,
@@ -179,7 +224,7 @@ export function transactionItemsInsert(opts: {
                 LIMIT 1),
              item.tax_minor, item.tip_share_minor, item.discount_share_minor,
              ${opts.runExpr}, '${PROMPT_VERSION}'
-      FROM ${from}${itemsRecordset("        ")}${returning}`;
+      FROM ${from}item${returning}`;
 }
 
 /**

--- a/src/ingest/line-item-prompt.ts
+++ b/src/ingest/line-item-prompt.ts
@@ -216,7 +216,32 @@ line_type='tax'. Keep the printed NAME in raw_name / normalized_name.
 NEVER collapse them into the top-level tax_minor / discount_minor
 numbers only — that loses the name. parent_line_no is NULL on these
 rows. They are the audit baseline against the per-line allocations
-further below.`;
+further below.
+
+NAME PRESERVATION — the printed name is the only copy.
+
+  raw_name is the row EXACTLY as printed, verbatim: brand prefixes,
+  regulatory prefixes, store codes, CJK, punctuation, spacing.
+
+  normalized_name may expand an abbreviation or add an English gloss,
+  but it MUST still identify the SAME specific thing:
+    "KS PPR TWLS 12CT"     -> "Paper Towels"           OK (brand stripped)
+    "CRV / REDEMPTION FEE" -> "CRV Redemption Fee"     OK (expanded)
+    "CRV / REDEMPTION FEE" -> "Sales Fee"              WRONG (generalized)
+    "Tax(7.75%)"           -> "Sales Tax"              OK
+  Replacing a SPECIFIC printed name with a generic category word
+  destroys information that exists nowhere else — the UI renders this
+  string and never re-reads the image. When you cannot decode an
+  abbreviation, set normalized_name = NULL. NULL is honest; a plausible
+  generic label is a silent lie. This applies to tax / tip / discount /
+  fee / surcharge rows exactly as it applies to products.
+
+Two absolute rules on line_type:
+  * NEVER force a row into a label that misdescribes it. 'surcharge' is
+    not 'fee'; 'service_fee' is not 'tax'.
+  * NEVER DROP a printed row because you could not label it. 'other'
+    always exists. A dropped row is money that vanishes; a row labelled
+    'other' is money that stays auditable.`;
 
 /** The #162 two-level modifier rule, including BOTH the ADDITIVE and
  *  the INCLUSIVE branch. An agent given only the INCLUSIVE branch has
@@ -254,6 +279,35 @@ a PRICE?
     all-in price AND also emit priced children — that double-counts and
     breaks Σ line_total = subtotal.
 
+    GUARD — INCLUSIVE fires ONLY when this line HAS priced children.
+    "Σ priced add-ons" means exactly this: the sum of
+    line_total_minor over the child rows YOU ARE EMITTING with
+    parent_line_no = this line's line_no. Nothing else on the receipt
+    counts toward it. When that sum is ZERO — the line has no children,
+    or its children are printed at \$0.00 — then base = displayed, and
+    you MUST leave the parent's line_total EXACTLY as printed.
+      NEVER reduce or zero a printed price unless you are emitting
+      priced child rows that add back up to it. A price you removed
+      with nothing re-adding it is money DELETED from the receipt, not
+      money re-shaped, and it is strictly worse than double-counting
+      because nothing downstream can detect it.
+      Per-line cross-check, run it on every line you reduced:
+        (reduced parent base) + sum(that line's children's line_total)
+          == the price printed on that line
+      If that does not hold, your reduction was wrong. Put the printed
+      price back and re-derive the children.
+
+    ADDITIVE is the DEFAULT. Assume the printed price stands unless the
+    receipt gives you positive evidence that one all-in price already
+    contains its add-ons.
+
+    INVARIANT, stated in BOTH directions:
+      parent base + sum(its child add-ons) = the price actually charged
+      for that item — no MORE (never leave the parent at the all-in
+      price AND also emit priced children: that double-counts) and no
+      LESS (never zero or shrink a parent without children re-adding
+      the difference: that deletes money).
+
   ZERO-COST option → it is an ATTRIBUTE.
     Do NOT emit a separate line. Fold it into the PARENT item's
     product_variant string ("Less Sugar", "No Ice", "Spice Level 2",
@@ -269,7 +323,59 @@ receipts bundle "Milk Tea +Boba" at one blended price with no
 breakout), you cannot invent a split: keep the add-on name in the
 parent's product_variant and add a "variant-price-unresolved" tag on
 the parent so the limitation is auditable. Prefer a priced child line
-whenever the source shows any separable price.`;
+whenever the source shows any separable price.
+
+── Fixed-price PACKAGE / prix-fixe / AYCE / combo charges ─────────────
+
+A DIFFERENT shape from the modifier case above, and the one most often
+mangled. Some receipts charge ONE fixed package price and then list
+everything the package covers at \$0.00 each: all-you-can-eat, hot-pot
+"chang xuan" / "fang ti" selections, prix-fixe and tasting menus,
+banquet sets, "combo" meals, bundled service plans. Signals: a line
+whose price is large relative to the receipt and whose name contains
+AYCE / All You Can Eat / Package / Set / Course / Combo / Prix Fixe /
+per-person pricing, followed by a run of items printed at \$0.00 or with
+no price column at all.
+
+  1. THE PACKAGE CHARGE IS ITS OWN TOP-LEVEL PRODUCT LINE.
+     line_type='product', parent_line_no=NULL,
+     line_total_minor = the printed package price,
+     raw_name = the package line exactly as printed,
+     normalized_name = a clean gloss ("All-You-Can-Eat Package"),
+     product_merchant_exclusive=true, quantity = the guest / cover
+     count when printed.
+     NEVER fold the package price onto one of the items it covers. A
+     \$349.93 charge sitting on a "Green Bamboo Shoot" line is wrong
+     three times over: the package disappears as a purchasable thing,
+     a \$0 side dish acquires a \$349.93 price history, and no human
+     reading the ledger can reconstruct what was bought.
+
+  2. THE \$0.00 COVERED ITEMS ARE CHILDREN OF THE PACKAGE LINE.
+     parent_line_no = the package line's line_no,
+     line_total_minor = 0 (the printed price — do not impute one),
+     item_class / food_kind inherited from the parent.
+     They are the MANIFEST of what the package delivered. Keep every
+     one, keep them at zero, and keep duplicates as separate rows when
+     the receipt prints the same item more than once. Do NOT fold them
+     into the package's product_variant — product_variant is for
+     zero-cost CUSTOMIZATIONS of one item, not a list of distinct
+     dishes.
+
+  3. ANYTHING PRICED OUTSIDE THE PACKAGE KEEPS ITS PRINTED PRICE as its
+     own TOP-LEVEL line: soup bases and pot charges, a-la-carte dishes,
+     drinks, table / cover charges, sauce-bar fees. A soup base printed
+     at \$90.98 is NOT "included in" the package merely because the
+     package charge is larger. This is the INCLUSIVE GUARD restated: it
+     has no priced children, so it gets no reduction. Do not zero it.
+
+  4. TIE CHECK, before you write:
+       sum(top-level line_type='product' lines)
+         = package charge + everything priced outside the package
+         = the printed SUBTOTAL
+     The \$0.00 children contribute nothing by construction, so they
+     cannot break this sum. If it misses the subtotal you either
+     transplanted the package price onto a covered item or zeroed
+     something printed. Fix the shape; do not paper over it.`;
 
 /**
  * The arithmetic invariant + the TOTAL-ONLY fallback.
@@ -282,36 +388,79 @@ whenever the source shows any separable price.`;
  *
  * PR #165/#166 extends this export with the occlusion-bridge rule.
  */
-export const LINE_ITEM_COVERAGE_AND_BRIDGE = `── Coverage + arithmetic invariant ───────────────────────────────────
+export const LINE_ITEM_COVERAGE_AND_BRIDGE = `── Coverage: never silently lose money to a region you cannot read ────
 
-  Σ line_total_minor across rows with line_type IN ('product','other')
-  SHOULD approximate the receipt's printed SUBTOTAL (within \$0.01
-  rounding). 'other' counts toward coverage because the TOTAL-ONLY row
-  below stands in for product lines the source would not let you read.
+Two different failures, two different answers. Do not confuse them.
 
-  The remaining rows — tax / tip / discount / shipping / surcharge /
-  service_fee / gift_card — carry the rest (discount rows are
-  negative), so Σ of ALL rows ≈ the printed GRAND TOTAL.
+  NOTHING is itemizable — a total-only receipt, no item section, fully
+  illegible thermal print, an image that is only a total:
+    emit exactly ONE row —
+      line_type='other', item_class='other', confidence='low',
+      raw_name='TOTAL ONLY', line_total_minor=<TOTAL_MINOR>,
+      parent_line_no=NULL, product_key=NULL,
+      tags=['no-item-section'].
 
-  If the coverage sum is off by more than \$0.50, drop confidence to
-  "low" on the items that look most suspect.
+  SOME lines are readable but part of the item block is BLOCKED — a
+  hand or thumb over the paper, a fold, a glare or flash band, a tear,
+  a staple, a crop that cuts lines off — and the printed subtotal is
+  materially larger than what you can actually read (gap > \$0.50):
+    keep EVERY readable line at its printed price, AND emit ONE BRIDGE
+    ROW carrying the difference —
 
-  Self-check before COMMIT:
-    Σ tax rows      ≈ the printed tax
-    Σ discount rows ≈ the printed discount (negative)
-    Σ product effective_total ≈ the transaction total
+      line_type         'other'
+      item_class        'other'
+      parent_line_no    NULL
+      product_key       NULL
+      raw_name          a literal description of what blocked the read:
+                        "ITEMS OBSCURED BY HAND (unreadable)"
+                        "LINES CUT OFF BY CROP"
+                        "FOLD OBSCURES ~3 LINES"
+                        "GLARE BAND OVER ITEM BLOCK"
+      normalized_name   NULL
+      line_total_minor  printed subtotal - sum(readable product lines)
+      confidence        'low'
+      tags              ['occluded','unreadable'] (or ['cropped'],
+                        ['glare'], ['torn'] — describe the cause)
+      quantity / unit / unit_price_minor   NULL
 
-If you cannot itemize at all (total-only receipt, unreadable item
-section, illegible thermal print) emit exactly ONE item with
+    The bridge row makes the gap EXPLICIT and auditable instead of
+    silently missing, and it is what lets the receipt still tie.
+      Do NOT invent plausible item names to fill the gap.
+      Do NOT inflate a readable line to absorb it.
+      Do NOT discard the readable lines and fall back to TOTAL ONLY —
+        the readable lines are real data and must survive.
+      Emit at most ONE bridge row per receipt.
 
-  line_type='other', item_class='other', confidence='low',
-  raw_name='TOTAL ONLY', line_total_minor=<TOTAL_MINOR>,
-  parent_line_no=NULL, product_key=NULL,
-  tags=['no-item-section']
+  BRIDGE ONLY FOR SOURCE PROBLEMS. A gap you created yourself — by
+  zeroing a parent, by folding a package charge onto a covered dish, by
+  dropping a row you could not label — is a BUG to fix, not a gap to
+  bridge. Before emitting a bridge row, re-read the two-level rule, the
+  INCLUSIVE guard, and the package rule, and confirm the missing money
+  is genuinely unreadable ink on the source. A bridge row on a legible
+  receipt is a cover-up.
 
-— one label for "money the source would not let me itemize" keeps
-every downstream product-scoped sum a two-value check instead of an
-open-ended one.`;
+── Reconciliation self-check — run this BEFORE you write ──────────────
+
+  A = sum(line_total_minor) over rows with line_type IN ('product','other')
+      (bridge and total-only rows count in A: they stand in for product
+       lines the source would not let you read)
+  A  ~= the printed SUBTOTAL
+  sum(tax rows)      ~= the printed tax
+  sum(tip rows)      ~= the printed tip
+  sum(discount rows) ~= the printed discount (negative)
+  A + tax + tip + discount + shipping/surcharge/service_fee/gift_card
+                     ~= the printed GRAND TOTAL
+
+  Off by > \$0.50 with NO bridge row -> you lost or mis-shaped a line.
+    Go find it. Usual culprits in order: a parent you zeroed, a package
+    charge you transplanted, a printed row you dropped for want of a
+    line_type.
+  Off by > \$0.50 WITH a bridge row -> recompute the bridge amount from
+    the printed subtotal.
+  Within \$0.50 but over 1 cent -> keep it, set confidence='low' on the
+    lines you least trust, and record
+    transactions.metadata.allocation_audit = {kind, expected, got, delta}.
+  Never block the write on a residual; log it.`;
 
 /** Phase 2.7 — per-line tax / tip / discount allocation (#84). The
  *  re-extract SQL writes `tax_minor` / `tip_share_minor` /
@@ -454,6 +603,63 @@ $7.49 so base + add-ons re-sum to the $9.49 actually charged:
     // keep them in product_variant + "variant-price-unresolved" instead.
   ]
 
+Fixed-price PACKAGE with $0.00 covered items (#165) — hot pot, AYCE
+"chang xuan" selections. Contrast this against the INCLUSIVE example
+directly above: there, the parent was REDUCED because it had priced
+children. Here the children are all $0.00, so the GUARD says the
+package charge stays EXACTLY as printed. Two top-level product lines
+(a soup-base/pot charge priced outside the package, and the package
+itself), every covered dish a $0.00 child of the package:
+  items = [
+    {"line_no":1, "raw_name":"Small Pots", "normalized_name":"Small Pots",
+     "parent_line_no":null, "quantity":1, "unit":"ea",
+     "line_total_minor":9098, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"restaurant_dish", "line_type":"product",
+     "product_key":"hot-pot-small-pots", "product_merchant_exclusive":true,
+     "confidence":"high"},
+    {"line_no":2, "raw_name":"AYCE Package (7 guests)",
+     "normalized_name":"All-You-Can-Eat Package", "parent_line_no":null,
+     "quantity":7, "unit":"ea", "line_total_minor":34993, "currency":"USD",
+     "item_class":"food_drink", "food_kind":"restaurant_dish",
+     "line_type":"product", "product_key":"ayce-package",
+     "product_merchant_exclusive":true, "confidence":"high"},
+    {"line_no":3, "raw_name":"绿竹笋 Green Bamboo Shoot",
+     "normalized_name":"Green Bamboo Shoot", "parent_line_no":2,
+     "quantity":1, "unit":"ea", "line_total_minor":0, "currency":"USD",
+     "item_class":"food_drink", "food_kind":"restaurant_dish",
+     "line_type":"product", "confidence":"high"},
+    {"line_no":4, "raw_name":"安格斯肥牛 Angus Beef",
+     "normalized_name":"Angus Beef", "parent_line_no":2,
+     "quantity":1, "unit":"ea", "line_total_minor":0, "currency":"USD",
+     "item_class":"food_drink", "food_kind":"restaurant_dish",
+     "line_type":"product", "confidence":"high"},
+    {"line_no":5, "raw_name":"安格斯肥牛 Angus Beef",
+     "normalized_name":"Angus Beef", "parent_line_no":2,
+     "quantity":1, "unit":"ea", "line_total_minor":0, "currency":"USD",
+     "item_class":"food_drink", "food_kind":"restaurant_dish",
+     "line_type":"product", "confidence":"high"},
+    // … one $0.00 child per printed selection, duplicates kept as
+    // separate rows exactly as the receipt printed them …
+    {"line_no":20, "raw_name":"Promotion", "normalized_name":"Promotion",
+     "parent_line_no":null, "line_total_minor":-7000, "currency":"USD",
+     "item_class":"other", "line_type":"discount", "tags":["promo"],
+     "confidence":"high"},
+    {"line_no":21, "raw_name":"Tax(7.75%)", "normalized_name":"Sales Tax",
+     "parent_line_no":null, "line_total_minor":2875, "currency":"USD",
+     "item_class":"other", "line_type":"tax", "confidence":"high"}
+    // Arithmetic: top-level product lines 9098 + 34993 = 44091 = the
+    // printed SUBTOTAL. 44091 - 7000 + 2875 = 39966 = the printed
+    // GRAND TOTAL. The $0.00 children add nothing, by construction.
+    //
+    // BOTH of these shapes are WRONG and both have shipped before:
+    //   (a) transplanting the 34993 package price onto line 3, the
+    //       covered "Green Bamboo Shoot" — the package vanishes as a
+    //       purchasable thing and a side dish gets a $349.93 history;
+    //   (b) zeroing the 9098 "Small Pots" line as "included in the
+    //       package" — it has NO priced children, so the INCLUSIVE
+    //       guard forbids reducing it. That is $90.98 deleted.
+  ]
+
 Costco gas (single line):
   items = [
     {"line_no":1, "raw_name":"GAS REG", "normalized_name":"Regular Gas",
@@ -462,7 +668,64 @@ Costco gas (single line):
      "item_class":"consumable", "tags":["fuel"], "confidence":"high"}
   ]
 
-AYCE sushi dinner ($46.20):
+Occluded item block — the BRIDGE row (#166). A hand covers part of the
+item list on a grocery receipt; five lines are readable and sum to
+$63.17, but the printed subtotal is $156.09. Keep the readable lines,
+carry the $92.92 gap on ONE explicit bridge row, and preserve the
+printed fee names:
+  items = [
+    {"line_no":1, "raw_name":"SPINACH", "normalized_name":"Spinach",
+     "parent_line_no":null, "quantity":1, "unit":"ea",
+     "line_total_minor":1899, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"grocery_food", "line_type":"product",
+     "product_key":"spinach", "confidence":"high"},
+    {"line_no":2, "raw_name":"TOFU FIRM", "normalized_name":"Firm Tofu",
+     "parent_line_no":null, "quantity":1, "unit":"ea",
+     "line_total_minor":1499, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"grocery_food", "line_type":"product",
+     "product_key":"firm-tofu", "confidence":"high"},
+    {"line_no":3, "raw_name":"PORK BELLY", "normalized_name":"Pork Belly",
+     "parent_line_no":null, "quantity":1, "unit":"lb",
+     "line_total_minor":1299, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"grocery_food", "line_type":"product",
+     "product_key":"pork-belly", "confidence":"high"},
+    {"line_no":4, "raw_name":"KIMCHI 1KG", "normalized_name":"Kimchi 1kg",
+     "parent_line_no":null, "quantity":1, "unit":"ea",
+     "line_total_minor":999, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"grocery_food", "line_type":"product",
+     "product_key":"kimchi-1kg", "confidence":"high"},
+    {"line_no":5, "raw_name":"GREEN ONION", "normalized_name":"Green Onion",
+     "parent_line_no":null, "quantity":1, "unit":"ea",
+     "line_total_minor":621, "currency":"USD", "item_class":"food_drink",
+     "food_kind":"grocery_food", "line_type":"product",
+     "product_key":"green-onion", "confidence":"high"},
+    {"line_no":6, "raw_name":"ITEMS OBSCURED BY HAND (unreadable)",
+     "normalized_name":null, "parent_line_no":null, "quantity":null,
+     "unit":null, "unit_price_minor":null, "line_total_minor":9292,
+     "currency":"USD", "item_class":"other", "line_type":"other",
+     "product_key":null, "tags":["occluded","unreadable"],
+     "confidence":"low"},
+    {"line_no":7, "raw_name":"SALES TAX", "normalized_name":"Sales Tax",
+     "parent_line_no":null, "line_total_minor":360, "currency":"USD",
+     "item_class":"other", "line_type":"tax", "confidence":"high"},
+    {"line_no":8, "raw_name":"CRV / REDEMPTION FEE",
+     "normalized_name":"CRV Redemption Fee", "parent_line_no":null,
+     "line_total_minor":10, "currency":"USD", "item_class":"other",
+     "line_type":"surcharge", "confidence":"high"}
+    // Arithmetic: 6317 (readable products) + 9292 (bridge) = 15609 =
+    // the printed SUBTOTAL. 15609 + 360 + 10 = 15979 = the printed
+    // GRAND TOTAL.
+    // Do NOT collapse 'surcharge' to 'fee', and do NOT generalize
+    // "CRV Redemption Fee" to "Sales Fee" — that specific printed name
+    // exists nowhere else once the image is filed away.
+    // Do NOT invent five more plausible grocery names to fill the
+    // $92.92, and do NOT throw the readable lines away for a TOTAL
+    // ONLY row.
+  ]
+
+AYCE sushi dinner — flat per-cover pricing, NOT a package ($46.20).
+Nothing here is printed at $0.00, so there is no package line and no
+$0.00 manifest; this is just two ordinary priced lines:
   items = [
     {"line_no":1, "raw_name":"AYCE Lunch", "normalized_name":"All-You-Can-Eat Lunch",
      "quantity":2, "unit":"ea", "unit_price_minor":2199,

--- a/src/ingest/prompt-contract.ts
+++ b/src/ingest/prompt-contract.ts
@@ -31,7 +31,7 @@ import { fileURLToPath } from "node:url";
  * pure liability, and nothing reads or compares either value. The path
  * is distinguished by `metadata.extraction.source ∈ {'ingest','re-extract'}`.
  */
-export const PROMPT_VERSION = "3.0";
+export const PROMPT_VERSION = "3.0.1";
 
 /**
  * The model identifier stamped into `transactions.metadata.extraction.model`
@@ -51,15 +51,32 @@ export const EXTRACTION_MODEL = process.env.CLAUDE_MODEL ?? "cli-default";
 export const NO_JSON_SCHEMA_RULE = `Reason in plain text first. Chain-of-thought measurably improves OCR.
 Do NOT use \`--json-schema\`-style structured output.`;
 
-/** The psql connection + heredoc form. Both prompts write via psql and
- *  both need the multi-statement heredoc shape. */
+/**
+ * The psql connection + heredoc form + the BATCHING rule (#181).
+ *
+ * The batching rule is the turn-count half of #181. Nothing in either
+ * prompt ever forbade multiple *statements* per invocation, but nothing
+ * asked for it either, and the per-section structure produced ~8 core
+ * write turns. Each extra round trip re-sends the whole conversation,
+ * so turns multiply input tokens super-linearly.
+ */
 export const PSQL_DISCIPLINE = `DB connection: \`psql "\$DATABASE_URL"\` — the env var is set. Use it for
-every SQL call. If you want a multi-statement block, use a heredoc:
-  psql "\$DATABASE_URL" <<'SQL'
-    BEGIN;
-    ...
-    COMMIT;
-  SQL`;
+every SQL call.
+
+- One psql INVOCATION per Bash tool call, and BATCH your statements
+  into that one invocation with a heredoc. Do NOT issue one psql call
+  per statement — each round trip re-sends the whole conversation.
+    psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" <<'SQL'
+      BEGIN;
+      ...
+      COMMIT;
+    SQL
+  Always use the QUOTED heredoc marker <<'SQL' so the shell does not
+  mangle \$items\$ dollar-quoting. Always pass -v ON_ERROR_STOP=1 —
+  without it, a failed statement inside BEGIN turns COMMIT into a
+  silent ROLLBACK and psql still exits 0.
+- Still SEQUENTIAL: one Bash tool call at a time, never a parallel
+  tool-call block.`;
 
 /**
  * Scratch-file discipline (#143) + sequential tool discipline (#126) +

--- a/src/ingest/prompt-contract.ts
+++ b/src/ingest/prompt-contract.ts
@@ -31,7 +31,7 @@ import { fileURLToPath } from "node:url";
  * pure liability, and nothing reads or compares either value. The path
  * is distinguished by `metadata.extraction.source ∈ {'ingest','re-extract'}`.
  */
-export const PROMPT_VERSION = "3.0.1";
+export const PROMPT_VERSION = "3.1";
 
 /**
  * The model identifier stamped into `transactions.metadata.extraction.model`

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -32,7 +32,7 @@ import {
   LINE_ITEM_WORKED_EXAMPLES,
 } from "./line-item-prompt.js";
 import {
-  ITEMS_JSON_EXPR,
+  itemsCte,
   brandFkGuard,
   productsUpsert,
   transactionItemsInsert,
@@ -120,7 +120,9 @@ ${phase0DocumentRead({ filePath: ctx.filePath, scratchDir })}
 
 ── Phase 1 — Classify ─────────────────────────────────────────────────
 
-Read the file (image / pdf / html / .eml) and decide which category:
+Follow the document-reading rules above FIRST — for a PDF that means
+the text file, never the PDF itself (the Read tool rasterizes PDFs into
+images). Then decide which category:
 
   receipt_image   photo/scan of a physical receipt
   receipt_email   .eml / .html purchase confirmation (Amazon, Uber, …)
@@ -307,18 +309,18 @@ Any non-OK status / HTTP error → skip. Phase 3 is best-effort.
 ### Phase 3b — Local-first cache check
 
 Before hitting any v1 endpoint, check whether we already have this
-place cached:
+place cached. Do NOT spend a psql call of your own here: this lookup
+is result set ② of the ONE consolidated read (**Turn A**, Phase 4.0
+below). Run Turn A now — you have the \`<PLACE_ID>\` from 3a, which is
+all it was waiting for — and read its answer.
 
-  PID='<google_place_id from 3a>'
-  EXISTING=\$(psql "\$DATABASE_URL" -tA -c "SELECT id FROM places WHERE google_place_id = '\$PID'")
-
-If EXISTING is non-empty (the place is cached):
-  - Use the cached row id as your tx.place_id in Phase 4.
-  - Bump \`last_seen_at\`/\`hit_count\` via the upsert in Phase 4 — that
-    statement handles both insert-new and increment-existing.
+If Turn A's ② returned a row (the place is cached):
   - SKIP Phase 3c entirely. No outbound Google calls.
+  - You do NOT need the returned id in hand: the \`place\` CTE inside
+    Turn B upserts on \`google_place_id\` and feeds \`tx.place_id\`
+    inline, so it handles insert-new and increment-existing alike.
 
-Only when EXISTING is empty do you proceed to 3c.
+Only when Turn A's ② returned no row do you proceed to 3c.
 
 ### Phase 3c — Dual-language v1 fetch + photos
 
@@ -624,6 +626,77 @@ Invariants you MUST honor:
     titles ("World's", 12" pan) from breaking the write. Never revert it
     to a single-quoted \`'...'::jsonb\` literal.
 
+### 4.0 The write-phase turn plan — READ THIS BEFORE ANY WRITE
+
+The entire ledger write is **THREE psql invocations**, not eight and
+not twenty:
+
+  Turn A — ONE read invocation, four result sets. Everything the write
+           branches on.
+  Turn B — ONE write invocation. The whole ledger write.
+  Turn C — Phase 5, close the ingest row.
+
+Batch statements inside each invocation with a heredoc (see the psql
+discipline near the top). Every extra invocation re-sends this whole
+conversation, and that round-trip cost — not the extraction itself —
+is what makes a run expensive.
+
+**Turn A.** Run it ONCE, after you have (a) your extracted fields,
+(b) the Phase 2.5 merchant block, and (c) the Phase 3a geocode result
+if you are doing Phase 3 at all. Phase 3a is a \`curl\`, not a psql
+call, so doing it before Turn A costs you nothing and lets the place
+lookup ride along. Include only the result sets that apply; keep them
+in this order so you can read the output positionally:
+
+  psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" <<'SQL'
+  -- (1) brand registry: Phase 2.6 cache check AND the Phase 4b icon
+  --     pre-check, in one row per brand.
+  SELECT b.brand_id, b.name, b.domain, b.user_chose_at,
+         b.preferred_asset_id,
+         b.metadata->>'icon_resolution' AS icon_resolution,
+         (SELECT count(*) FROM brand_assets a
+           WHERE a.brand_id = b.brand_id AND a.retired_at IS NULL) AS live_count
+    FROM brands b
+   WHERE b.brand_id IN ('<merchant brand-id>' /* , '<product brand-ids>' */);
+
+  -- (2) place cache: Phase 3b. OMIT this query when Phase 3a produced
+  --     no place id (or you skipped Phase 3).
+  SELECT id FROM places WHERE google_place_id = '<PLACE_ID>';
+
+  -- (3) Message-ID dedup: receipt_email ONLY. OMIT otherwise.
+  SELECT id FROM documents
+   WHERE workspace_id = '${ctx.workspaceId}'
+     AND message_id = '<MESSAGE_ID>'
+     AND id <> '${ctx.documentId}'
+   LIMIT 1;
+
+  -- (4) near-duplicate candidates: Phase 4a.0. Use YOUR extracted
+  --     values; the ±3-day window covers settlement-date drift.
+  SELECT t.id, t.payee, t.occurred_on,
+         t.metadata->>'order_number'  AS order_number,
+         t.metadata->>'payment_id'    AS payment_id,
+         t.metadata->>'approval_code' AS approval_code,
+         t.metadata->>'payment'       AS payment
+    FROM transactions t
+    JOIN postings p ON p.transaction_id = t.id AND p.amount_minor > 0
+   WHERE t.workspace_id = '${ctx.workspaceId}'
+     AND t.status IN ('posted','reconciled')
+     AND t.occurred_on BETWEEN DATE '<YYYY-MM-DD>' - 3 AND DATE '<YYYY-MM-DD>' + 3
+   GROUP BY t.id
+  HAVING SUM(p.amount_minor) = <TOTAL_MINOR>
+   LIMIT 5;
+  SQL
+
+psql prints the result sets in order. Read them once, then branch:
+  (3) non-empty → duplicate email; skip the write entirely and go to
+      Turn C with status='done' (see 4a step 1).
+  (4) → walk the near-dup decision tree in 4a.0.
+  (2) → Phase 3b/3c.
+  (1) → Phase 2.6 discovery and the Phase 4b/4c icon cases.
+
+Do NOT re-run any of these queries later in the run. If a result
+surprises you, re-read the output you already have.
+
 ### 4a. receipt_image / receipt_email / receipt_pdf
 
 **Email-only pre/post steps (receipt_email). #122.**
@@ -643,42 +716,42 @@ document" phase above before reading it.)
 
 1. **Dedup pre-check — skip the WHOLE ingest if this email was already
    ingested.** A re-forwarded copy has different bytes (so the sha256
-   dedup misses it) but the same Message-ID. Run:
+   dedup misses it) but the same Message-ID. This is result set (3) of
+   **Turn A** — do not issue a separate psql call for it.
 
-     psql "\$DATABASE_URL" -tAc "SELECT id FROM documents WHERE workspace_id = '${ctx.workspaceId}' AND message_id = '<MESSAGE_ID>' AND id <> '${ctx.documentId}' LIMIT 1"
-
-   If it returns a row, do **NOT** write a transaction — go straight to
-   Phase 5 and close the ingest as \`done\` with
+   If Turn A's (3) returned a row, do **NOT** write a transaction — go
+   straight to Phase 5 (Turn C) and close the ingest as \`done\` with
    \`produced.transaction_ids = []\` and \`error = 'duplicate Message-ID'\`.
    (The \`(workspace_id, message_id)\` unique index is the hard backstop;
    this pre-check is the graceful path.)
 
-2. **After the transaction commits**, stamp the document so future
-   dedup and the frontend "Original email" fold work:
+2. **Stamping the document** with \`message_id\` / \`source_meta\` is NOT
+   a separate call either — it is folded into Turn B's
+   \`UPDATE documents\` statement, which runs after the transaction
+   INSERT inside the same transaction. The values to put there:
 
-     psql "\$DATABASE_URL" <<'SQL'
-       UPDATE documents
-          SET message_id  = '<MESSAGE_ID>',
-              source_meta = jsonb_build_object(
-                'channel', 'eml',
-                'sender', '<FROM>',
-                'subject', '<SUBJECT>',
-                'received_at', '<RFC822 Date as ISO-8601>',
-                'message_id', '<MESSAGE_ID>')
-        WHERE id = '${ctx.documentId}';
-     SQL
+       message_id  = '<MESSAGE_ID>',
+       source_meta = jsonb_build_object(
+         'channel', 'eml',
+         'sender', '<FROM>',
+         'subject', '<SUBJECT>',
+         'received_at', '<RFC822 Date as ISO-8601>',
+         'message_id', '<MESSAGE_ID>')
 
-**Pre-step — brand FK guard.** Phase 2.6 ensured the merchant's
-brand_id is in \`brands\`. Items may also carry \`product_brand_id\`
+**Brand rows are FK parents — they are the first statements of Turn
+B.** \`merchants.brand_id\` and \`products.brand_id\` are both FK into
+\`brands\`, so both must exist before the \`m\` and \`p_upsert\` CTEs
+run. Items may carry a \`product_brand_id\` distinct from the merchant's
 (e.g. Apple-branded products at Best Buy → product brand = "apple",
-merchant brand = "best-buy"). \`products.brand_id\` is FK into
-\`brands\`, so before the BEGIN below, run one defensive UPSERT for
-every distinct product_brand_id present in items[]:
+merchant brand = "best-buy").
 
-${brandFkGuard()}
+Each is its OWN statement inside Turn B's heredoc, never a sibling
+CTE: \`WITH\` sub-statements cannot see each other's effects on target
+tables, and RI checks are AFTER-ROW, so a brands row created in a
+sibling CTE is not reliably visible to the FK check.
 
-This is a stub row (domain NULL); we don't run Phase 2.6 discovery
-for product brand_ids in v1. Phase 4b will skip them at the
+The product-brand rows are stubs (domain NULL); we don't run Phase 2.6
+discovery for product brand_ids in v1. Phase 4b will skip them at the
 discovery_failed check, so they cost nothing extra at ingest. They
 become eligible for discovery + icon acquisition if a future ingest
 sees the same brand as a merchant.
@@ -698,12 +771,10 @@ the extracted fields below always decide, never this list by itself):
 
 ${renderPhashNeighbors(ctx.phashNeighbors)}
 
-Candidate query — run it with YOUR extracted values (±3-day window
-covers settlement-date drift):
+Candidate list — this is result set (4) of **Turn A**, already run with
+YOUR extracted values. Do not re-query it here.
 
-  psql "\$DATABASE_URL" -c "SELECT t.id, t.payee, t.occurred_on, t.metadata->>'order_number' AS order_number, t.metadata->>'payment_id' AS payment_id, t.metadata->>'approval_code' AS approval_code, t.metadata->>'payment' AS payment FROM transactions t JOIN postings p ON p.transaction_id = t.id AND p.amount_minor > 0 WHERE t.workspace_id = '${ctx.workspaceId}' AND t.status IN ('posted','reconciled') AND t.occurred_on BETWEEN DATE '<YYYY-MM-DD>' - 3 AND DATE '<YYYY-MM-DD>' + 3 GROUP BY t.id HAVING SUM(p.amount_minor) = <TOTAL_MINOR> LIMIT 5"
-
-Union the result with any pHash-neighbor transactions above, then walk
+Union that result with any pHash-neighbor transactions above, then walk
 this tree (tiebreaker strength: order/receipt number > payment auth
 code / card last-4 > time-of-day > items list):
 
@@ -713,7 +784,7 @@ code / card last-4 > time-of-day > items list):
    same items) AND same merchant → this purchase is already in the
    ledger. Do NOT insert a transaction. Instead ATTACH:
 
-     psql "\$DATABASE_URL" <<'SQL'
+     psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" <<'SQL'
      BEGIN;
      INSERT INTO document_links (document_id, transaction_id)
      VALUES ('${ctx.documentId}', '<EXISTING_TX_ID>')
@@ -729,11 +800,23 @@ code / card last-4 > time-of-day > items list):
               )
             )
       WHERE id = '<EXISTING_TX_ID>';
+     -- receipt_email only: Turn B never runs on this branch, so stamp
+     -- the document here or dedup breaks for the next forwarded copy.
+     UPDATE documents
+        SET message_id  = '<MESSAGE_ID>',
+            source_meta = jsonb_build_object(
+              'channel', 'eml',
+              'sender', '<FROM>',
+              'subject', '<SUBJECT>',
+              'received_at', '<RFC822 Date as ISO-8601>',
+              'message_id', '<MESSAGE_ID>'),
+            updated_at  = NOW()
+      WHERE id = '${ctx.documentId}';
      COMMIT;
      SQL
 
-   Still run the email post-step (message_id / source_meta stamp) if
-   classification is receipt_email. Then close the ingest in Phase 5
+   That heredoc is the whole write for this branch — one invocation.
+   Then close the ingest in Phase 5 (Turn C)
    with **status='near_dup'** and
    \`produced.transaction_ids = ['<EXISTING_TX_ID>']\`. Skip Phases
    2.6/3/4b/4c entirely — the existing transaction already carries
@@ -770,13 +853,48 @@ and never leave the category blank.
 
 Mirror side is Credit Card (default).
 
-Template (substitute your extracted values for the placeholders; the
-subqueries resolve account ids inline so you do NOT need to SELECT
-them first):
+Template — **this whole heredoc is Turn B: ONE Bash tool call.**
+Substitute your extracted values for the placeholders; the subqueries
+resolve account ids inline so you do NOT need to SELECT them first.
+Statements marked OPTIONAL get deleted when they don't apply to this
+receipt. Everything that stays goes in this single invocation — do not
+split it back into one psql call per statement.
 
-  psql "\$DATABASE_URL" <<'SQL'
+\`<TX>\` below means the expression
+
+  (SELECT id FROM transactions WHERE source_ingest_id = '${ctx.ingestId}' AND workspace_id = '${ctx.workspaceId}')
+
+— the row the \`tx\` CTE inserts in step (3). Later statements resolve
+the new transaction that way, so nothing here needs its uuid echoed
+back to you in a separate turn.
+
+  psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" <<'SQL'
   BEGIN;
+
+  -- (1) FK parent — the merchant's brand. Its OWN statement: a sibling
+  --     CTE cannot reliably satisfy merchants.brand_id's AFTER-ROW RI
+  --     check. Use the canonical_name + domain you settled in Phase 2.6
+  --     (domain NULL is fine). When Phase 2.6 found no usable domain,
+  --     add  metadata = jsonb_build_object('icon_resolution','discovery_failed')
+  --     to the DO UPDATE list so Phase 4b skips the brand cheaply.
+  INSERT INTO brands (brand_id, name, domain)
+  VALUES ('<brand-id>', '<CANONICAL_NAME>', <'<domain>' | NULL>)
+  ON CONFLICT (brand_id) DO UPDATE
+    SET name       = EXCLUDED.name,
+        domain     = COALESCE(brands.domain, EXCLUDED.domain),
+        updated_at = NOW();
+
+  -- (2) OPTIONAL FK parents — every distinct product_brand_id in
+  --     items[]. Stub rows (domain NULL). Delete when no item carries
+  --     a product_brand_id.
+${brandFkGuard({ bare: true })}
+
+  -- (3) The ledger write itself: merchant, transaction, both postings,
+  --     the document link, the product catalog and the line items —
+  --     ONE statement, so the deferred balance trigger sees a matched
+  --     set of postings.
   WITH
+${itemsCte()},
     expense AS (SELECT id FROM accounts WHERE workspace_id = '${ctx.workspaceId}' AND type = 'expense' AND name = '<EXPENSE_NAME>' LIMIT 1),
     credit  AS (SELECT id FROM accounts WHERE workspace_id = '${ctx.workspaceId}' AND type = 'liability' AND name = 'Credit Card' LIMIT 1),
     m AS (
@@ -815,8 +933,10 @@ them first):
           ),
           -- items[] is REQUIRED for receipt_image / receipt_email /
           -- receipt_pdf per #81. Statement_pdf omits this key. Each
-          -- object follows the schema in Phase 2.
-          'items', ${ITEMS_JSON_EXPR}
+          -- object follows the schema in Phase 2. This reads the SAME
+          -- array you already pasted into the \`raw\` CTE above — copy
+          -- it from there, do not retype it differently.
+          'items', (SELECT j FROM raw)
           -- add tax/tip/raw_text here if useful, as extra JSONB keys
         ),
         '${ctx.userId}'
@@ -857,112 +977,164 @@ ${transactionItemsInsert({
 })}
     )
   SELECT tx.id AS tx_id FROM tx;
-  COMMIT;
-  SQL
 
-After the main block commits, run the products aggregate recomputation
-for every product touched by this ingest. The agent runs this so
-the stats reflect THE LIVE set of transaction_items immediately —
-this is the recompute-not-increment rule from #84. \`from_dt\` is
-optional; use the workspace base currency snapshot already on
-\`postings.amount_base_minor\` for total_spent_minor:
+  -- (4) Force the DEFERRABLE balance triggers to fire HERE, where psql
+  --     can point at a line number, instead of at COMMIT where it
+  --     cannot. If postings don't sum to zero you find out now.
+  SET CONSTRAINTS ALL IMMEDIATE;
 
-  psql "\$DATABASE_URL" <<'SQL'
+  -- (5) OPTIONAL — owned_items for the durable lines you judged worth
+  --     tracking (see 4a-bis for the judgment). ONE set-based
+  --     statement: list those line_no values in the ARRAY. Delete this
+  --     statement entirely when no line qualifies.
+  INSERT INTO owned_items (workspace_id, product_id, transaction_item_id, instance_index, acquired_on)
+  SELECT '${ctx.workspaceId}', ti.product_id, ti.id, gs.idx, '<YYYY-MM-DD>'::date
+  FROM transaction_items ti
+  CROSS JOIN LATERAL generate_series(1, COALESCE(ti.quantity, 1)::int) gs(idx)
+  WHERE ti.transaction_id = <TX>
+    AND ti.retired_at IS NULL
+    AND ti.line_no = ANY(ARRAY[<durable line_nos, comma-separated>]::int[])
+    AND ti.item_class = 'durable'
+    AND ti.product_id IS NOT NULL
+  ON CONFLICT (transaction_item_id, instance_index) DO NOTHING;
+
+  -- (6) Stamp the document: ties the file back to this ingest AND
+  --     stores the OCR text, so \`documents.ocr_text\` is populated by
+  --     BOTH the ingest and the re-extract path (it used to be
+  --     re-extract only, which made every "what did the agent actually
+  --     read?" question unanswerable for ingest-only documents).
+  --     message_id / source_meta are the receipt_email post-step from
+  --     4a step 2 — drop those two assignments for non-email uploads.
+  UPDATE documents
+     SET source_ingest_id  = '${ctx.ingestId}',
+         ocr_text          = '<RAW_TEXT, single-quote-escaped>',
+         ocr_model_version = '${EXTRACTION_MODEL}',
+         message_id        = '<MESSAGE_ID>',
+         source_meta       = jsonb_build_object(
+                               'channel', 'eml',
+                               'sender', '<FROM>',
+                               'subject', '<SUBJECT>',
+                               'received_at', '<RFC822 Date as ISO-8601>',
+                               'message_id', '<MESSAGE_ID>'),
+         updated_at        = NOW()
+   WHERE id = '${ctx.documentId}';
+
+  -- (7) products aggregate recomputation, for every product this
+  --     ingest touched. Recompute, never increment (#84) — the stats
+  --     then reflect the LIVE set of transaction_items immediately.
+  --     total_spent_minor uses the workspace base-currency snapshot
+  --     already on postings.amount_base_minor.
 ${productAggregateRecompute({ workspaceId: ctx.workspaceId, touchedPredicate: `t.source_ingest_id = '${ctx.ingestId}'` })}
-  SQL
 
-If you have a geocode result, run this AFTER the main transaction
-(use the tx_id printed above).
+  COMMIT;
 
-The INSERT is a full multilingual upsert (#74). For uncached places
-include every column you extracted in Phase 3c/3d. For cached places
-the ON CONFLICT clause keeps existing per-language data and the
-\`custom_name\` user override (renamed from \`custom_name_zh\` in #79); only \`last_seen_at\` and \`hit_count\`
-bump. \`COALESCE(EXCLUDED.x, places.x)\` ensures a NEW fetch that
-returned NULL for a field never overwrites a previously-good value.
+  -- (8) AFTER COMMIT, still inside this one invocation: the party
+  --     graph (see 4a-ter for which parties to record). Additive —
+  --     it must never be able to roll back the transaction itself,
+  --     which is why it sits after COMMIT rather than inside it.
+  INSERT INTO transaction_parties
+    (workspace_id, transaction_id, transaction_item_id, role, display_name, brand_id)
+  VALUES
+    ('${ctx.workspaceId}', <TX>, NULL, 'channel', '<as printed>', '<brand_id-or-NULL>')
+    -- , line-level example:
+    -- ('${ctx.workspaceId}', <TX>,
+    --   (SELECT id FROM transaction_items WHERE transaction_id=<TX> AND line_no=<N> AND retired_at IS NULL),
+    --   'maker', 'Anker', 'anker')
+  ON CONFLICT ON CONSTRAINT transaction_parties_identity_uq DO NOTHING;
 
-  psql "\$DATABASE_URL" <<'SQL'
-  WITH
-    place AS (
-      INSERT INTO places (
-        id, google_place_id, formatted_address, lat, lng, source, raw_response,
-        last_seen_at, hit_count,
-        display_name_en, display_name_zh, display_name_zh_locale, display_name_zh_source, display_name_zh_is_native,
-        primary_type, primary_type_display_zh, maps_type_label_zh, types,
-        formatted_address_en, formatted_address_zh, postal_code, country_code,
-        business_status, business_hours, time_zone,
-        rating, user_rating_count,
-        national_phone_number, website_uri, google_maps_uri
-      ) VALUES (
-        gen_random_uuid(),
-        '<PLACE_ID>', '<FORMATTED_ADDRESS>', <LAT>, <LNG>,
-        '<google_geocode|google_places>',
-        '<RAW_JSON_STRING_WITH_BOTH_LANGS>'::jsonb,
-        NOW(), 1,
-        <NULLABLE_TEXT 'display_name_en'>,
-        <NULLABLE_TEXT 'display_name_zh'>,
-        <NULLABLE_TEXT 'display_name_zh_locale'>,
-        <NULLABLE_TEXT 'display_name_zh_source'>,           -- 'google_text' | 'photo_ocr' | 'receipt_ocr' | NULL
-        <NULLABLE_BOOL 'display_name_zh_is_native'>,        -- true unless brand is a global English-first name w/ Google gloss
-        <NULLABLE_TEXT 'primary_type'>,
-        <NULLABLE_TEXT 'primary_type_display_zh'>,
-        <NULLABLE_TEXT 'maps_type_label_zh'>,
-        <NULLABLE_TEXT_ARRAY 'types[]'>,                     -- e.g. ARRAY['store','food']::text[] or NULL
-        <NULLABLE_TEXT 'formatted_address_en'>,
-        <NULLABLE_TEXT 'formatted_address_zh'>,
-        <NULLABLE_TEXT 'postal_code'>,
-        <NULLABLE_TEXT 'country_code'>,
-        <NULLABLE_TEXT 'business_status'>,
-        <NULLABLE_JSONB 'business_hours'>,
-        <NULLABLE_TEXT 'time_zone'>,
-        <NULLABLE_NUMERIC 'rating'>,
-        <NULLABLE_INT 'user_rating_count'>,
-        <NULLABLE_TEXT 'national_phone_number'>,
-        <NULLABLE_TEXT 'website_uri'>,
-        <NULLABLE_TEXT 'google_maps_uri'>
-      )
-      ON CONFLICT (google_place_id) DO UPDATE
-        SET last_seen_at = NOW(),
-            hit_count = places.hit_count + 1,
-            raw_response = EXCLUDED.raw_response,
-            display_name_en          = COALESCE(EXCLUDED.display_name_en,          places.display_name_en),
-            display_name_zh          = COALESCE(EXCLUDED.display_name_zh,          places.display_name_zh),
-            display_name_zh_locale   = COALESCE(EXCLUDED.display_name_zh_locale,   places.display_name_zh_locale),
-            display_name_zh_source   = COALESCE(EXCLUDED.display_name_zh_source,   places.display_name_zh_source),
-            display_name_zh_is_native = COALESCE(EXCLUDED.display_name_zh_is_native, places.display_name_zh_is_native),
-            primary_type             = COALESCE(EXCLUDED.primary_type,             places.primary_type),
-            primary_type_display_zh  = COALESCE(EXCLUDED.primary_type_display_zh,  places.primary_type_display_zh),
-            maps_type_label_zh       = COALESCE(EXCLUDED.maps_type_label_zh,       places.maps_type_label_zh),
-            types                    = COALESCE(EXCLUDED.types,                    places.types),
-            formatted_address_en     = COALESCE(EXCLUDED.formatted_address_en,     places.formatted_address_en),
-            formatted_address_zh     = COALESCE(EXCLUDED.formatted_address_zh,     places.formatted_address_zh),
-            postal_code              = COALESCE(EXCLUDED.postal_code,              places.postal_code),
-            country_code             = COALESCE(EXCLUDED.country_code,             places.country_code),
-            business_status          = COALESCE(EXCLUDED.business_status,          places.business_status),
-            business_hours           = COALESCE(EXCLUDED.business_hours,           places.business_hours),
-            time_zone                = COALESCE(EXCLUDED.time_zone,                places.time_zone),
-            rating                   = COALESCE(EXCLUDED.rating,                   places.rating),
-            user_rating_count        = COALESCE(EXCLUDED.user_rating_count,        places.user_rating_count),
-            national_phone_number    = COALESCE(EXCLUDED.national_phone_number,    places.national_phone_number),
-            website_uri              = COALESCE(EXCLUDED.website_uri,              places.website_uri),
-            google_maps_uri          = COALESCE(EXCLUDED.google_maps_uri,          places.google_maps_uri)
-            -- Note: custom_name is INTENTIONALLY OMITTED — user overrides never get overwritten by re-fetches. (Renamed from custom_name_zh in #79.)
-      RETURNING id
-    ),
-    -- #90 Phase 3: append-only history of every Google/Yelp fetch.
-    -- One row per ingest that touched this place; \`places.raw_response\`
-    -- is the latest pointer, \`place_snapshots\` is the full audit
-    -- trail that #91 refresh will diff against.  Use the SAME
-    -- \`<RAW_JSON_STRING_WITH_BOTH_LANGS>\` body you passed into the
-    -- \`places\` upsert above and the SAME \`<google_geocode|google_places>\`
-    -- source string.
-    snapshot AS (
-      INSERT INTO place_snapshots (place_id, source, raw_response, fetched_by_sha)
-      SELECT id, '<google_geocode|google_places>', '<RAW_JSON_STRING_WITH_BOTH_LANGS>'::jsonb, '${buildInfo.gitShortSha}'
-        FROM place
-    )
-  UPDATE transactions SET place_id = (SELECT id FROM place), updated_at = NOW()
-   WHERE id = '<TX_ID>' AND workspace_id = '${ctx.workspaceId}';
+  -- (9) OPTIONAL, Phase 3 only — the place cache. Also after COMMIT,
+  --     and for the same reason: Phase 3 is best-effort enrichment and
+  --     a malformed Google blob must never take the ledger write down
+  --     with it. Full multilingual upsert (#74): for uncached places
+  --     include every column you extracted in Phase 3c/3d; for cached
+  --     places the ON CONFLICT clause keeps existing per-language data
+  --     and the \`custom_name\` user override (renamed from
+  --     \`custom_name_zh\` in #79) and only bumps \`last_seen_at\` /
+  --     \`hit_count\`. COALESCE(EXCLUDED.x, places.x) ensures a NEW
+  --     fetch that returned NULL for a field never overwrites a
+  --     previously-good value. Delete (9)-(11) when you have no
+  --     geocode result.
+  INSERT INTO places (
+    id, google_place_id, formatted_address, lat, lng, source, raw_response,
+    last_seen_at, hit_count,
+    display_name_en, display_name_zh, display_name_zh_locale, display_name_zh_source, display_name_zh_is_native,
+    primary_type, primary_type_display_zh, maps_type_label_zh, types,
+    formatted_address_en, formatted_address_zh, postal_code, country_code,
+    business_status, business_hours, time_zone,
+    rating, user_rating_count,
+    national_phone_number, website_uri, google_maps_uri
+  ) VALUES (
+    gen_random_uuid(),
+    '<PLACE_ID>', '<FORMATTED_ADDRESS>', <LAT>, <LNG>,
+    '<google_geocode|google_places>',
+    '<RAW_JSON_STRING_WITH_BOTH_LANGS>'::jsonb,
+    NOW(), 1,
+    <NULLABLE_TEXT 'display_name_en'>,
+    <NULLABLE_TEXT 'display_name_zh'>,
+    <NULLABLE_TEXT 'display_name_zh_locale'>,
+    <NULLABLE_TEXT 'display_name_zh_source'>,           -- 'google_text' | 'photo_ocr' | 'receipt_ocr' | NULL
+    <NULLABLE_BOOL 'display_name_zh_is_native'>,        -- true unless brand is a global English-first name w/ Google gloss
+    <NULLABLE_TEXT 'primary_type'>,
+    <NULLABLE_TEXT 'primary_type_display_zh'>,
+    <NULLABLE_TEXT 'maps_type_label_zh'>,
+    <NULLABLE_TEXT_ARRAY 'types[]'>,                     -- e.g. ARRAY['store','food']::text[] or NULL
+    <NULLABLE_TEXT 'formatted_address_en'>,
+    <NULLABLE_TEXT 'formatted_address_zh'>,
+    <NULLABLE_TEXT 'postal_code'>,
+    <NULLABLE_TEXT 'country_code'>,
+    <NULLABLE_TEXT 'business_status'>,
+    <NULLABLE_JSONB 'business_hours'>,
+    <NULLABLE_TEXT 'time_zone'>,
+    <NULLABLE_NUMERIC 'rating'>,
+    <NULLABLE_INT 'user_rating_count'>,
+    <NULLABLE_TEXT 'national_phone_number'>,
+    <NULLABLE_TEXT 'website_uri'>,
+    <NULLABLE_TEXT 'google_maps_uri'>
+  )
+  ON CONFLICT (google_place_id) DO UPDATE
+    SET last_seen_at = NOW(),
+        hit_count = places.hit_count + 1,
+        raw_response = EXCLUDED.raw_response,
+        display_name_en          = COALESCE(EXCLUDED.display_name_en,          places.display_name_en),
+        display_name_zh          = COALESCE(EXCLUDED.display_name_zh,          places.display_name_zh),
+        display_name_zh_locale   = COALESCE(EXCLUDED.display_name_zh_locale,   places.display_name_zh_locale),
+        display_name_zh_source   = COALESCE(EXCLUDED.display_name_zh_source,   places.display_name_zh_source),
+        display_name_zh_is_native = COALESCE(EXCLUDED.display_name_zh_is_native, places.display_name_zh_is_native),
+        primary_type             = COALESCE(EXCLUDED.primary_type,             places.primary_type),
+        primary_type_display_zh  = COALESCE(EXCLUDED.primary_type_display_zh,  places.primary_type_display_zh),
+        maps_type_label_zh       = COALESCE(EXCLUDED.maps_type_label_zh,       places.maps_type_label_zh),
+        types                    = COALESCE(EXCLUDED.types,                    places.types),
+        formatted_address_en     = COALESCE(EXCLUDED.formatted_address_en,     places.formatted_address_en),
+        formatted_address_zh     = COALESCE(EXCLUDED.formatted_address_zh,     places.formatted_address_zh),
+        postal_code              = COALESCE(EXCLUDED.postal_code,              places.postal_code),
+        country_code             = COALESCE(EXCLUDED.country_code,             places.country_code),
+        business_status          = COALESCE(EXCLUDED.business_status,          places.business_status),
+        business_hours           = COALESCE(EXCLUDED.business_hours,           places.business_hours),
+        time_zone                = COALESCE(EXCLUDED.time_zone,                places.time_zone),
+        rating                   = COALESCE(EXCLUDED.rating,                   places.rating),
+        user_rating_count        = COALESCE(EXCLUDED.user_rating_count,        places.user_rating_count),
+        national_phone_number    = COALESCE(EXCLUDED.national_phone_number,    places.national_phone_number),
+        website_uri              = COALESCE(EXCLUDED.website_uri,              places.website_uri),
+        google_maps_uri          = COALESCE(EXCLUDED.google_maps_uri,          places.google_maps_uri);
+        -- Note: custom_name is INTENTIONALLY OMITTED — user overrides never get overwritten by re-fetches. (Renamed from custom_name_zh in #79.)
+
+  -- (10) OPTIONAL, Phase 3 only — #90 Phase 3: append-only history of
+  --      every Google/Yelp fetch. One row per ingest that touched this
+  --      place; \`places.raw_response\` is the latest pointer,
+  --      \`place_snapshots\` is the full audit trail that #91 refresh
+  --      will diff against. Use the SAME
+  --      \`<RAW_JSON_STRING_WITH_BOTH_LANGS>\` body you passed into the
+  --      \`places\` upsert above and the SAME
+  --      \`<google_geocode|google_places>\` source string.
+  INSERT INTO place_snapshots (place_id, source, raw_response, fetched_by_sha)
+  SELECT id, '<google_geocode|google_places>', '<RAW_JSON_STRING_WITH_BOTH_LANGS>'::jsonb, '${buildInfo.gitShortSha}'
+    FROM places WHERE google_place_id = '<PLACE_ID>';
+
+  -- (11) OPTIONAL, Phase 3 only — attach the place to the transaction.
+  UPDATE transactions
+     SET place_id = (SELECT id FROM places WHERE google_place_id = '<PLACE_ID>'),
+         updated_at = NOW()
+   WHERE id = <TX> AND workspace_id = '${ctx.workspaceId}';
   SQL
 
 If you downloaded photos in Phase 3c, insert one \`place_photos\` row
@@ -996,21 +1168,6 @@ record \`file_path\` accordingly:
     "
   done
 
-Also stamp the document row — it ties the file back to this ingest AND
-stores the OCR text, so \`documents.ocr_text\` is populated by BOTH the
-ingest and the re-extract path (it used to be re-extract only, which
-made every "what did the agent actually read?" question unanswerable
-for ingest-only documents):
-
-  psql "\$DATABASE_URL" <<'SQL'
-    UPDATE documents
-       SET source_ingest_id  = '${ctx.ingestId}',
-           ocr_text          = '<RAW_TEXT, single-quote-escaped>',
-           ocr_model_version = '${EXTRACTION_MODEL}',
-           updated_at        = NOW()
-     WHERE id = '${ctx.documentId}';
-  SQL
-
 ### 4a-bis. owned_items judgment (#84 Phase 2)
 
 For each line where you set \`item_class='durable'\` AND assigned a
@@ -1028,24 +1185,14 @@ Leave \`serial_number\`, \`location\`, \`warranty_until\`, \`condition\`,
 \`notes\` blank — the user fills those in. \`acquired_on\` defaults to
 the transaction's \`occurred_on\`.
 
-Query back the just-inserted transaction_items.id for each durable
-line you want to track, then INSERT into owned_items:
-
-  psql "\$DATABASE_URL" <<'SQL'
-  INSERT INTO owned_items (workspace_id, product_id, transaction_item_id, instance_index, acquired_on)
-  SELECT '${ctx.workspaceId}', ti.product_id, ti.id, gs.idx, '<occurred_on>'::date
-  FROM transaction_items ti
-  CROSS JOIN LATERAL generate_series(1, COALESCE(ti.quantity, 1)::int) gs(idx)
-  WHERE ti.transaction_id = '<TX_ID>'
-    AND ti.line_no = <LINE_NO>            -- one statement per durable line
-    AND ti.item_class = 'durable'
-    AND ti.product_id IS NOT NULL
-  ON CONFLICT (transaction_item_id, instance_index) DO NOTHING;
-  SQL
-
-The ON CONFLICT clause makes the insert safe to re-run. Skip this
-step entirely for non-durable items, for durables you judge not
-worth tracking, and for product-less lines.
+The INSERT is statement (5) of Turn B — you do NOT run it here and you
+do NOT need to query the transaction_items ids back first. Decide which
+durable lines qualify, then put THOSE line_no values into the
+\`ARRAY[...]\` in Turn B (5). It is ONE set-based statement for the
+whole receipt, not one per line. The ON CONFLICT clause makes it safe
+to re-run. Delete Turn B (5) entirely when nothing qualifies — which
+is the common case: non-durable items, durables you judge not worth
+tracking, and product-less lines all fall out.
 
 ### 4a-ter. transaction_parties — the party graph (#149 P4)
 
@@ -1091,25 +1238,15 @@ party is unambiguously a known brand — then upsert a brands row first
 parent brand is obvious, e.g. AnkerDirect → anker, set parent_id).
 Otherwise leave brand_id NULL — a text-only row is still useful.
 
-Insert after 4a's items exist (line-level rows reference
-transaction_items by line):
-
-  psql "\$DATABASE_URL" <<'SQL'
-  INSERT INTO transaction_parties
-    (workspace_id, transaction_id, transaction_item_id, role, display_name, brand_id)
-  VALUES
-    ('${ctx.workspaceId}', '<TX_ID>', NULL, 'channel', '<as printed>', '<brand_id-or-NULL>')
-    -- , line-level example:
-    -- ('${ctx.workspaceId}', '<TX_ID>',
-    --   (SELECT id FROM transaction_items WHERE transaction_id='<TX_ID>' AND line_no=<N>),
-    --   'maker', 'Anker', 'anker')
-  ON CONFLICT ON CONSTRAINT transaction_parties_identity_uq DO NOTHING;
-  SQL
+The INSERT is statement (8) of Turn B — you do NOT run it here. Fill in
+one VALUES row per (role, party) you decided on above; line-level rows
+resolve their \`transaction_item_id\` by line_no from the items Turn B
+just wrote, in the same invocation.
 
 Don't fabricate parties; a plain single-merchant receipt legitimately
-produces just the one channel row. This step is additive — never let
-a parties failure roll back the transaction itself (run it in its own
-statement after COMMIT).
+produces just the one channel row. This step is additive — never let a
+parties failure roll back the transaction itself, which is exactly why
+Turn B places it after COMMIT rather than inside the block.
 
 ### 4b. statement_pdf
 
@@ -1134,11 +1271,11 @@ fallback providers — one or two cheap tries, then move on and close.
 ${PHASE_4B_4C_ICON_PIPELINE}
 
 
-── Phase 5 — Close the ingest row ─────────────────────────────────────
+── Phase 5 — Close the ingest row (Turn C) ────────────────────────────
 
-Regardless of classification, end with:
+Regardless of classification, end with ONE invocation:
 
-  psql "\$DATABASE_URL" <<SQL
+  psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" <<SQL
   UPDATE ingests
      SET status = '<done|unsupported|near_dup>',
          classification = '<classification>',
@@ -1165,7 +1302,7 @@ already be committed — the worker verifies the link exists and forces
 If any INSERT above fails (foreign key violation, balance trigger,
 constraint error), catch it and instead:
 
-  psql "\$DATABASE_URL" <<SQL
+  psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" <<SQL
   UPDATE ingests
      SET status = 'error',
          error = '<one-line message, escape quotes>',
@@ -1209,8 +1346,10 @@ the database is your output.
 
 ── Rules ──────────────────────────────────────────────────────────────
 
-- Every \`psql\` invocation is a separate Bash tool call. Plan them in
-  order; don't try to pipeline from one to the next via stdin chaining.
+- Every \`psql\` INVOCATION is a separate Bash tool call, so BATCH your
+  statements into as few invocations as possible — the write phase is
+  Turn A / Turn B / Turn C and nothing else (Phase 4.0). Don't try to
+  pipeline from one invocation to the next via stdin chaining.
 - NEVER insert a transaction without exactly matching balanced
   postings in the SAME BEGIN/COMMIT block. The deferred constraint
   trigger will reject at COMMIT and roll back the whole block.

--- a/src/ingest/reextract-prompt.ts
+++ b/src/ingest/reextract-prompt.ts
@@ -62,6 +62,7 @@ import {
 } from "./line-item-prompt.js";
 import {
   ITEMS_JSON_EXPR,
+  itemsCte,
   brandFkGuard,
   productsUpsert,
   transactionItemsInsert,
@@ -156,15 +157,19 @@ live there, so you do not extract them at all.
 
 **Brand FK guard (#101).** Items may carry product_brand_id, which is
 FK into \`brands\`. The products UPSERT below would fail if the brand
-row doesn't exist. Run this defensively BEFORE the main block:
+row doesn't exist, so it runs defensively as the FIRST statement of the
+block below — its own statement, never a sibling CTE (\`WITH\`
+sub-statements cannot see each other's effects on target tables and RI
+checks are AFTER-ROW). Delete it when no item carries a
+product_brand_id.
 
-${brandFkGuard()}
+Run exactly ONE psql INVOCATION for the whole write. Substitute your
+extracted values for the placeholders; the CASE statements consult
+\`metadata.user_edited\` so a user override survives this re-extract.
 
-Run exactly ONE psql block. Substitute your extracted values for the
-placeholders; the CASE statements consult \`metadata.user_edited\` so a
-user override survives this re-extract.
+  psql -v ON_ERROR_STOP=1 "\$DATABASE_URL" <<'SQL'
+${brandFkGuard({ bare: true })}
 
-  psql "\$DATABASE_URL" <<'SQL'
   BEGIN;
 
   UPDATE transactions SET
@@ -238,6 +243,7 @@ user override survives this re-extract.
     FROM transaction_items
     WHERE transaction_id = '${ctx.transactionId}'
   ),
+${itemsCte()},
 ${productsUpsert({ workspaceId: ctx.workspaceId, merchantIdExpr })}
 ${transactionItemsInsert({
   workspaceId: ctx.workspaceId,

--- a/src/ingest/reextract-prompt.ts
+++ b/src/ingest/reextract-prompt.ts
@@ -81,6 +81,42 @@ export interface ReExtractPromptContext {
   transactionId: string;
   /** Owner user id, recorded in the `transaction_events` row. */
   userId: string;
+  /** Pre-decoded plain text of the source (#167), inlined below. Set for
+   *  `.eml` and raw-HTML documents, NULL for images and PDFs. */
+  ocrText?: string | null;
+}
+
+/**
+ * The decoded-source block (#167).
+ *
+ * Inlined into the prompt rather than pre-written to `documents.ocr_text`:
+ * the agent has no `SELECT ocr_text` instruction, and its own psql block
+ * overwrites that column at the end of the run anyway, so pre-populating
+ * it would be a write the agent never reads and then destroys.
+ */
+function renderDecodedSource(ocrText: string | null | undefined): string {
+  if (!ocrText || ocrText.trim().length === 0) return "";
+  return `
+── Decoded source text (already extracted for you) ────────────────────
+
+This document is an email / HTML file, so its body has ALREADY been
+MIME-decoded and linearized for you. Read it here; you do NOT need to
+decode the file yourself. Item tables are linearized one row per line,
+so a name and its price sit on the SAME line.
+
+Treat this as the receipt text. Open the original file only if this
+text is obviously truncated or contradicts itself — and if you do,
+follow the document-reading rules above.
+
+The \`Date (envelope)\` header, when present, is when the EMAIL was sent.
+It is NOT automatically \`occurred_on\`: use the transaction date printed
+in the body, and fall back to the envelope date only when the body
+prints none.
+
+<<<DECODED_SOURCE
+${ocrText.trim()}
+DECODED_SOURCE
+`;
 }
 
 export function buildReExtractPrompt(ctx: ReExtractPromptContext): string {
@@ -110,11 +146,12 @@ ${PSQL_DISCIPLINE}
 ${agentHygiene({ scratchDir, filePath: ctx.filePath })}
 ${renderActiveLessons()}
 ${phase0DocumentRead({ filePath: ctx.filePath, scratchDir })}
-
+${renderDecodedSource(ctx.ocrText)}
 ── Phase 1 — Extract ──────────────────────────────────────────────────
 
 Read the file at the path above (same image / pdf / .eml the original
-ingest read). ${NO_JSON_SCHEMA_RULE}
+ingest read) — or, when a decoded source block is present above, read
+that instead. ${NO_JSON_SCHEMA_RULE}
 
 Pull these fields. Use NULL when the field is not visible — never
 guess, never fall back to today's date.
@@ -326,6 +363,11 @@ corrupted), do NOT write anything to the database. Print:
 
   ERROR <one-line reason>
 
-and exit. The service will mark the document accordingly.
+and exit. This line is a CONTRACT, not a log message: the service reads
+the last non-empty line of your stdout, and a leading \`ERROR\` makes it
+skip the audit record and return 422 with your reason as the detail the
+user sees. So make the reason specific and user-facing ("scan is a blank
+page", "PDF has no text layer and rasterizes to noise"), keep it to one
+line, and never print it after a successful write.
 `;
 }

--- a/src/ingest/worker.ts
+++ b/src/ingest/worker.ts
@@ -48,7 +48,7 @@ async function pickExtractor(absPath: string) {
   if (process.env.EXTRACTOR_STUB_ALLOWED !== "1") return defaultClaudeExtractor;
   return (await isStubFile(absPath)) ? stubFileExtractor : defaultClaudeExtractor;
 }
-import { ingestSession, getSessionJsonlPath } from "../langfuse.js";
+import { trackLangfuse } from "../langfuse.js";
 
 // ── Configuration ─────────────────────────────────────────────────────
 
@@ -618,20 +618,6 @@ export async function maybeCompleteBatch(
   workspaceId: string,
 ): Promise<void> {
   await onBatchChildTerminated(batchId, workspaceId);
-}
-
-// ── Langfuse trace ingestion (fire-and-forget) ───────────────────────
-
-/**
- * Kick off Langfuse ingestion for a finished extraction without blocking
- * the worker. `ingestSession` itself swallows errors, so Langfuse
- * downtime never fails a batch.
- */
-function trackLangfuse(sessionId: string, tags: string[]): void {
-  ingestSession(getSessionJsonlPath(sessionId), tags).catch((err) => {
-    // eslint-disable-next-line no-console
-    console.error("[ingest worker] langfuse ingestion failed:", err);
-  });
 }
 
 // ── Auto-reconcile hook (#32 Phase 2a) ───────────────────────────────

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -365,3 +365,23 @@ export async function ingestSession(jsonlPath: string, tags?: string[]): Promise
     console.error("[langfuse] Ingestion failed:", (err as Error).message);
   }
 }
+
+// ── Fire-and-forget wrapper ──────────────────────────────────────────
+
+/**
+ * Kick off Langfuse ingestion for a finished `claude -p` run without
+ * blocking the caller. `ingestSession` itself swallows errors, so
+ * Langfuse downtime never fails a batch or a re-extract.
+ *
+ * Lives here rather than in `worker.ts` because the re-extract path
+ * (`routes/documents.service.ts`) needs it too, and `worker.ts` already
+ * imports from that module — putting it there would close an import
+ * cycle. Before #181 only the ingest worker called it, so every
+ * re-extract ran completely untraced and the #181 token measurement
+ * would have been blind on exactly the path the campaign uses.
+ */
+export function trackLangfuse(sessionId: string, tags: string[]): void {
+  ingestSession(getSessionJsonlPath(sessionId), tags).catch((err) => {
+    console.error("[langfuse] ingestion failed:", err);
+  });
+}

--- a/src/routes/documents.service.ts
+++ b/src/routes/documents.service.ts
@@ -706,7 +706,169 @@ export async function cascadeDeleteDocument(params: {
   return { ...report, hardDeletedFilePath: pendingFileUnlink };
 }
 
+// ── Source text for re-extract (#167) ──────────────────────────────────
+
+/**
+ * Tags whose CONTENT is never receipt data — dropped wholesale rather
+ * than reduced to their text.
+ */
+const TEXT_EXTRACT_DROP = [
+  "script",
+  "style",
+  "head",
+  "noscript",
+  "title",
+  "textarea",
+];
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+  ndash: "–",
+  mdash: "—",
+  hellip: "…",
+  rsquo: "’",
+  lsquo: "‘",
+  rdquo: "”",
+  ldquo: "“",
+};
+
+function decodeEntities(s: string): string {
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (whole, body: string) => {
+    if (body.startsWith("#x") || body.startsWith("#X")) {
+      const cp = Number.parseInt(body.slice(2), 16);
+      return Number.isFinite(cp) ? String.fromCodePoint(cp) : whole;
+    }
+    if (body.startsWith("#")) {
+      const cp = Number.parseInt(body.slice(1), 10);
+      return Number.isFinite(cp) ? String.fromCodePoint(cp) : whole;
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? whole;
+  });
+}
+
+/**
+ * Linearize HTML into receipt-shaped plain text.
+ *
+ * Table structure is load-bearing, not cosmetic: Square and Toast lay
+ * their item lists out as `<table>`, so a naive tag-strip collapses
+ * "Uni  $12.00" into a column of orphaned words and the agent loses the
+ * name↔price pairing. Cells are joined on ONE line; rows and block
+ * elements each start a new one.
+ *
+ * Built on `sanitize-html` (already a dependency) rather than adding
+ * `html-to-text`: sanitize-html does the genuinely hard part — parsing
+ * malformed real-world email markup and dropping `<script>` / `<style>`
+ * bodies and comments — so the pass below only ever sees well-formed,
+ * attribute-free tags.
+ */
+export function htmlToPlainText(html: string): string {
+  const safe = sanitizeHtml(html, {
+    allowedTags: [
+      "p", "div", "br", "table", "thead", "tbody", "tfoot", "tr", "td",
+      "th", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "span",
+      "strong", "b", "em", "i", "u", "small", "big", "a", "hr", "section",
+      "article", "header", "footer", "center", "font", "blockquote", "pre",
+    ],
+    allowedAttributes: {},
+    nonTextTags: TEXT_EXTRACT_DROP,
+  });
+
+  const linearized = safe
+    // Cell boundary → a soft separator, so a "name / qty / price" row
+    // survives as one readable line.
+    .replace(/<\/(td|th)>/gi, "\t")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<hr\s*\/?>/gi, "\n")
+    .replace(
+      /<\/(p|div|tr|li|h[1-6]|section|article|header|footer|center|blockquote|pre|table)>/gi,
+      "\n",
+    )
+    .replace(/<[^>]*>/g, "");
+
+  return decodeEntities(linearized)
+    .split("\n")
+    // Collapse runs of spaces (but not the cell tabs) first, then turn
+    // each tab into a visible two-space gutter.
+    .map((line) =>
+      line
+        // NBSP written as an escape: a literal U+00A0 here is invisible
+        // in the source and the next editor would delete it by accident.
+        .replace(/\u00a0/g, " ")
+        .replace(/[^\S\t]+/g, " ")
+        .replace(/\t+/g, "  ")
+        .trim(),
+    )
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Best-effort plain text for the source file behind a document, used to
+ * seed re-extract (#167).
+ *
+ * `parsed.text` alone is NOT sufficient, measured on real fixtures:
+ * Square's Sushi Nozomi `.eml` carries a short `text/plain` stub with no
+ * line items at all, and Toast's Elysee `.eml` has no `text/plain` part.
+ * Both carry the full itemization — including the #162 two-level
+ * modifier structure — only in `text/html`, so the HTML branch is the
+ * one that matters and the longer of the two wins.
+ *
+ * Returns null for images and PDFs: those the agent reads itself, and a
+ * bad text stand-in would be worse than none.
+ */
+async function extractSourceText(
+  doc: { kind: DocumentKindValue | null; mimeType: string | null },
+  absPath: string,
+): Promise<string | null> {
+  const baseMime = (doc.mimeType ?? "").split(";")[0]!.trim().toLowerCase();
+  const isHtml =
+    baseMime === "text/html" || baseMime === "application/xhtml+xml";
+
+  if (doc.kind === "receipt_email") {
+    const parsed = await simpleParser(await readFile(absPath));
+    const fromHtml =
+      typeof parsed.html === "string" && parsed.html.length > 0
+        ? htmlToPlainText(parsed.html)
+        : "";
+    const fromText = (parsed.text ?? "").trim();
+    const body = fromHtml.length >= fromText.length ? fromHtml : fromText;
+    const headers = [
+      parsed.from?.text ? `From: ${parsed.from.text}` : null,
+      parsed.subject ? `Subject: ${parsed.subject}` : null,
+      parsed.date ? `Date (envelope): ${parsed.date.toISOString()}` : null,
+    ].filter((l): l is string => l !== null);
+    const joined = [headers.join("\n"), body].filter(Boolean).join("\n\n");
+    return joined.length > 0 ? joined : null;
+  }
+
+  if (isHtml) {
+    const text = htmlToPlainText((await readFile(absPath)).toString("utf8"));
+    return text.length > 0 ? text : null;
+  }
+
+  return null;
+}
+
 // ── Re-extract (Phase 4c of #80 / #91) ─────────────────────────────────
+
+/**
+ * What the run actually did (#167).
+ *
+ * The old signal — "did `re_extracted_at` advance?" — was structurally
+ * blind: that column only moves as a side effect of the agent's own psql
+ * block, so a run that wrote NOTHING was indistinguishable from a
+ * successful one, and the frontend rendered "No changes — the agent
+ * produced the same output." That string is exactly what made #167
+ * invisible for weeks. Key future batch tooling on `outcome`, never on a
+ * timestamp.
+ */
+export type ReExtractOutcome = "written" | "no_change" | "agent_error";
 
 export interface ReExtractDocumentResult {
   document_id: string;
@@ -719,6 +881,10 @@ export interface ReExtractDocumentResult {
   /** Re-extract is observability-first; carry the session id so the
    *  operator can pull the Langfuse trace without a join. */
   session_id: string;
+  /** `written` when the agent's psql block moved something, `no_change`
+   *  when it demonstrably wrote nothing. `agent_error` is part of the
+   *  vocabulary but never reaches a 200 — it surfaces as a 422. */
+  outcome: ReExtractOutcome;
 }
 
 /**
@@ -746,7 +912,7 @@ export async function reExtractDocument(
   workspaceId: string,
   userId: string,
   documentId: string,
-  options: { reExtractor?: ReExtractor } = {},
+  options: { reExtractor?: ReExtractor; transactionId?: string } = {},
 ): Promise<ReExtractDocumentResult | null> {
   const reExtractor = options.reExtractor ?? defaultClaudeReExtractor;
 
@@ -755,6 +921,8 @@ export async function reExtractDocument(
     .select({
       id: documents.id,
       workspaceId: documents.workspaceId,
+      kind: documents.kind,
+      mimeType: documents.mimeType,
       filePath: documents.filePath,
       ocrText: documents.ocrText,
       deletedAt: documents.deletedAt,
@@ -779,6 +947,25 @@ export async function reExtractDocument(
     );
   }
 
+  // 1b) Preflight the file BEFORE spending a 15-minute `claude -p` round
+  //     trip (#167). 95 of 1600 live `file_path` values did not resolve;
+  //     every one of them used to burn a full agent run and come back as
+  //     a misleading `200 {}` with empty `changed_keys`, which reads as
+  //     "the agent produced the same output" rather than "there was no
+  //     file". Same `stat` guard `renderDocumentHtml` already uses.
+  const absPath = resolveUploadPath(doc.filePath);
+  try {
+    await stat(absPath);
+  } catch {
+    throw new HttpProblem(
+      422,
+      "document-file-missing",
+      "Source file is missing on disk",
+      `Document ${documentId} points at ${doc.filePath}, which does not resolve to a readable file. Re-extract has nothing to read; restore the file before retrying.`,
+      { document_id: documentId, file_path: doc.filePath },
+    );
+  }
+
   const linkRows = await db
     .select({ transactionId: documentLinks.transactionId })
     .from(documentLinks)
@@ -792,35 +979,87 @@ export async function reExtractDocument(
       { document_id: documentId },
     );
   }
-  if (linkRows.length > 1) {
+  let transactionId: string;
+  if (linkRows.length === 1) {
+    transactionId = linkRows[0]!.transactionId;
+  } else if (
+    options.transactionId &&
+    linkRows.some((r) => r.transactionId === options.transactionId)
+  ) {
+    // Multi-link documents are no longer a dead end (#167): the caller
+    // names which transaction to re-derive via `?transaction_id=`.
+    transactionId = options.transactionId;
+  } else {
     throw new HttpProblem(
       422,
       "document-multiple-transactions",
       "Document linked to multiple transactions",
-      "Re-extract refuses when a document links to more than one transaction; pick a tx and use a per-tx flow.",
+      "Re-extract operates per-transaction and will not pick for you; pass ?transaction_id=<uuid> naming one of the linked transactions.",
       {
         document_id: documentId,
         transaction_ids: linkRows.map((r) => r.transactionId),
       },
     );
   }
-  const transactionId = linkRows[0]!.transactionId;
 
   // 2) Snapshot BEFORE — projection-domain tx fields only. Layer-3
   //    fields are excluded from the diff because re-extract can't
   //    change them anyway; including them would clutter `changed_keys`.
   const beforeSnapshot = await snapshotReExtractFields(transactionId, doc.id);
 
+  // 2b) Give an email / HTML document a TEXT source (#167). The agent
+  //     can open an image or a PDF itself, but an `.eml` body is
+  //     MIME-encoded and its itemization usually lives only in the
+  //     `text/html` part. Inlining the decoded text into the prompt is
+  //     what makes re-extract produce anything at all on these.
+  //     Deliberately NOT written to `documents.ocr_text` first: the
+  //     agent has no `SELECT ocr_text` instruction, and its own psql
+  //     block overwrites that column at the end of the run anyway.
+  let sourceText: string | null = null;
+  try {
+    sourceText = await extractSourceText(doc, absPath);
+  } catch (err) {
+    console.warn(
+      `[re-extract] doc=${documentId} source-text extraction failed: ${(err as Error).message}`,
+    );
+  }
+
   // 3) Spawn the agent. Errors here bubble to the route handler;
   //    nothing has been written yet so the DB state is untouched.
   const { sessionId, stdout } = await reExtractor({
     // The agent needs a container-absolute path it can open (#128).
-    filePath: resolveUploadPath(doc.filePath),
+    filePath: absPath,
     workspaceId,
     documentId,
     transactionId,
     userId,
+    ocrText: sourceText,
   });
+
+  // 3c) The prompt's own contract: on an unreadable source the agent
+  //     writes NOTHING and prints `ERROR <reason>`. Honour it before
+  //     inserting a `derivation_events` row — that row asserts a
+  //     derivation ran, and writing one for a run that refused is a
+  //     false audit record.
+  const lastLine =
+    stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+      .pop() ?? "";
+  if (/^ERROR\b/.test(lastLine)) {
+    throw new HttpProblem(
+      422,
+      "re-extract-agent-error",
+      "The extraction agent could not read this document",
+      lastLine.replace(/^ERROR\s*/, "") || "Agent reported an error.",
+      {
+        document_id: documentId,
+        transaction_id: transactionId,
+        session_id: sessionId,
+      },
+    );
+  }
 
   // 3b) Ship the session transcript to Langfuse (#181). Fire-and-forget
   //     — `trackLangfuse` never throws and never blocks the response.
@@ -875,6 +1114,14 @@ export async function reExtractDocument(
       afterSnapshot.ocr_text,
     ),
     session_id: sessionId,
+    // The agent's metadata UPDATE always rewrites `extraction.ran_at`
+    // with NOW(), so `metadata_extraction` is present whenever the psql
+    // block ran at all. An EMPTY `changed_keys` therefore means the
+    // agent wrote nothing — a no-op, not a confirmation that the output
+    // was identical. Production corroborates: 118 of 122
+    // `derivation_events` contain the key; the 4 empties are exactly the
+    // #167 no-ops.
+    outcome: changedKeys.length > 0 ? "written" : "no_change",
   };
 }
 

--- a/src/routes/documents.service.ts
+++ b/src/routes/documents.service.ts
@@ -30,6 +30,7 @@ import {
   EXTRACTION_MODEL,
 } from "../ingest/prompt-contract.js";
 import { buildInfo } from "../generated/build-info.js";
+import { trackLangfuse } from "../langfuse.js";
 
 export type DocumentKindValue =
   | "receipt_image"
@@ -820,6 +821,13 @@ export async function reExtractDocument(
     transactionId,
     userId,
   });
+
+  // 3b) Ship the session transcript to Langfuse (#181). Fire-and-forget
+  //     — `trackLangfuse` never throws and never blocks the response.
+  //     Without this, re-extract produced ZERO traces (every trace on
+  //     the box came from ingest), so there was no way to measure token
+  //     burn or turn count on the path the re-extract campaign uses.
+  trackLangfuse(sessionId, [documentId, transactionId, "re-extract"]);
 
   // 4) Snapshot AFTER. Agent has now UPDATEd transactions + documents.
   const afterSnapshot = await snapshotReExtractFields(transactionId, doc.id);

--- a/src/routes/documents.ts
+++ b/src/routes/documents.ts
@@ -84,6 +84,10 @@ function asyncHandler<T>(
 }
 
 const IdOnlyParams = z.object({ id: Uuid });
+
+/** Query for `POST /:id/re-extract` — names which linked transaction to
+ *  re-derive when the document links to more than one (#167). */
+const ReExtractQuery = z.object({ transaction_id: Uuid.optional() });
 const LinkParams = z.object({ id: Uuid, txn_id: Uuid });
 
 // ── POST /v1/documents ─────────────────────────────────────────────────
@@ -342,10 +346,18 @@ documentsRouter.post(
   "/:id/re-extract",
   asyncHandler(async (req, res) => {
     const { id } = parseOrThrow(IdOnlyParams, req.params);
+    // `?transaction_id=` disambiguates a document linked to more than one
+    // transaction (#167) — without it those documents were a permanent
+    // 422 and could never be re-derived at all.
+    const { transaction_id } = parseOrThrow(
+      ReExtractQuery,
+      req.query as Record<string, unknown>,
+    );
     const out = await reExtractDocument(
       req.ctx.workspaceId,
       req.ctx.userId,
       id,
+      { transactionId: transaction_id },
     );
     if (!out) throw new NotFoundProblem("Document", id);
     res.json(out);
@@ -577,9 +589,23 @@ export function registerDocumentsOpenApi(registry: OpenAPIRegistry): void {
       "identity columns) never touched; SOFT fields (occurred_on, " +
       "occurred_at, payee) protected by `metadata.user_edited.<field>` " +
       "CASE expressions, so user PATCH overrides survive. " +
-      "Returns 422 if the document has zero or >1 linked transactions.",
+      "For `.eml` / `text/html` documents the body is MIME-decoded and " +
+      "linearized server-side and inlined into the prompt (#167) — the " +
+      "agent does not decode it itself. The response's `outcome` field " +
+      "is the completion signal; do NOT infer success from " +
+      "`re_extracted_at` advancing.",
     tags: ["documents"],
-    request: { params: z.object({ id: Uuid }) },
+    request: {
+      params: z.object({ id: Uuid }),
+      query: z.object({
+        transaction_id: Uuid.optional().openapi({
+          description:
+            "Which linked transaction to re-derive. Required only when " +
+            "the document links to more than one transaction; without it " +
+            "such a document 422s with `document-multiple-transactions`.",
+        }),
+      }),
+    },
     responses: {
       200: {
         description: "Re-extract committed",
@@ -591,7 +617,13 @@ export function registerDocumentsOpenApi(registry: OpenAPIRegistry): void {
       },
       422: {
         description:
-          "Document not linked to exactly one transaction, or has no file_path",
+          "`document-no-file-path` (row has no file_path), " +
+          "`document-file-missing` (file_path does not resolve on disk — " +
+          "checked BEFORE spawning the agent), `document-no-transaction` " +
+          "(zero linked transactions), `document-multiple-transactions` " +
+          "(more than one and no `?transaction_id=`), or " +
+          "`re-extract-agent-error` (the agent printed `ERROR <reason>` " +
+          "and wrote nothing; `detail` carries its reason).",
         content: problemContent,
       },
     },

--- a/src/schemas/v1/document.ts
+++ b/src/schemas/v1/document.ts
@@ -66,6 +66,17 @@ export const ReExtractDocumentResponse = z
     changed_keys: z.array(z.string()),
     ocr_text_changed: z.boolean(),
     session_id: Uuid,
+    outcome: z.enum(["written", "no_change", "agent_error"]).openapi({
+      description:
+        "What the run actually did (#167). `written` = the agent's psql " +
+        "block moved something. `no_change` = it demonstrably wrote " +
+        "NOTHING (the metadata UPDATE always rewrites `extraction.ran_at`, " +
+        "so empty `changed_keys` means no write happened, NOT that the " +
+        "output was identical). `agent_error` is part of the vocabulary " +
+        "but never appears on a 200 — the agent's `ERROR` line surfaces " +
+        "as a 422 `re-extract-agent-error`. Batch tooling MUST key on " +
+        "this field, never on whether `re_extracted_at` advanced.",
+    }),
   })
   .openapi("ReExtractDocumentResponse");
 


### PR DESCRIPTION
Closes #181. Closes #165. Closes #166. Closes #167.

Builds on #164 (merged). Three commits, reviewable separately.

---

## `ec1006f` — #181 token burn

~2.7M cache-read tokens over ~36 turns per receipt. Prompt caching kept the *dollar* cost low, but cache reads still count against the Claude 5-hour rate limit, so a bulk backfill stalls. Two independent levers.

**Lever A — PDF text-first.** The document-read phase was render-first: `pdftoppm -png -r 200`, no page cap, with `pdftotext` mentioned only as a subordinate clause. Four rasterized pages sat in the ~100K context and were re-read from cache *every* turn. Now the text layer is tried first and rasterizing is an explicit fallback for scanned/mojibake/untied documents, at `-r 150` with a 3-page cap. The "Read the file and decide which category" line is amended too — without that, the Read tool rasterizes the PDF anyway and the no-image-blocks goal fails even with `pdftoppm` gone.

**Lever B — batched ledger writes.** The prompt never said "batch your statements", so the write phase ran ~8 sequential `psql` turns, each re-sending the whole conversation. Collapsed to three turns: one read invocation returning four result sets, one write invocation containing the whole transaction, and the unchanged Phase 5 close-out. `<<'SQL'` quoted heredoc (so `$items$` dollar-quoting survives the shell) and `-v ON_ERROR_STOP=1` (without it a failed statement inside `BEGIN` turns `COMMIT` into a silent `ROLLBACK` and psql still exits 0).

Also adds the missing `trackLangfuse(...)` on the re-extract path — re-extract wrote **zero** traces, so the token measurement was blind on exactly the path the campaign uses.

## `87f1e7f` — #165 AYCE/package shaping, #166 occlusion bridge

Written **once** into the shared `line-item-prompt.ts`; both prompts inline it. That is the #164 payoff.

- **INCLUSIVE guard.** The rule fires only when a line has priced children. Re-extract's prompt defined *only* the INCLUSIVE branch, so its single directive about parent prices was "REDUCE" — which is why Haidilao's $90.98 soup base got zeroed with nothing re-adding it. Now: never reduce a printed price unless you are emitting priced children that add back to it, with a per-line cross-check, and ADDITIVE stated as the default.
- **Package/AYCE rule.** A fixed-price package is its own top-level product line; the $0.00 covered items are its children; anything priced outside the package keeps its printed price. Names the exact failure: a $349.93 charge sitting on a "Green Bamboo Shoot" line.
- **Occlusion bridge.** Restores the `line_type='other'` bridge row for the readable-but-blocked case, distinguished from total-only, with an explicit "bridge only for source problems — a gap you created yourself is a bug, not a gap to bridge."
- **Name preservation.** `CRV Redemption Fee` → `Sales Fee` was a *normalization* failure no prompt forbade. Now: a specific printed name may never be replaced by a generic category word; `NULL` is honest, a plausible generic label is a silent lie.
- Two new worked examples drawn from the real Haidilao and California Market fixtures, each stating the arithmetic and naming both wrong shapes.

## `b2458aa` — #167 email-only re-extract

`.eml` re-extracts returned `200` with empty `changed_keys`, rendered as "No changes — the agent produced the same output", which is indistinguishable from a successful no-op. That sentence is why it stayed invisible.

- **Source text.** Measured: Square's Sushi Nozomi `.eml` has a `text/plain` stub with no line items; Toast's Elysee has no `text/plain` part at all — the itemization lives only in `text/html`. Body is decoded with `simpleParser`, linearized, inlined into the prompt. Table structure is preserved deliberately (Square/Toast lay items out as `<table>`; a naive tag-strip separates each name from its price and destroys the #162 two-level shape).
- Built on **`sanitize-html`, already a dependency**, not a new `html-to-text` package. No lockfile change.
- **`outcome: 'written' | 'no_change' | 'agent_error'`** on the response. The "did `re_extracted_at` advance" heuristic is structurally blind, because that column only moves as a side effect of the agent's own write.
- Three more failure modes that all surfaced as the same empty 200: a `stat()` preflight (**95 of 1600** live `file_path` values don't resolve, each previously burning a ~15-minute round trip to say nothing), the prompt's `ERROR <reason>` line finally honoured as the contract it claimed to be, and `?transaction_id=` to disambiguate multi-linked documents that were a permanent 422.

---

## Verification

`tsc --noEmit` clean at each commit. Both prompts rendered and inspected at HEAD:

| | ingest | re-extract |
|---|---|---|
| rendered lines | 2568 | 1564 |
| INCLUSIVE guard / package rule / bridge / name-preservation | all present | **all present** |
| `pdftoppm` | fallback branch only | — |
| `-r 200` | 0 | 0 |
| `undefined` / `[object Object]` / unresolved `${` | none | none |

The re-extract column is the point: before #164 none of those rules existed on that path at all.

**Live verification is deliberately not in this PR.** The user approved re-extracting exactly three production transactions (Haidilao `ac0e0844`, California Market `3bf834a1`, Sushi Nozomi `a2edcb8c`) and no others. Rollback snapshots for all three are captured. That runs against the mini after this merges, so the approval is spent once against the whole chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ssDbfdur7JHRCLfZSQsyx