### PR TITLE
fix(ingest): pass claude prompt on stdin, not argv (fixes spawn E2BIG outage)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,43 @@ Re-running re-extract on the same document with the same `PROMPT_VERSION` and mo
 
 ## Known Pitfalls
 
+0. **Never pass a prompt (or any payload) as a `claude` CLI *argument* —
+   it must go on stdin.** Linux caps a **single** `execve` argument at
+   `MAX_ARG_STRLEN = 32 * 4096 = 131072` bytes. This is a separate limit
+   from the total `ARG_MAX`, so `getconf ARG_MAX` reports a healthy
+   2097152 while every spawn dies with the kernel's opaque
+   `spawn E2BIG` — no mention of which argument, or that a size is
+   involved.
+
+   `buildExtractorPrompt()` is **~135 KB of fixed contract text** before
+   any document-specific content (it stitches together `prompt.ts`,
+   `line-item-prompt.ts`, `prompt-contract.ts`, `items-sql.ts`, and
+   `document-read-prompt.ts`), so it sits permanently over the ceiling.
+   The prompt is expected to keep growing; stdin is what makes that safe.
+
+   Incident 2026-07-28: the prompt crossed 131072 bytes and **every
+   ingest in production failed instantly** — the first casualty was a
+   Subway `.eml`, which made it look like an oversized-email bug. It was
+   not: the ingest path passes only `filePath` into the prompt and the
+   agent opens the file itself. Any document would have failed
+   identically. Fixed in #194 by moving the prompt to `child.stdin`.
+
+   Guard rails now in place, do not remove them:
+   - `src/claude.ts::assertArgvSafe()` runs before every spawn and
+     throws a message naming the offending argument and its byte size.
+   - Both `src/claude.ts::runClaude` and
+     `src/ingest/extractor.ts::runClaude` take `prompt` as a separate
+     parameter and write it to stdin. `stdio[0]` must be `"pipe"`, and
+     the `child.stdin.on("error", …)` handler must stay — the child can
+     exit before draining stdin (auth failure, bad flag) and the
+     resulting `EPIPE` would otherwise crash the worker instead of
+     rejecting the promise.
+
+   The same exposure applies to `src/ingest/reextract-prompt.ts`, which
+   *does* inline user-sized text (`renderDecodedSource` embeds the
+   decoded `.eml`/HTML body). Because the prompt now travels on stdin,
+   no truncation cap is needed — but never move it back to argv.
+
 1. **`--json-schema` degrades OCR accuracy vs plain-text output**:
    Tested 10 receipts with Sonnet, same prompt, same model:
    - `--json-schema` mode: 4/10 dates wrong (including year errors,

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -16,18 +16,59 @@ function buildClaudeEnv(): NodeJS.ProcessEnv {
 }
 
 /**
+ * Linux caps a SINGLE `execve` argument at 32 pages, independent of the
+ * much larger total `ARG_MAX`. A prompt passed as argv silently works
+ * until it crosses this line, then every spawn dies with an opaque
+ * `spawn E2BIG`. See `assertArgvSafe` below.
+ */
+export const MAX_ARG_STRLEN = 32 * 4096;
+
+/**
+ * Turn the kernel's unactionable `spawn E2BIG` into a message that names
+ * the offending argument and its size. Prompts must go over stdin, so
+ * tripping this means someone put payload back on the command line.
+ */
+export function assertArgvSafe(args: string[]): void {
+  for (const [i, arg] of args.entries()) {
+    const bytes = Buffer.byteLength(arg, "utf8");
+    if (bytes >= MAX_ARG_STRLEN) {
+      throw new Error(
+        `claude CLI argv[${i}] is ${bytes} bytes, over the ${MAX_ARG_STRLEN}-byte ` +
+          `per-argument kernel limit (would fail as "spawn E2BIG"). ` +
+          `Large payloads must be passed on stdin, not argv. ` +
+          `Offending arg starts: ${arg.slice(0, 120)}…`,
+      );
+    }
+  }
+}
+
+/**
  * Run `claude` CLI and return stdout + sessionId.
  * Automatically assigns a session ID for traceability.
- * stdin is closed immediately to avoid "no stdin data" warnings.
+ *
+ * The prompt is written to the child's **stdin**, never argv — argv has a
+ * hard 128 KiB per-argument ceiling that the extractor prompt already
+ * exceeds (see `assertArgvSafe`). Callers pass only flags in `args`.
  */
-export function runClaude(args: string[], timeoutMs: number): Promise<{ stdout: string; sessionId: string }> {
+export function runClaude(
+  prompt: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<{ stdout: string; sessionId: string }> {
   const sessionId = randomUUID();
-  const fullArgs = [...args, "--session-id", sessionId];
+  const fullArgs = ["-p", ...args, "--session-id", sessionId];
+  assertArgvSafe(fullArgs);
   return new Promise((resolve, reject) => {
     const child = spawn("claude", fullArgs, {
       env: buildClaudeEnv(),
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe"],
     });
+
+    // The child may exit before draining stdin (bad flag, auth failure).
+    // Without this the EPIPE surfaces as an unhandled 'error' on the
+    // stream and crashes the process instead of rejecting the promise.
+    child.stdin.on("error", () => {});
+    child.stdin.end(prompt);
 
     let stdout = "";
     let stderr = "";

--- a/src/ingest/extractor.ts
+++ b/src/ingest/extractor.ts
@@ -8,6 +8,7 @@
  */
 import { spawn } from "child_process";
 import { randomUUID } from "crypto";
+import { assertArgvSafe } from "../claude.js";
 import { getSessionJsonlPath } from "../langfuse.js";
 import { buildExtractorPrompt, type ExtractorPromptContext } from "./prompt.js";
 import {
@@ -68,6 +69,17 @@ function buildClaudeEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
+/**
+ * Spawn `claude -p` with the prompt on **stdin**.
+ *
+ * The prompt must never be an argv element: Linux caps a single execve
+ * argument at 128 KiB (`MAX_ARG_STRLEN`) regardless of the 2 MB total
+ * `ARG_MAX`, and `buildExtractorPrompt()` alone is already ~135 KB of
+ * fixed contract text before any variable content. Passing it as argv
+ * made every ingest die with an opaque `spawn E2BIG` (incident
+ * 2026-07-28 — production ingestion was down until this moved to stdin).
+ * stdin has no such limit.
+ */
 function runClaude(
   prompt: string,
   sessionId: string,
@@ -76,7 +88,6 @@ function runClaude(
   return new Promise((resolve, reject) => {
     const args = [
       "-p",
-      prompt,
       "--output-format",
       "text",
       "--dangerously-skip-permissions",
@@ -91,10 +102,16 @@ function runClaude(
     if (process.env.CLAUDE_MODEL) {
       args.push("--model", process.env.CLAUDE_MODEL);
     }
+    assertArgvSafe(args);
     const child = spawn("claude", args, {
       env: buildClaudeEnv(),
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe"],
     });
+    // The child can exit before draining stdin (auth failure, bad flag).
+    // Swallow the resulting EPIPE so it rejects via 'close'/'error'
+    // instead of crashing the worker with an unhandled stream error.
+    child.stdin.on("error", () => {});
+    child.stdin.end(prompt);
     let out = "";
     let err = "";
     child.stdout.on("data", (c: Buffer) => {

--- a/src/insights/ask.ts
+++ b/src/insights/ask.ts
@@ -53,14 +53,12 @@ RULES:
 QUESTION: ${question}`;
 
   const args = [
-    "-p",
-    prompt,
     "--output-format",
     "text",
     "--dangerously-skip-permissions",
     "--model",
     process.env.CLAUDE_MODEL || "sonnet",
   ];
-  const { stdout, sessionId } = await runClaude(args, 180_000);
+  const { stdout, sessionId } = await runClaude(prompt, args, 180_000);
   return { answer: stdout.trim(), sessionId };
 }


### PR DESCRIPTION
Fixes #194

## What was wrong

`src/ingest/extractor.ts::runClaude` spawned the CLI as `["-p", prompt, …]`. Linux caps a **single** `execve` argument at `MAX_ARG_STRLEN = 32 * 4096 = 131072` bytes — a separate limit from the total `ARG_MAX`, which is why `getconf ARG_MAX` reported a healthy `2097152` while every spawn died with the kernel's unhelpful `spawn E2BIG`.

Measured against the deployed `/app/dist/ingest/prompt.js`:

```
phashNeighbors=0   134635 bytes   <- zero variable content
phashNeighbors=5   135123 bytes
MAX_ARG_STRLEN     131072
```

The prompt was **3,563 bytes over the ceiling before a single byte of document data**, so production ingestion was down for every document from the `d815b31` deploy (`14:24:42Z`) onward. The one failure on record is a Subway `.eml`, which looked like an oversized-email bug — but the ingest path only ever puts `filePath` in the prompt and the agent opens the file itself. Any receipt would have failed identically.

## The fix

Move the prompt to `child.stdin`, which has no size limit. Verified inside the deployed container with the full production flag set and a deliberately oversized payload:

```
$ python3 -c 'print("Ignore filler: " + "x"*140000 + "\n\nReply with exactly: BIGSTDIN_OK")' \
    | claude -p --output-format text --dangerously-skip-permissions --session-id $SID
BIGSTDIN_OK
```

- `src/ingest/extractor.ts` — prompt out of argv, onto stdin; `stdio[0]` becomes `"pipe"`.
- `src/claude.ts` — same treatment; `runClaude` now takes `prompt` as its own parameter and prepends `-p` itself, so no caller can put payload back on the command line by accident.
- `src/insights/ask.ts` — updated for the new signature. It embeds a user-supplied question, so it had the same latent exposure.
- `src/claude.ts::assertArgvSafe()` — runs before every spawn; converts a future regression from `spawn E2BIG` into a message naming the argument index, its byte size, and the limit.
- `child.stdin.on("error", …)` on both paths — the child can exit before draining stdin (auth failure, bad flag); the resulting `EPIPE` would otherwise surface as an unhandled stream error and crash the worker instead of rejecting the promise.

This also removes the ceiling from the re-extract path, which genuinely does inline user-sized text (`reextract-prompt.ts::renderDecodedSource` embeds the decoded `.eml`/HTML body) and would have broken on any large email.

## Why no size cap on the prompt instead

Capping would mean truncating the extraction contract or the document text — both degrade output quality to work around a limit that stdin simply does not have. The prompt is expected to keep growing; stdin is what makes that safe. `assertArgvSafe()` guards the direction that actually matters.

## Verification

- [x] `npx tsc --noEmit` clean.
- [x] stdin accepted by the deployed CLI with `--session-id` / `--output-format` / `--dangerously-skip-permissions`.
- [x] 140 KB stdin payload succeeds where argv fails.
- [ ] Deployed to the mini and the stuck `ingest_subway.eml` re-ingests into a balanced transaction — recorded below after rollout.

## Docs

`CLAUDE.md` gains a Known Pitfall #0 recording the argv limit, the incident, and the guard rails that must not be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123xPGbFQfS2dqUGK181LHY