### PR TITLE
fix(ops): log ingest-worker failures; stop leaking DATABASE_URL into prompts

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -1,8 +1,6 @@
 import { spawn } from "child_process";
 import { randomUUID } from "crypto";
 
-const DATABASE_URL = process.env.DATABASE_URL || "postgresql://postgres:postgres@localhost:5432/receipts";
-
 /**
  * Build a clean env for spawning claude CLI subprocesses.
  * - Removes CLAUDECODE to avoid "nested session" errors
@@ -100,6 +98,13 @@ export function runClaude(
  * Detect the right psql command for the current environment.
  * In Docker: psql is available directly.
  * Local dev: use docker exec to reach the postgres container.
+ *
+ * The returned string is interpolated into a prompt, so it must emit the
+ * **unexpanded** `"$DATABASE_URL"` literal and let the agent's shell
+ * expand it — matching `PSQL_DISCIPLINE` in `src/ingest/prompt-contract.ts`
+ * and every other prompt. Interpolating the resolved URL would write the
+ * DB password into the prompt, and from there verbatim into the session
+ * JSONL and the Langfuse trace.
  */
 export async function detectPsqlCommand(): Promise<string> {
   // Check if psql is available locally
@@ -109,9 +114,11 @@ export async function detectPsqlCommand(): Promise<string> {
       child.on("close", (code) => code === 0 ? resolve() : reject());
       child.on("error", reject);
     });
-    return `psql "${DATABASE_URL}" -c`;
+    return `psql "$DATABASE_URL" -c`;
   } catch {
-    // Fallback: use docker exec (local dev)
-    return `docker exec langfuse-postgres-1 psql -U postgres -d receipts -c`;
+    // Fallback: use docker exec (local dev). The app DB has lived in
+    // `receipts-postgres` since ccc80e2 decoupled it from Langfuse —
+    // `langfuse-postgres-1` no longer holds these tables.
+    return `docker exec receipts-postgres psql -U postgres -d receipts -c`;
   }
 }

--- a/src/ingest/worker.ts
+++ b/src/ingest/worker.ts
@@ -386,6 +386,14 @@ async function runOne(item: QueueItem): Promise<void> {
     // Agent died / timed out before closing out the ingest row. Stamp
     // it with the error; leave place_id etc. untouched (the agent may
     // have gotten partway through — operators can inspect `ingests`).
+    //
+    // This console.error is load-bearing, do not drop it. Because this
+    // catch handles the rejection, the `[ingest worker] uncaught:` path
+    // never fires — so without a log here a total extraction outage
+    // produces container output indistinguishable from an idle healthy
+    // run. That is exactly how the 2026-07-28 E2BIG outage (#194) went
+    // ~11h unnoticed: 19 log lines, none of them an error.
+    console.error(`[ingest worker] ingest=${ingestId} FAILED:`, err);
     await markError(ingestId, workspaceId, err);
     busEmit("job.error", {
       batchId,


### PR DESCRIPTION
Refs #194 — three defects surfaced by the E2BIG post-mortem. All small, all in the blast radius of that incident.

## 1. A total extraction outage produced no error log (`src/ingest/worker.ts:385`)

The `catch` around the extractor calls `markError` + `busEmit` and returns — with no `console.error`. The only logging path that *would* print (`[ingest worker] uncaught:`, `worker.ts:94`) never fires **precisely because** this catch handles the rejection.

The container's entire log for the ~11h broken window was 19 lines: the boot banner, one `[claude] extract ingestId=…` printed *before* the spawn, and three `[reconcile] … skipped`. A complete outage was indistinguishable from an idle healthy run.

One line turns that into `docker logs | grep FAILED`.

## 2. `detectPsqlCommand()` wrote the DB password into the prompt (`src/claude.ts`)

```diff
-    return `psql "${DATABASE_URL}" -c`;
+    return `psql "$DATABASE_URL" -c`;
```

Every other prompt emits the **unexpanded** literal and lets the agent's shell expand it — `PSQL_DISCIPLINE` in `src/ingest/prompt-contract.ts:63`, and likewise `prompt.ts`, `reextract-prompt.ts`, `brand-icon-prompt.ts`. Only the ask-ledger path resolved it first, so the credential was interpolated into the prompt text.

Before #195 that put the password in `/proc/<pid>/cmdline`. Even after #195 moved the prompt to stdin it still lands verbatim in the session JSONL, and from there in the Langfuse trace. The now-unused module-level `DATABASE_URL` constant is dropped with it.

## 3. Dev fallback pointed at a container that no longer holds the app DB (`src/claude.ts`)

`docker exec langfuse-postgres-1 …` — the app DB moved out of that container in `ccc80e2 Decouple app DB from Langfuse`. Corrected to `receipts-postgres`.

## Verification

- [x] `npx tsc --noEmit` clean.
- [ ] Deployed to the mini and a fresh ingest logged/succeeded — recorded below after rollout.

## Not in this PR

The post-mortem also produced three larger items, filed separately rather than bundled here: a prompt-size budget gate, an `ocrText` cap for cost/quality, and the `retryable` classification mismatch between backend and frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123xPGbFQfS2dqUGK181LHY