### PR TITLE
refactor(claude): one owner for spawning the CLI

### DIFF
--- a/scripts/backfill-photo-ocr.ts
+++ b/scripts/backfill-photo-ocr.ts
@@ -27,9 +27,8 @@
  *   --only-id UUID  Single-row debug.
  */
 import "dotenv/config";
-import { spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
 import { sql } from "drizzle-orm";
+import { runClaude } from "../src/claude.js";
 import { db } from "../src/db/client.js";
 
 interface Args {
@@ -146,42 +145,17 @@ Fetch each via:
 Read all three, judge, then print the single JSON object.`;
 }
 
-function runClaude(prompt: string, timeoutMs: number): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const env = { ...process.env };
-    delete env.CLAUDECODE;
-    delete env.ANTHROPIC_API_KEY;
-    const child = spawn(
-      "claude",
-      [
-        "-p",
-        prompt,
-        "--output-format",
-        "text",
-        "--dangerously-skip-permissions",
-        "--session-id",
-        randomUUID(),
-      ],
-      { env, stdio: ["ignore", "pipe", "pipe"] },
-    );
-    let out = "";
-    let err = "";
-    child.stdout.on("data", (b: Buffer) => (out += b.toString()));
-    child.stderr.on("data", (b: Buffer) => (err += b.toString()));
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error(`claude -p timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      if (code !== 0) reject(new Error(err || out || `claude -p exited ${code}`));
-      else resolve(out);
-    });
-    child.on("error", (e) => {
-      clearTimeout(timer);
-      reject(e);
-    });
+/**
+ * Spawning goes through src/claude.ts so this script cannot drift from
+ * the production path — in particular the prompt travels on stdin, not
+ * argv (#194).
+ */
+async function askClaude(prompt: string, timeoutMs: number): Promise<string> {
+  const { stdout } = await runClaude(prompt, {
+    args: ["--output-format", "text", "--dangerously-skip-permissions"],
+    timeoutMs,
   });
+  return stdout;
 }
 
 interface OcrResult {
@@ -235,7 +209,7 @@ async function main(): Promise<void> {
   for (const c of cands) {
     process.stdout.write(`  ${ok + miss + fail + 1}/${cands.length} ${c.display_name_en ?? c.google_place_id}: `);
     try {
-      const raw = await runClaude(buildPlacePrompt(c), TIMEOUT);
+      const raw = await askClaude(buildPlacePrompt(c), TIMEOUT);
       const parsed = parseClaudeJson(raw);
       if (!parsed) {
         fail++;

--- a/scripts/smoke-v1-ingest.ts
+++ b/scripts/smoke-v1-ingest.ts
@@ -26,10 +26,10 @@
  *        --concurrency=<n>        Parallel workers (default 3)
  *        --limit=<n>              Cap processed count (default 15)
  */
-import { spawn } from "child_process";
-import { randomUUID, createHash } from "crypto";
+import { createHash } from "crypto";
 import * as fs from "fs";
 import * as path from "path";
+import { runClaude } from "../src/claude.js";
 
 // ── CLI args ───────────────────────────────────────────────────────────
 
@@ -200,42 +200,12 @@ async function runClaudeOnImage(
   absImagePath: string,
   timeoutMs = 180_000,
 ): Promise<{ raw: string; parsed: Extracted | null; parseError?: string; sessionId: string }> {
-  const sessionId = randomUUID();
-  const prompt = buildPrompt(absImagePath);
-  const args = [
-    "-p",
-    prompt,
-    "--output-format",
-    "text",
-    "--dangerously-skip-permissions",
-    "--session-id",
-    sessionId,
-  ];
-
-  // Clear env quirks that break nested sessions (same as src/claude.ts).
-  const env = { ...process.env };
-  delete env.CLAUDECODE;
-  delete env.ANTHROPIC_API_KEY;
-
-  const raw = await new Promise<string>((resolve, reject) => {
-    const child = spawn("claude", args, { env, stdio: ["ignore", "pipe", "pipe"] });
-    let out = "";
-    let err = "";
-    child.stdout.on("data", (c: Buffer) => (out += c.toString()));
-    child.stderr.on("data", (c: Buffer) => (err += c.toString()));
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error(`claude -p timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      if (code !== 0) reject(new Error(err || out || `exit ${code}`));
-      else resolve(out);
-    });
-    child.on("error", (e) => {
-      clearTimeout(timer);
-      reject(e);
-    });
+  // Spawning goes through src/claude.ts so this script cannot drift from
+  // the production path — in particular the prompt travels on stdin, not
+  // argv (#194).
+  const { stdout: raw, sessionId } = await runClaude(buildPrompt(absImagePath), {
+    args: ["--output-format", "text", "--dangerously-skip-permissions"],
+    timeoutMs,
   });
 
   const fence = extractLastJsonFence(raw);

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -40,20 +40,38 @@ export function assertArgvSafe(args: string[]): void {
   }
 }
 
+export interface RunClaudeOptions {
+  /** Flags only, never payload — the prompt goes on stdin. `-p` and
+   *  `--session-id` are supplied by this function. */
+  args?: string[];
+  timeoutMs: number;
+  /** Pre-allocated session id. The ingest path mints its own before
+   *  spawning so the Langfuse JSONL path is known while the agent is
+   *  still running (root CLAUDE.md invariant); other callers omit it and
+   *  get a fresh one back. */
+  sessionId?: string;
+}
+
 /**
- * Run `claude` CLI and return stdout + sessionId.
- * Automatically assigns a session ID for traceability.
+ * Run `claude -p` and return its stdout plus the session id used.
  *
- * The prompt is written to the child's **stdin**, never argv — argv has a
- * hard 128 KiB per-argument ceiling that the extractor prompt already
- * exceeds (see `assertArgvSafe`). Callers pass only flags in `args`.
+ * The single owner of "how this service spawns the Claude CLI" — the
+ * ingest extractor, re-extract and insights paths all come through here.
+ * It used to be copy-pasted per call site, which is how the same
+ * three-line stdin fix had to be written twice in #195.
+ *
+ * The prompt is written to the child's **stdin**, never argv: a single
+ * argv element is capped at 128 KiB (`MAX_ARG_STRLEN`) regardless of the
+ * 2 MB total `ARG_MAX`, and `buildExtractorPrompt()` alone is already
+ * ~135 KB of fixed contract text. Passing it as argv made every ingest
+ * die with an opaque `spawn E2BIG` (incident 2026-07-28, #194 —
+ * production ingestion was down until this moved to stdin). stdin has no
+ * such limit.
  */
 export function runClaude(
   prompt: string,
-  args: string[],
-  timeoutMs: number,
+  { args = [], timeoutMs, sessionId = randomUUID() }: RunClaudeOptions,
 ): Promise<{ stdout: string; sessionId: string }> {
-  const sessionId = randomUUID();
   const fullArgs = ["-p", ...args, "--session-id", sessionId];
   assertArgvSafe(fullArgs);
   return new Promise((resolve, reject) => {
@@ -75,13 +93,13 @@ export function runClaude(
 
     const timer = setTimeout(() => {
       child.kill("SIGTERM");
-      reject(new Error(`Claude CLI timed out after ${timeoutMs}ms`));
+      reject(new Error(`claude -p timed out after ${timeoutMs}ms`));
     }, timeoutMs);
 
     child.on("close", (code) => {
       clearTimeout(timer);
       if (code !== 0) {
-        reject(new Error(stderr || stdout || `Claude CLI exited with code ${code}`));
+        reject(new Error(stderr || stdout || `claude -p exited with code ${code}`));
       } else {
         resolve({ stdout, sessionId });
       }

--- a/src/ingest/extractor.ts
+++ b/src/ingest/extractor.ts
@@ -6,9 +6,8 @@
  * produced tx_ids) is read by polling the `ingests` row the agent
  * itself updates.
  */
-import { spawn } from "child_process";
 import { randomUUID } from "crypto";
-import { assertArgvSafe } from "../claude.js";
+import { runClaude } from "../claude.js";
 import { getSessionJsonlPath } from "../langfuse.js";
 import { buildExtractorPrompt, type ExtractorPromptContext } from "./prompt.js";
 import {
@@ -61,82 +60,30 @@ export type Extractor = (input: ExtractorInput) => Promise<ExtractorResult>;
 
 // ── Default impl: spawn `claude -p` ───────────────────────────────────
 
-function buildClaudeEnv(): NodeJS.ProcessEnv {
-  const env = { ...process.env };
-  // These quirks poison nested CLI sessions — carry forward from Phase 1.
-  delete env.CLAUDECODE;
-  delete env.ANTHROPIC_API_KEY;
-  return env;
-}
-
 /**
- * Spawn `claude -p` with the prompt on **stdin**.
+ * Spawn `claude -p` for the two extraction prompts.
  *
- * The prompt must never be an argv element: Linux caps a single execve
- * argument at 128 KiB (`MAX_ARG_STRLEN`) regardless of the 2 MB total
- * `ARG_MAX`, and `buildExtractorPrompt()` alone is already ~135 KB of
- * fixed contract text before any variable content. Passing it as argv
- * made every ingest die with an opaque `spawn E2BIG` (incident
- * 2026-07-28 — production ingestion was down until this moved to stdin).
- * stdin has no such limit.
+ * The shared `runClaude` in `src/claude.ts` owns the mechanics — prompt
+ * on stdin (never argv, see #194), argv-size guard, env scrubbing,
+ * timeout. This wrapper adds only the flags both extraction prompts
+ * want and forwards the caller's pre-allocated session id.
  */
-function runClaude(
+async function runExtractorClaude(
   prompt: string,
   sessionId: string,
   timeoutMs: number,
 ): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const args = [
-      "-p",
-      "--output-format",
-      "text",
-      "--dangerously-skip-permissions",
-      "--session-id",
-      sessionId,
-    ];
-    // Only pin the model when CLAUDE_MODEL is explicitly set. Unset (the
-    // mini today) means the CLI picks its own default, and the prompt
-    // stamps `EXTRACTION_MODEL = "cli-default"` — which is the truth.
-    // Passing a hard-coded "sonnet" here would silently downgrade the
-    // model that has actually been running.
-    if (process.env.CLAUDE_MODEL) {
-      args.push("--model", process.env.CLAUDE_MODEL);
-    }
-    assertArgvSafe(args);
-    const child = spawn("claude", args, {
-      env: buildClaudeEnv(),
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    // The child can exit before draining stdin (auth failure, bad flag).
-    // Swallow the resulting EPIPE so it rejects via 'close'/'error'
-    // instead of crashing the worker with an unhandled stream error.
-    child.stdin.on("error", () => {});
-    child.stdin.end(prompt);
-    let out = "";
-    let err = "";
-    child.stdout.on("data", (c: Buffer) => {
-      out += c.toString();
-    });
-    child.stderr.on("data", (c: Buffer) => {
-      err += c.toString();
-    });
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error(`claude -p timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        reject(new Error(err || out || `claude -p exited ${code}`));
-      } else {
-        resolve(out);
-      }
-    });
-    child.on("error", (e) => {
-      clearTimeout(timer);
-      reject(e);
-    });
-  });
+  const args = ["--output-format", "text", "--dangerously-skip-permissions"];
+  // Only pin the model when CLAUDE_MODEL is explicitly set. Unset (the
+  // mini today) means the CLI picks its own default, and the prompt
+  // stamps `EXTRACTION_MODEL = "cli-default"` — which is the truth.
+  // Passing a hard-coded "sonnet" here would silently downgrade the
+  // model that has actually been running.
+  if (process.env.CLAUDE_MODEL) {
+    args.push("--model", process.env.CLAUDE_MODEL);
+  }
+  const { stdout } = await runClaude(prompt, { args, sessionId, timeoutMs });
+  return stdout;
 }
 
 /**
@@ -162,7 +109,7 @@ export const defaultClaudeExtractor: Extractor = async (input) => {
   console.log(
     `[claude] extract ingestId=${input.ingestId} sessionId=${sessionId} jsonl=${getSessionJsonlPath(sessionId)}`,
   );
-  const stdout = await runClaude(prompt, sessionId, CLAUDE_TIMEOUT_MS);
+  const stdout = await runExtractorClaude(prompt, sessionId, CLAUDE_TIMEOUT_MS);
   return { sessionId, stdout };
 };
 
@@ -212,6 +159,6 @@ export const defaultClaudeReExtractor: ReExtractor = async (input) => {
   console.log(
     `[claude] re-extract txId=${input.transactionId} sessionId=${sessionId} jsonl=${getSessionJsonlPath(sessionId)}`,
   );
-  const stdout = await runClaude(prompt, sessionId, CLAUDE_TIMEOUT_MS);
+  const stdout = await runExtractorClaude(prompt, sessionId, CLAUDE_TIMEOUT_MS);
   return { sessionId, stdout };
 };

--- a/src/ingest/prompt-contract.ts
+++ b/src/ingest/prompt-contract.ts
@@ -38,7 +38,7 @@ export const PROMPT_VERSION = "3.1";
  * and `documents.ocr_model_version`.
  *
  * `claude -p` is spawned WITHOUT a `--model` flag unless `CLAUDE_MODEL`
- * is set (see `extractor.ts::runClaude`), in which case the CLI picks its
+ * is set (see `extractor.ts::runExtractorClaude`), in which case the CLI picks its
  * own default — so `"cli-default"` is the truthful stamp for an unset
  * env var. The old `"sonnet"` fallback was a lie: the container CLI has
  * been running opus while the column read `sonnet`.

--- a/src/insights/ask.ts
+++ b/src/insights/ask.ts
@@ -59,6 +59,9 @@ QUESTION: ${question}`;
     "--model",
     process.env.CLAUDE_MODEL || "sonnet",
   ];
-  const { stdout, sessionId } = await runClaude(prompt, args, 180_000);
+  const { stdout, sessionId } = await runClaude(prompt, {
+    args,
+    timeoutMs: 180_000,
+  });
   return { answer: stdout.trim(), sessionId };
 }


### PR DESCRIPTION
## Summary

Four copies of the `claude` CLI spawn logic existed in this repo — `src/claude.ts`, `src/ingest/extractor.ts`, `scripts/smoke-v1-ingest.ts`, `scripts/backfill-photo-ocr.ts`. Each had its own `spawn`, its own timeout, its own env scrubbing, and (in the two `src/` copies) its own `buildClaudeEnv`.

That is not a cosmetic problem. #195 fixed the E2BIG outage by moving the prompt from argv to stdin, and the identical three-part fix — stdin pipe, EPIPE swallow, `assertArgvSafe` — had to be hand-applied to **both** `src/` copies in one commit. The next change to this path would have needed the same treatment again, and the two `scripts/` copies never got the fix at all.

## Changes

**`src/claude.ts` is now the single owner.** `runClaude` takes an options object so one implementation serves both caller shapes:

- the ingest path passes its **pre-allocated `sessionId`** (root `CLAUDE.md` invariant — Langfuse's JSONL path must be resolvable while the agent is still running);
- everything else omits it and gets a fresh one back.

**`extractor.ts` keeps a thin `runExtractorClaude`** holding only what is genuinely extractor-specific: the `--output-format text` / `--dangerously-skip-permissions` flags and the "pin `--model` only if `CLAUDE_MODEL` is set" rule. Its private `buildClaudeEnv` and 55-line `runClaude` are gone.

**The two scripts** now call the shared helper. Both were still passing the prompt on argv with `stdio: ["ignore", …]` — the #194 shape. Their prompts are small enough that neither has tripped the ceiling, so this was a latent pattern rather than a live bug, but they also bypassed `assertArgvSafe`, so the #195 guard would never have fired for them.

Net: **-165 / +77** lines.

## Behavior

Unchanged, with one deliberate exception. The two copies emitted different text for the same event (`Claude CLI timed out after Xms` vs `claude -p timed out after Xms`). Unified on the `claude -p` wording, which is accurate for both now that the shared function always passes `-p`. Nothing parses these strings — they land in `ingests.error` and render as prose.

## Verification

Typechecking is not sufficient for this path, so it was exercised against the real binary:

| Check | Result |
|---|---|
| Real extractor prompt vs. argv ceiling | 133,225 B vs 131,072 B — **over**, guard is load-bearing (the outage had 2 KB of headroom) |
| `assertArgvSafe` on argv payload | throws, naming arg index + size |
| 228 KB prompt over stdin, end to end | returns expected stdout |
| `npm run build` (tsc) | clean |
| `scripts/` (outside `tsconfig` `include`) | typechecked explicitly with matching options |

Refs #194, #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123xPGbFQfS2dqUGK181LHY