### PR TITLE
fix(docker): pin compose project names so the test stack cannot delete prod

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,17 @@
 # Sandbox stack for frontend-test-runner.
 #
-#   docker compose -p receipts-test -f docker-compose.test.yml up -d --build
+#   docker compose -f docker-compose.test.yml up -d --build
+#
+# The `name:` below pins the compose project. Do NOT remove it. Without it,
+# Compose derives the project name from the directory — which is the same
+# directory the production compose file lives in — and because both files
+# declare the SAME service names (`receipts-postgres`, `receipt-assistant`),
+# Compose concludes the running PRODUCTION containers are stale instances of
+# this file's services and destroys them. That happened on 2026-07-28: a
+# `docker compose -f docker-compose.test.yml up -d` without `-p` removed the
+# prod app and DB containers and took the backend down for ~3 minutes. Data
+# survived only because postgres is on a bind mount, not a named volume.
+# `name:` makes the `-p` flag unnecessary and the mistake impossible.
 #
 # Side-by-side with the production stack — different ports, different
 # postgres volume, different uploads dir, different container names.
@@ -23,6 +34,8 @@
 #
 # Reset script: scripts/sandbox-reset.sh — TRUNCATEs all test tables and
 # nukes test-uploads/, fast (~1s) versus a full down/up cycle.
+
+name: receipts-test
 
 services:
   receipts-postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@
 #
 # Requires Docker Compose v2.20+ for `include:` support.
 
+name: receipt-assistant
+
 include:
   - path: langfuse/docker-compose.yml
 


### PR DESCRIPTION
## What happened

Running `docker compose -f docker-compose.test.yml up -d` from the repo root **destroys the production containers**. I did this on 2026-07-28 while trying to start the sandbox to run `eval:dates`; the prod app and DB containers were removed and the backend was down for ~3 minutes.

## Why

Neither compose file set a project name, so Compose derived it from the directory — the same directory both files live in. Both declare the **same service names** (`receipts-postgres`, `receipt-assistant`), differing only in `container_name`. Compose therefore concluded the running production containers were stale instances of the sandbox file's services and replaced them.

Data survived only because postgres is on a **bind mount** rather than a named volume. With a named volume this would have been real loss.

## Why a comment wasn't enough

`docker-compose.test.yml`'s header already documented the correct form:

```
docker compose -p receipts-test -f docker-compose.test.yml up -d --build
```

So the knowledge existed — it just lived in a comment the caller has to read and remember, guarding an operation whose failure mode is silent deletion of production. That's the wrong place for it.

## Fix

```yaml
# docker-compose.yml
name: receipt-assistant      # explicit; identical to the previously derived
                             # value, so a no-op for anything already running

# docker-compose.test.yml
name: receipts-test
```

`name:` makes the `-p` flag unnecessary and the mistake impossible.

## Verification

```
docker compose -f docker-compose.yml      config → project "receipt-assistant"
docker compose -f docker-compose.test.yml config → project "receipts-test"
```

The two projects can no longer see each other's containers. Production was restored from the prod compose file and confirmed intact: 1356 live transactions, 1604 documents, 3562 live line items, and the Haidilao re-extract still summing to 44091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ssDbfdur7JHRCLfZSQsyx