### PR TITLE
fix(ingest): stale hardcoded date, dangling placeholder, cross-path prose

### DIFF
--- a/src/ingest/line-item-prompt.ts
+++ b/src/ingest/line-item-prompt.ts
@@ -396,7 +396,9 @@ Two different failures, two different answers. Do not confuse them.
   illegible thermal print, an image that is only a total:
     emit exactly ONE row —
       line_type='other', item_class='other', confidence='low',
-      raw_name='TOTAL ONLY', line_total_minor=<TOTAL_MINOR>,
+      raw_name='TOTAL ONLY',
+      line_total_minor = the receipt's printed grand total, in minor
+                         units (cents), as you read it off the paper,
       parent_line_no=NULL, product_key=NULL,
       tags=['no-item-section'].
 

--- a/src/ingest/prompt-contract.ts
+++ b/src/ingest/prompt-contract.ts
@@ -95,7 +95,28 @@ export function agentHygiene(opts: {
   scratchDir: string;
   /** Container-absolute path of the file under extraction. */
   filePath: string;
+  /** Which path is rendering this. The effort-budget prose names the run's
+   *  own phases, and the two paths do not share them — re-extract has no
+   *  Phase 5 to close an ingest in, and its Phase 3 is a brand refresh, not
+   *  a Google place resolve. Telling a re-extract agent to "close the ingest
+   *  in Phase 5" points it at a step that does not exist in its own prompt. */
+  path: "ingest" | "re-extract";
 }): string {
+  const core =
+    opts.path === "ingest"
+      ? `classify → extract fields → write the balanced double-entry transaction
+  (+ postings + line items + document link) → close the ingest in Phase 5.
+  A run that commits a correct, balanced transaction and closes the ingest
+  is a SUCCESS even if it did zero enrichment.`
+      : `re-read the source → UPDATE the existing transaction's fields in place
+  → replace its line items (retiring the previous run) → stamp
+  metadata.extraction. A run that commits a correct in-place update is a
+  SUCCESS even if it did zero enrichment.`;
+  const enrichment =
+    opts.path === "ingest"
+      ? `Phase 3 (Google place resolve / multilingual fetch / storefront photos)
+  and the brand-icon resolution pipeline.`
+      : `the brand refresh and the brand-icon resolution pipeline.`;
   return `Scratch files — PER-INGEST DIRECTORY ONLY. Several extractions run
 concurrently in this container and /tmp is shared: a generic name like
 /tmp/receipt_rot.jpg WILL be overwritten by a sibling agent mid-run,
@@ -127,14 +148,10 @@ to 40+ turns — and the extra 30 turns are almost always merchant enrichment
 (Google fetches, storefront photos, brand icons), NOT harder extraction.
 
 CORE — required. Do this and commit it no matter what:
-  classify → extract fields → write the balanced double-entry transaction
-  (+ postings + line items + document link) → close the ingest in Phase 5.
-  A run that commits a correct, balanced transaction and closes the ingest
-  is a SUCCESS even if it did zero enrichment.
+  ${core}
 
 ENRICHMENT — best-effort, SECONDARY. You may abbreviate or SKIP any of it:
-  Phase 3 (Google place resolve / multilingual fetch / storefront photos)
-  and the brand-icon resolution pipeline. These are polish and a cache.
+  ${enrichment} These are polish and a cache.
   You have full authority to skip them. They must NEVER:
     • block, delay, or fail the core write;
     • trigger a self-correction loop — if a step errors or a column/table
@@ -167,14 +184,32 @@ a decision, not a failure:
   metadata.enrichment_skipped = ['photos','brand_icon', ...]   -- reasons ok`;
 }
 
+/** Today, in the agent's own terms. Computed per render, never baked in —
+ *  see `dateSelfCheck()`. */
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+function currentYear(): number {
+  return new Date().getUTCFullYear();
+}
+
 /**
  * Phase 3.5 Checks A + B — the two evidence-proven date self-checks.
+ *
+ * A FUNCTION, not a const, and that is load-bearing. This block tells the
+ * agent what "today" is so it can sanity-check an extracted year, and a
+ * hardcoded date here is worse than none: it silently teaches the agent the
+ * wrong present. A `const` would freeze the date at module load, which on a
+ * container that runs for weeks drifts just as badly. Date accuracy is the
+ * known weak spot (#27) and this check is the mechanism meant to catch it,
+ * so it evaluates on every render.
  *
  * Check C (payee cross-check via Google) is NOT here: it depends on a
  * Phase 3 geocode that only the ingest path performs, so it stays in
  * `prompt.ts`.
  */
-export const DATE_SELF_CHECK = `── Phase 3.5 — Targeted OCR self-check (date + payee only) ────────────
+export function dateSelfCheck(): string {
+  return `── Phase 3.5 — Targeted OCR self-check (date + payee only) ────────────
 
 Round 1 + Round 2 (40 receipts total) showed that **failures cluster
 on two axes**: (a) date OCR errors (wrong year, day/month digit swaps)
@@ -188,14 +223,18 @@ evidence-driven**: only the two checks that provably help.
 Before committing your YYYY-MM-DD:
 
   1. What year did you extract? Say it out loud: "I extracted year YYYY."
-  2. Today's date (from \`date\` command if needed) is 2026-04-20.
+  2. Today's date is ${todayISO()}, and the current year is ${currentYear()}.
   3. Is your extracted year more than 12 months before today? Receipts
      are almost always from the current or previous calendar year.
-  4. If your year is 2023 or earlier AND today is 2026: **LOOK AGAIN**
+  4. If your extracted year is ${currentYear() - 2} or earlier: **LOOK AGAIN**
      at the year digit on the receipt. It is statistically extremely
      unlikely that a receipt processed today is 2+ years old.
-     Common misread: "2025" rendered as "2023" on faint thermal paper;
-     the middle digit is usually '2' with the last digit 5 vs 3.
+     Common misread: "${currentYear()}" rendered as "${currentYear() - 2}" on
+     faint thermal paper; the middle digit is usually '2' and it is the last
+     digit that is misread.
+     This is a PROMPT, not a veto — genuine old receipts exist (a backfill of
+     a 2021 purchase is legitimate). Look again, then keep what the paper
+     actually says.
 
 ### Check B — Multi-candidate date enumeration (catches day-digit swaps)
 
@@ -224,6 +263,7 @@ Emit your date-candidate list in metadata:
 
   "date_candidates": ["09/30/2025", "12/31/2025"],
   "chosen_date_reason": "top of receipt adjacent to transaction time"`;
+}
 
 /** The mandatory `metadata.ocr_audit` provenance key. */
 export const OCR_AUDIT_REQUIREMENT = `### REQUIRED metadata.ocr_audit shape

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -17,7 +17,7 @@ import {
   EXTRACTION_MODEL,
   NO_JSON_SCHEMA_RULE,
   PSQL_DISCIPLINE,
-  DATE_SELF_CHECK,
+  dateSelfCheck,
   OCR_AUDIT_REQUIREMENT,
   agentHygiene,
   renderActiveLessons,
@@ -114,7 +114,7 @@ Optional: if you want to discover schema details, \`\\d\` works:
   psql "\$DATABASE_URL" -c "\\d transactions"
   psql "\$DATABASE_URL" -c "SELECT id, name, type FROM accounts WHERE workspace_id = '${ctx.workspaceId}' ORDER BY type, name"
 
-${agentHygiene({ scratchDir, filePath: ctx.filePath })}
+${agentHygiene({ scratchDir, filePath: ctx.filePath, path: "ingest" })}
 ${renderActiveLessons()}
 ${phase0DocumentRead({ filePath: ctx.filePath, scratchDir })}
 
@@ -532,7 +532,7 @@ Also record provenance in metadata:
 This phase is FREE — it uses OCR you've already done. Always run
 it before giving up on the Chinese name.
 
-${DATE_SELF_CHECK}
+${dateSelfCheck()}
 
 ### Check C — Payee cross-check via Google (KEEP — evidence-proven)
 

--- a/src/ingest/reextract-prompt.ts
+++ b/src/ingest/reextract-prompt.ts
@@ -46,7 +46,7 @@ import {
   EXTRACTION_MODEL,
   NO_JSON_SCHEMA_RULE,
   PSQL_DISCIPLINE,
-  DATE_SELF_CHECK,
+  dateSelfCheck,
   OCR_AUDIT_REQUIREMENT,
   agentHygiene,
   renderActiveLessons,
@@ -143,7 +143,7 @@ Context variables for SQL (use as-is):
 
 ${PSQL_DISCIPLINE}
 
-${agentHygiene({ scratchDir, filePath: ctx.filePath })}
+${agentHygiene({ scratchDir, filePath: ctx.filePath, path: "re-extract" })}
 ${renderActiveLessons()}
 ${phase0DocumentRead({ filePath: ctx.filePath, scratchDir })}
 ${renderDecodedSource(ctx.ocrText)}
@@ -176,7 +176,7 @@ ${LINE_ITEM_WORKED_EXAMPLES}
 
 ${ALLOCATION_LOGIC}
 
-${DATE_SELF_CHECK}
+${dateSelfCheck()}
 
 ${OCR_AUDIT_REQUIREMENT}
 


### PR DESCRIPTION
Three defects the #164 consolidation carried into **both** prompts. All found by reading the *rendered* output rather than the source — none is visible in a diff or caught by `tsc`.

## 1. The date self-check was teaching the agent the wrong present

Check A told the agent, as a literal string:

> `Today's date (from \`date\` command if needed) is 2026-04-20.`
> `If your year is 2023 or earlier AND today is 2026: LOOK AGAIN`

Today is **2026-07-28**. That block exists specifically to catch the known date-OCR weakness (#27), so a stale date there is worse than no check: it anchors the year-sanity test three months in the past. #164 had just propagated it to the re-extract path too, doubling the blast radius.

Now computed per render. `DATE_SELF_CHECK` → **`dateSelfCheck()`**, a function rather than a const, because a const freezes at module load and this container runs for weeks. The threshold and the misread example derive from the current year.

Also softened the branch to say explicitly it is a prompt to look again, **not a veto** — genuine old receipts exist, and #183 just shipped a manual-backfill flow whose motivating example is a 2021 router.

## 2. `<TOTAL_MINOR>` was dangling in the shared TOTAL-ONLY rule

The token is a real placeholder on the *ingest* path, where the surrounding SQL defines it. Moving the coverage rule into `line-item-prompt.ts` put it in front of the **re-extract** agent as well, which has no such variable and no total — that lives on `postings`, outside its scope. It rendered as an undefined reference the agent would have had to improvise around.

Replaced with the instruction it always meant: the receipt's printed grand total, in minor units, as read off the paper.

## 3. The effort-budget prose named phases re-extract doesn't have

It instructed re-extract to *"close the ingest in Phase 5"* — no such phase — and listed *"Phase 3 (Google place resolve / storefront photos)"* as its skippable enrichment, when re-extract's Phase 3 is a brand refresh. A name collision pointing the agent at the wrong step.

`agentHygiene()` now takes `path: "ingest" | "re-extract"` and states each one's own core deliverable and enrichment tail.

## Verification

Both prompts re-rendered:

| | ingest | re-extract |
|---|---|---|
| stale `2026-04-20` | gone | gone |
| today's real date present | ✅ | ✅ |
| dangling `<TOTAL_MINOR>` in shared rule | 0 | 0 |
| mentions "close the ingest in Phase 5" | ✅ (correct) | 0 (fixed) |
| mentions "Google place resolve" | ✅ (correct) | 0 (fixed) |
| `undefined` / `[object Object]` / unresolved `${` | none | none |

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ssDbfdur7JHRCLfZSQsyx