### PR TITLE
fix(reextract): keep manual line items, cap decoded source (#192, #198)

### DIFF
--- a/src/ingest/items-sql.ts
+++ b/src/ingest/items-sql.ts
@@ -195,9 +195,17 @@ export function transactionItemsInsert(opts: {
   fromPrefix?: string;
   /** RETURNING column list, when the caller wraps this in a CTE. */
   returning?: string;
+  /** SQL expression added to every `line_no`, so a run can be shifted past
+   *  rows that survived it. Re-extract passes the highest live manual line
+   *  (#192): manual rows are no longer retired, and since the unique index is
+   *  (transaction_id, line_no, extraction_run) a new run may legally reuse a
+   *  survivor's number — leaving two LIVE rows with the same line_no and an
+   *  ambiguous rendered order. Ingest passes nothing; it has no survivors. */
+  lineNoOffsetExpr?: string;
 }): string {
   const from = opts.fromPrefix ? `${opts.fromPrefix} ` : "";
   const returning = opts.returning ? `\n      RETURNING ${opts.returning}` : "";
+  const off = opts.lineNoOffsetExpr ? ` + ${opts.lineNoOffsetExpr}` : "";
   return `      INSERT INTO transaction_items (
         id, workspace_id, transaction_id, line_no, parent_line_no,
         raw_name, normalized_name, product_variant, quantity, unit,
@@ -206,8 +214,9 @@ export function transactionItemsInsert(opts: {
         line_type, product_id, tax_minor, tip_share_minor,
         discount_share_minor, extraction_run, extraction_version
       )
-      SELECT gen_random_uuid(), '${opts.workspaceId}', ${opts.txIdExpr}, item.line_no,
-             item.parent_line_no,
+      SELECT gen_random_uuid(), '${opts.workspaceId}', ${opts.txIdExpr}, item.line_no${off},
+             CASE WHEN item.parent_line_no IS NULL THEN NULL
+                  ELSE item.parent_line_no${off} END,
              item.raw_name, item.normalized_name, item.product_variant,
              item.quantity, item.unit,
              item.unit_price_minor, item.line_total_minor, item.currency,

--- a/src/ingest/reextract-prompt.ts
+++ b/src/ingest/reextract-prompt.ts
@@ -268,17 +268,35 @@ ${brandFkGuard()}
   -- bumps; old run rows soft-deleted via retired_at). Live aggregates
   -- read WHERE retired_at IS NULL, so old purchases drop out and new
   -- ones count immediately — purchase_count stays correct, no drift.
-  -- Soft-delete every live item belonging to this tx.
+  -- Soft-delete the live items THIS PIPELINE produced. Rows the user entered
+  -- by hand (#183, source='manual') survive: you are re-reading the document,
+  -- and the document never contained them. Retiring them would silently
+  -- delete the user's own data on a machine re-read (#192).
+  --
+  -- Those survivors keep their line_no. The unique index is
+  -- (transaction_id, line_no, extraction_run), so a new row may legally reuse
+  -- a surviving row's number — but then two LIVE rows share it and the
+  -- rendered order is ambiguous. Number your items from 1 as usual; the
+  -- INSERT below shifts them past any surviving manual line.
   UPDATE transaction_items
   SET retired_at = NOW()
   WHERE transaction_id = '${ctx.transactionId}'
-    AND retired_at IS NULL;
+    AND retired_at IS NULL
+    AND source <> 'manual';
 
-  -- Insert the freshly extracted rows under run = MAX(prev)+1.
+  -- Insert the freshly extracted rows under run = MAX(prev)+1, numbered past
+  -- any manual line that survived the retire above (#192).
   WITH next_run AS (
     SELECT COALESCE(MAX(extraction_run), 0) + 1 AS run
     FROM transaction_items
     WHERE transaction_id = '${ctx.transactionId}'
+  ),
+  manual_offset AS (
+    SELECT COALESCE(MAX(line_no), 0) AS n
+    FROM transaction_items
+    WHERE transaction_id = '${ctx.transactionId}'
+      AND retired_at IS NULL
+      AND source = 'manual'
   ),
 ${itemsCte()},
 ${productsUpsert({ workspaceId: ctx.workspaceId, merchantIdExpr })}
@@ -287,6 +305,7 @@ ${transactionItemsInsert({
   txIdExpr: `'${ctx.transactionId}'`,
   runExpr: "(SELECT run FROM next_run)",
   merchantIdExpr,
+  lineNoOffsetExpr: "(SELECT n FROM manual_offset)",
 })};
 
   -- #84: recompute aggregate stats for every product this run touched.

--- a/src/routes/documents.service.ts
+++ b/src/routes/documents.service.ts
@@ -893,6 +893,57 @@ async function extractSourceText(
   return null;
 }
 
+/**
+ * Tail guard on the decoded source inlined into the re-extract prompt (#198).
+ *
+ * 65,536 B is 3.3x the p99 of the live corpus (19,875 B) and 1.24x the largest
+ * real document (Home Depot, 52,852 B), so it fires on approximately nothing
+ * today and exists for the document that has not arrived yet.
+ *
+ * Pre-#195 an uncapped body was a crash: prompt on argv, 131,071 B ceiling.
+ * The Home Depot order confirmation already cleared it — 52,852 B decoded,
+ * 135,546 B of total prompt — and never fired only because that document
+ * happened to have zero re-extract runs. Now the prompt travels on stdin, so
+ * the failure mode changed from a loud E2BIG into a silent one: a 50 KB
+ * marketing footer diluting the extraction context and inflating the bill.
+ *
+ * Head AND tail, never head-only. Retailer order confirmations — exactly the
+ * risk class here, Home Depot / Groupon / Robinhood — print the total and the
+ * payment method in the footer. Truncating from the front alone would drop the
+ * two fields the extraction most needs while looking like it worked.
+ *
+ * Caps the DECODED text, never the raw file size, which is not merely a weak
+ * predictor but anti-correlated: the largest HTML document on disk (3,214,335 B)
+ * decodes to 1,837 B, while the breaker decodes from 121,986 to 52,852.
+ */
+const REEXTRACT_SOURCE_CAP_BYTES = 65_536;
+const REEXTRACT_SOURCE_HEAD_BYTES = 49_152;
+const REEXTRACT_SOURCE_TAIL_BYTES = 8_192;
+
+export function capSourceText(
+  text: string | null,
+  documentId: string,
+): string | null {
+  if (text === null) return null;
+  const size = Buffer.byteLength(text, "utf8");
+  if (size <= REEXTRACT_SOURCE_CAP_BYTES) return text;
+
+  const buf = Buffer.from(text, "utf8");
+  const head = buf.subarray(0, REEXTRACT_SOURCE_HEAD_BYTES).toString("utf8");
+  const tail = buf.subarray(buf.length - REEXTRACT_SOURCE_TAIL_BYTES).toString("utf8");
+  const elided = size - REEXTRACT_SOURCE_HEAD_BYTES - REEXTRACT_SOURCE_TAIL_BYTES;
+
+  // Loud on purpose. An unannounced truncation is precisely the silent
+  // degradation this guard exists to prevent, so it must never be the thing
+  // that becomes invisible.
+  console.warn(
+    `[re-extract] doc=${documentId} decoded source ${size} B exceeds ` +
+      `${REEXTRACT_SOURCE_CAP_BYTES} B cap — kept head ${REEXTRACT_SOURCE_HEAD_BYTES} B ` +
+      `+ tail ${REEXTRACT_SOURCE_TAIL_BYTES} B, elided ${elided} B`,
+  );
+  return `${head}\n\n[… ${elided} bytes elided by the ${REEXTRACT_SOURCE_CAP_BYTES} B source cap; head and tail kept …]\n\n${tail}`;
+}
+
 // ── Re-extract (Phase 4c of #80 / #91) ─────────────────────────────────
 
 /**
@@ -1055,7 +1106,7 @@ export async function reExtractDocument(
   //     block overwrites that column at the end of the run anyway.
   let sourceText: string | null = null;
   try {
-    sourceText = await extractSourceText(doc, absPath);
+    sourceText = capSourceText(await extractSourceText(doc, absPath), documentId);
   } catch (err) {
     console.warn(
       `[re-extract] doc=${documentId} source-text extraction failed: ${(err as Error).message}`,


### PR DESCRIPTION
Closes #192. Closes #198. Two guards on the re-extract path, both on code shipped earlier in this same batch of work.

## #192 — re-extract was deleting the user's own line items

The retire step soft-deleted **every** live `transaction_items` row before inserting the new run. Once #183 shipped manual line items, a hand-entered row on a re-extracted receipt would go with them: the user adds a line the extractor missed, someone re-reads the document, and the addition is silently gone.

```sql
AND source <> 'manual'
```

You are re-reading the *document*, and the document never contained that row.

**Keeping survivors creates a numbering problem the retire alone doesn't solve.** The unique index is `(transaction_id, line_no, extraction_run)`, so a new run may *legally* reuse a survivor's `line_no` — nothing rejects it, but two **live** rows then share a number and the rendered order is ambiguous. `transactionItemsInsert` gained an optional `lineNoOffsetExpr`; re-extract passes the highest surviving manual line so the new run numbers past it. `parent_line_no` shifts by the same offset **only when non-NULL**, or every top-level row would acquire a parent. Ingest passes no offset — it has no survivors.

Cannot have bitten yet: re-extract needs a document and manual-backfill transactions have none, so only the mixed case is exposed, and no such transaction has been re-extracted.

## #198 — the decoded email body was inlined uncapped

Pre-#195 this was a crash risk (prompt on argv, 131,071 B ceiling). The Home Depot order confirmation **already cleared it** — 52,852 B decoded, 135,546 B total prompt — and never fired only because that document happened to have zero re-extract runs.

Now the prompt travels on stdin, so the failure mode changed from a loud `E2BIG` into a silent one: a 50 KB marketing footer diluting the extraction context and inflating the bill.

| | |
|---|---|
| Cap | **65,536 B** — 3.3× the corpus p99 (19,875 B), 1.24× the largest real document |
| Shape | **head 49,152 B + tail 8,192 B**, explicit elision marker between |
| On fire | `console.warn` with doc id and byte counts |

**Head *and* tail, never head-only.** The risk class is retailer order confirmations (Home Depot, Groupon, Robinhood) and those print the total and payment method in the **footer** — truncating from the front would drop the two fields extraction most needs while appearing to work.

**Caps the decoded text, never raw file size**, which is not a weak predictor but an anti-correlated one: the largest HTML document on disk (3,214,335 B) decodes to 1,837 B, while the breaker decodes 121,986 → 52,852.

## Verification

```
p50 typical            in=   2964 out=   2964 truncated=false  head✓ tail✓
p99                    in=  19875 out=  19875 truncated=false  head✓ tail✓
Home Depot real max    in=  52852 out=  52852 truncated=false  head✓ tail✓
cap boundary           in=  65536 out=  65536 truncated=false  head✓ tail✓
over cap               in= 120000 out=  57422 truncated=true   head✓ tail✓
null -> null
```

The `tail✓` column is the one that matters — it asserts the trailing total survives truncation.

`tsc --noEmit` clean. Prompt budget **+1,087 B**, inside the 4,096 B allowance; baseline deliberately **not** updated, so the growth keeps accumulating against it rather than resetting the ratchet (#197).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ssDbfdur7JHRCLfZSQsyx