### PR TITLE
fix(ingest): stop blaming the user's file for our outages (#199)

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3566,9 +3566,11 @@
           "ok",
           "in_progress",
           "transient_actionable",
+          "infrastructure_fault",
           "input_problem",
           "informational"
-        ]
+        ],
+        "description": "Why an ingest ended where it did, so a client picks its affordance from\nan enum instead of string-parsing `error` (which is agent prose).\n\n- `ok` — reached `done` and produced a transaction.\n- `in_progress` — still `queued` / `processing`.\n- `transient_actionable` — our failure, self-clearing: expired auth,\n  timeout, rate limit, upstream 5xx. Retrying the same bytes is likely\n  to succeed once the outage passes. Retryable.\n- `infrastructure_fault` — our failure, not obviously self-clearing: a\n  crash, a bad deploy, a kernel or database fault. Nothing is wrong with\n  the user's document, so do not tell them there is. Retryable, and a\n  retry is how such an incident is normally recovered.\n- `input_problem` — `unsupported`: the pipeline could not find a receipt\n  in this file. The same bytes will fail the same way; the user must\n  supply a different document. Not retryable.\n- `informational` — `dedup` / `near_dup`; not a failure at all. The\n  pre-existing transaction is in `dedup_of`. Not retryable.\n\nADDED IN #199: `infrastructure_fault`. Additive — no previously-emitted\nvalue changed meaning, but a client that exhaustively switches on this\nenum must add a branch or it will fall through to its default. Before\n#199 an unrecognized `error` string defaulted to `input_problem`, so\nbackend outages were reported to the user as bad documents; the default\nis now `infrastructure_fault`. Rows that previously came back as\n`input_problem` with `status='error'` will now come back as\n`infrastructure_fault` with `retryable: true`.\n\n`retryable` is exactly membership of `transient_actionable` /\n`infrastructure_fault`, and `POST /v1/ingests/{id}/retry` enforces the\nsame predicate — a row the API reports as retryable will be accepted,\nand one it does not will 409."
       },
       "Ingest": {
         "type": "object",
@@ -3622,7 +3624,8 @@
             "$ref": "#/components/schemas/IngestCategory"
           },
           "retryable": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether `POST /v1/ingests/{id}/retry` will accept this ingest. True exactly for categories `transient_actionable` and `infrastructure_fault`; the endpoint enforces the same predicate, so this field and the endpoint can never disagree (#199)."
           },
           "dedup_of": {
             "type": [
@@ -9450,7 +9453,7 @@
     },
     "/v1/ingests/{id}/retry": {
       "post": {
-        "summary": "Retry a failed/unsupported ingest (#158). Re-runs the original stored bytes through the batch pipeline (genuine-restore dedup branch — not suppressed). Returns 202 with the freshly-created ingest to poll. Only `error`/`unsupported` are retryable.",
+        "summary": "Retry a failed ingest (#158). Re-runs the original stored bytes through the batch pipeline (genuine-restore dedup branch — not suppressed). Returns 202 with the freshly-created ingest to poll. Accepts exactly the ingests whose `retryable` field is true, i.e. category `transient_actionable` or `infrastructure_fault` (#199); anything else 409s. `unsupported` was accepted before #199 despite always reporting `retryable: false`, and no longer is.",
         "tags": [
           "ingest"
         ],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:seed": "tsx scripts/seed.ts",
     "openapi:generate": "tsx scripts/generate-openapi.ts",
     "eval:dates": "tsx scripts/eval-dates.ts",
-    "check:prompt-budget": "tsx scripts/check-prompt-budget.ts"
+    "check:prompt-budget": "tsx scripts/check-prompt-budget.ts",
+    "check:ingest-classification": "tsx scripts/check-ingest-classification.ts"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.3.4",

--- a/scripts/check-ingest-classification.ts
+++ b/scripts/check-ingest-classification.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env tsx
+/**
+ * Classification table for `categorizeIngest` / `isIngestRetryable` (#199).
+ *
+ * There is no test runner in this repo and the classifier is a pure function,
+ * so this is how it gets exercised: real error strings in, `(category,
+ * retryable)` out, printed as a table and asserted against an expectation.
+ * Run it after touching anything in the `categoryOf` / `RETRYABLE_CATEGORIES`
+ * region of `src/routes/ingest.service.ts`.
+ *
+ *   npx tsx scripts/check-ingest-classification.ts
+ *
+ * Exits non-zero on the first mismatch. No DB, no network — importing the
+ * service pulls in the drizzle client module but never opens a connection.
+ */
+import {
+  categorizeIngest,
+  isIngestRetryable,
+  type IngestCategory,
+  type IngestStatus,
+} from "../src/routes/ingest.service.js";
+
+interface Case {
+  /** What this row is a specimen of, for the table's first column. */
+  label: string;
+  status: IngestStatus;
+  error: string | null;
+  expect: IngestCategory;
+  expectRetryable: boolean;
+}
+
+const CASES: Case[] = [
+  // ── The #199 regression itself ──────────────────────────────────────
+  {
+    // Verbatim from ingest 019fa959-87dd-73d4-8ca5-0eed8c8bd9e6, the row
+    // still in production and the live example cited by FE#151. Was
+    // input_problem / not retryable; the user was told their Subway .eml
+    // "could not be processed" during a total backend outage (#194).
+    label: "#194 kernel argv fault (live prod row)",
+    status: "error",
+    error: "spawn E2BIG",
+    expect: "infrastructure_fault",
+    expectRetryable: true,
+  },
+  {
+    // #195's replacement for the opaque kernel error. More informative to a
+    // human and, before #199, classified identically wrongly — the proof
+    // that widening the regex would only have delayed the next miss.
+    label: "#195 assertArgvSafe guard",
+    status: "error",
+    error:
+      "claude CLI argv[1] is 134635 bytes, over the 131072-byte per-argument " +
+      "kernel limit (would fail as \"spawn E2BIG\"). Large payloads must be " +
+      "passed on stdin, not argv. Offending arg starts: You are an expert…",
+    expect: "infrastructure_fault",
+    expectRetryable: true,
+  },
+
+  // ── Transient subset: still recognized, still labelled precisely ─────
+  {
+    label: "expired OAuth (the #158 case)",
+    status: "error",
+    error: "API Error: 401 {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\"}}",
+    expect: "transient_actionable",
+    expectRetryable: true,
+  },
+  {
+    label: "extraction timeout",
+    status: "error",
+    error: "claude -p timed out after 600000ms",
+    expect: "transient_actionable",
+    expectRetryable: true,
+  },
+
+  // ── A genuine input problem ─────────────────────────────────────────
+  {
+    // The only structural way to say "the document was the problem": the
+    // extractor's close-out contract reserves `unsupported` for exactly this.
+    label: "not a receipt (marketing email)",
+    status: "unsupported",
+    error: "Promotional email with no purchase — no line items, no total.",
+    expect: "input_problem",
+    expectRetryable: false,
+  },
+
+  // ── Our own guards, all of them ours to fix ─────────────────────────
+  {
+    label: "agent never closed out the row",
+    status: "error",
+    error:
+      "agent did not close out ingest row (status still processing). stdout: ",
+    expect: "infrastructure_fault",
+    expectRetryable: true,
+  },
+  {
+    label: "#125 guard: receipt with no transaction",
+    status: "error",
+    error:
+      "receipt classified but no transaction written — forcing error " +
+      "(agent self-reported done; see #125)",
+    expect: "infrastructure_fault",
+    expectRetryable: true,
+  },
+  {
+    label: "ledger constraint rejected the write",
+    status: "error",
+    error:
+      'ERROR: postings for transaction do not balance (violates "postings_balance_ck")',
+    expect: "infrastructure_fault",
+    expectRetryable: true,
+  },
+  {
+    label: "container restarted mid-batch",
+    status: "error",
+    error: "worker restart: batch abandoned",
+    expect: "infrastructure_fault",
+    expectRetryable: true,
+  },
+  {
+    // The default itself. Nothing in the codebase emits this; it stands in
+    // for the *next* unforeseen fault, which is the one #199 is really about.
+    label: "an error string nobody has seen yet",
+    status: "error",
+    error: "EMFILE: too many open files, open '/app/data/uploads/x.heic'",
+    expect: "infrastructure_fault",
+    expectRetryable: true,
+  },
+  {
+    label: "error with no message at all",
+    status: "error",
+    error: null,
+    expect: "infrastructure_fault",
+    expectRetryable: true,
+  },
+
+  // ── Non-failure states, unchanged by #199 ───────────────────────────
+  { label: "succeeded", status: "done", error: null, expect: "ok", expectRetryable: false },
+  { label: "waiting on the worker", status: "queued", error: null, expect: "in_progress", expectRetryable: false },
+  { label: "extracting now", status: "processing", error: null, expect: "in_progress", expectRetryable: false },
+  { label: "byte-identical duplicate", status: "dedup", error: null, expect: "informational", expectRetryable: false },
+  { label: "perceptual near-duplicate", status: "near_dup", error: null, expect: "informational", expectRetryable: false },
+];
+
+const pad = (s: string, n: number) => s.padEnd(n);
+const cols = {
+  label: Math.max(...CASES.map((c) => c.label.length), "case".length),
+  status: Math.max(...CASES.map((c) => c.status.length), "status".length),
+  error: 46,
+  category: Math.max(...CASES.map((c) => c.expect.length), "category".length),
+};
+
+const rule = [
+  "─".repeat(cols.label),
+  "─".repeat(cols.status),
+  "─".repeat(cols.error),
+  "─".repeat(cols.category),
+  "─".repeat(9),
+].join("──");
+
+console.log(
+  [
+    pad("case", cols.label),
+    pad("status", cols.status),
+    pad("error (truncated)", cols.error),
+    pad("category", cols.category),
+    "retryable",
+  ].join("  "),
+);
+console.log(rule);
+
+let failures = 0;
+for (const c of CASES) {
+  const { category, retryable } = categorizeIngest(c.status, c.error, null);
+  const predicate = isIngestRetryable(c.status, c.error);
+
+  const errCell =
+    c.error === null
+      ? "(null)"
+      : c.error.length > cols.error
+        ? c.error.slice(0, cols.error - 1) + "…"
+        : c.error;
+
+  const ok =
+    category === c.expect &&
+    retryable === c.expectRetryable &&
+    // The whole point of #199's second half: the field the API reports and
+    // the predicate `retryIngest` guards on are the same value, always.
+    predicate === retryable;
+
+  console.log(
+    [
+      pad(c.label, cols.label),
+      pad(c.status, cols.status),
+      pad(errCell, cols.error),
+      pad(category, cols.category),
+      pad(String(retryable), 9),
+      ok ? "" : `  ✗ expected ${c.expect}/${c.expectRetryable}, predicate=${predicate}`,
+    ].join("  ").trimEnd(),
+  );
+  if (!ok) failures += 1;
+}
+
+console.log(rule);
+if (failures > 0) {
+  console.error(`\n✗ ${failures} of ${CASES.length} cases mismatched.`);
+  process.exit(1);
+}
+console.log(
+  `\n✓ ${CASES.length}/${CASES.length} cases classified as expected; ` +
+    "`retryable` and `isIngestRetryable` agree on every one.",
+);

--- a/src/http/problem.ts
+++ b/src/http/problem.ts
@@ -192,20 +192,26 @@ export class GooglePlacesUpstreamProblem extends HttpProblem {
 }
 
 /**
- * Returned by `POST /v1/ingests/:id/retry` when the ingest is in a
- * state that cannot be re-run. Only `error` / `unsupported` ingests are
- * retryable — `done` already succeeded, `queued`/`processing` are still
- * in flight, and `dedup`/`near_dup` are duplicates whose canonical
- * transaction is reachable via `dedup_of` (retrying would re-suppress).
+ * Returned by `POST /v1/ingests/:id/retry` when the ingest is in a state
+ * that cannot be re-run. Retry is for failures on our side, so only the
+ * `transient_actionable` / `infrastructure_fault` categories qualify —
+ * `ok` already succeeded, `in_progress` is still in flight, `input_problem`
+ * would fail identically on identical bytes, and `informational`
+ * (`dedup`/`near_dup`) has a canonical transaction reachable via `dedup_of`
+ * that retrying would only re-suppress.
+ *
+ * `category` mirrors the field on the ingest resource, so a client that hid
+ * the retry control can explain the 409 without a second lookup (#199).
  */
 export class IngestNotRetryableProblem extends HttpProblem {
-  constructor(ingestId: string, status: string) {
+  constructor(ingestId: string, status: string, category: string) {
     super(
       409,
       "ingest-not-retryable",
       "Ingest is not retryable",
-      `Ingest ${ingestId} has status='${status}'. Only 'error' and 'unsupported' ingests can be retried.`,
-      { ingest_id: ingestId, status },
+      `Ingest ${ingestId} has status='${status}' (category='${category}'). ` +
+        `Only 'transient_actionable' and 'infrastructure_fault' ingests can be retried.`,
+      { ingest_id: ingestId, status, category },
     );
   }
 }

--- a/src/routes/ingest.service.ts
+++ b/src/routes/ingest.service.ts
@@ -53,6 +53,7 @@ export type IngestCategory =
   | "ok"
   | "in_progress"
   | "transient_actionable"
+  | "infrastructure_fault"
   | "input_problem"
   | "informational";
 
@@ -99,14 +100,74 @@ const ALL_INGEST_STATUSES: readonly IngestStatus[] = [
   "near_dup",
 ];
 
-// An `error` string matching this pattern is a transient/infrastructure
-// fault (expired auth, timeout, rate-limit, upstream 5xx) — re-running the
-// same bytes is likely to succeed once the outage clears. Anything else
-// (missing date, illegible, "no total") is treated as an input problem
-// where a blind retry won't help. Matches the 401 auth-expiry class that
-// motivated #158.
+// Recognizes the *self-clearing* subset of our own infrastructure faults —
+// expired auth, timeout, rate-limit, upstream 5xx — so the client can say
+// "wait and it'll work" instead of "an operator has to look at this". Both
+// buckets are ours and both are retryable, so a miss here costs a vaguer
+// label and nothing else.
+//
+// #199: this regex used to be the *gate* — an allowlist of known-transient
+// prose with `input_problem` as the default, which meant any error string it
+// had not seen before was blamed on the user's document. `spawn E2BIG`, a
+// kernel argv-limit fault during the #194 outage, was reported to the user
+// as "This file could not be processed." It must never again decide *whose*
+// fault a failure is; see `categoryOf` for what does.
 const TRANSIENT_ERROR_RE =
   /\b(401|403|429|500|502|503|504)\b|invalid authentication|unauthor|forbidden|timed?[ -]?out|timeout|rate.?limit|overloaded|econnreset|econnrefused|etimedout|network|socket hang up|fetch failed|temporarily|try again/i;
+
+// Categories whose rows `POST /v1/ingests/:id/retry` will accept. The single
+// definition of "retryable" for this feature: the `retryable` field the API
+// reports and the guard inside `retryIngest` are both this set, so the server
+// can never refuse a retry the UI offered, or accept one it hid (#199).
+//
+// Both members are our failures, and re-running the same bytes once the fault
+// clears is exactly the recovery path — #194 was recovered by a retry of a row
+// the UI had declared non-retryable.
+const RETRYABLE_CATEGORIES: ReadonlySet<IngestCategory> = new Set([
+  "transient_actionable",
+  "infrastructure_fault",
+]);
+
+/**
+ * Map an ingest's terminal state to its reason bucket.
+ *
+ * Blame is decided by `status`, a structural enum written by the pipeline —
+ * never by pattern-matching `error`, which is agent prose (#199). The split:
+ *
+ *   - `unsupported` is the *only* way to say the document was the problem.
+ *     The extractor prompt's close-out contract reserves it for exactly that
+ *     ("classification is unsupported, set error = <reason>"), and reserves
+ *     `error` for INSERT/constraint failures. Every `error` string our own
+ *     code writes — `spawn E2BIG`, `assertArgvSafe`, "workspace not found",
+ *     "agent did not close out", "worker restart: batch abandoned" — is a
+ *     fault on our side.
+ *   - Hence `error` defaults to `infrastructure_fault`, not `input_problem`.
+ *     An unrecognized failure is far more likely ours than the user's, and
+ *     mislabelling ours as theirs is the worse of the two mistakes: it blames
+ *     a document that was never at fault, withholds the retry that would have
+ *     fixed it, and misdirects the next investigation.
+ *
+ * A future failure mode that genuinely IS about the document must therefore
+ * be raised as `status='unsupported'`, not as `error` with explanatory prose.
+ */
+function categoryOf(status: IngestStatus, error: string | null): IngestCategory {
+  switch (status) {
+    case "done":
+      return "ok";
+    case "queued":
+    case "processing":
+      return "in_progress";
+    case "dedup":
+    case "near_dup":
+      return "informational";
+    case "unsupported":
+      return "input_problem";
+    case "error":
+      return TRANSIENT_ERROR_RE.test(error ?? "")
+        ? "transient_actionable"
+        : "infrastructure_fault";
+  }
+}
 
 /**
  * Derive the reason bucket + affordance hints for one ingest (#158). Pure
@@ -118,30 +179,27 @@ export function categorizeIngest(
   error: string | null,
   produced: IngestRow["produced"],
 ): { category: IngestCategory; retryable: boolean; dedup_of: string | null } {
-  switch (status) {
-    case "done":
-      return { category: "ok", retryable: false, dedup_of: null };
-    case "queued":
-    case "processing":
-      return { category: "in_progress", retryable: false, dedup_of: null };
-    case "dedup":
-    case "near_dup":
-      return {
-        category: "informational",
-        retryable: false,
-        dedup_of: produced?.transaction_ids?.[0] ?? null,
-      };
-    case "unsupported":
-      return { category: "input_problem", retryable: false, dedup_of: null };
-    case "error": {
-      const transient = TRANSIENT_ERROR_RE.test(error ?? "");
-      return {
-        category: transient ? "transient_actionable" : "input_problem",
-        retryable: transient,
-        dedup_of: null,
-      };
-    }
-  }
+  const category = categoryOf(status, error);
+  return {
+    category,
+    retryable: RETRYABLE_CATEGORIES.has(category),
+    dedup_of:
+      category === "informational"
+        ? (produced?.transaction_ids?.[0] ?? null)
+        : null,
+  };
+}
+
+/**
+ * The one predicate behind both the `retryable` field and `retryIngest`'s
+ * guard (#199). Call this rather than re-deriving the rule; two definitions
+ * of "retryable" in one feature is the bug being fixed, not a style nit.
+ */
+export function isIngestRetryable(
+  status: IngestStatus,
+  error: string | null,
+): boolean {
+  return RETRYABLE_CATEGORIES.has(categoryOf(status, error));
 }
 
 /**
@@ -769,9 +827,21 @@ export async function listIngests(params: {
  * of the failure; the returned `ingest` is the freshly-created one the
  * caller should poll.
  *
- * Guards: only `error` / `unsupported` are retryable. `done` already
- * succeeded; `queued`/`processing` are still in flight; `dedup`/`near_dup`
- * are duplicates whose canonical transaction is reachable via `dedup_of`.
+ * Guard: `isIngestRetryable` — the same predicate that produces the
+ * `retryable` field on every ingest the API returns (#199). Retrying is for
+ * failures on *our* side (`transient_actionable`, `infrastructure_fault`),
+ * where the same bytes through the same pipeline succeed once the fault
+ * clears. `done` already succeeded; `queued`/`processing` are still in
+ * flight; `dedup`/`near_dup` are duplicates whose canonical transaction is
+ * reachable via `dedup_of`.
+ *
+ * `unsupported` was accepted here before #199 even though the `retryable`
+ * field had always reported `false` for it — the contradiction #199 fixes.
+ * It is now refused, deliberately: re-running identical bytes through an
+ * identical pipeline lands on `unsupported` again, so the permissive side of
+ * that contradiction was the wrong one to keep. Re-running the ~100 stored
+ * `unsupported` rows after the pipeline gains new document support is an
+ * operator backfill (see `scripts/`), not a per-row user affordance.
  */
 export async function retryIngest(
   workspaceId: string,
@@ -783,8 +853,8 @@ export async function retryIngest(
   poll: string;
 }> {
   const original = await getIngest(workspaceId, id); // throws NotFound
-  if (original.status !== "error" && original.status !== "unsupported") {
-    throw new IngestNotRetryableProblem(id, original.status);
+  if (!isIngestRetryable(original.status, original.error)) {
+    throw new IngestNotRetryableProblem(id, original.status, original.category);
   }
 
   const abs = resolveUploadPath(original.file_path);

--- a/src/routes/ingest.ts
+++ b/src/routes/ingest.ts
@@ -482,10 +482,13 @@ export function registerIngestOpenApi(registry: OpenAPIRegistry): void {
     method: "post",
     path: "/v1/ingests/{id}/retry",
     summary:
-      "Retry a failed/unsupported ingest (#158). Re-runs the original " +
-      "stored bytes through the batch pipeline (genuine-restore dedup " +
-      "branch — not suppressed). Returns 202 with the freshly-created " +
-      "ingest to poll. Only `error`/`unsupported` are retryable.",
+      "Retry a failed ingest (#158). Re-runs the original stored bytes " +
+      "through the batch pipeline (genuine-restore dedup branch — not " +
+      "suppressed). Returns 202 with the freshly-created ingest to poll. " +
+      "Accepts exactly the ingests whose `retryable` field is true, i.e. " +
+      "category `transient_actionable` or `infrastructure_fault` (#199); " +
+      "anything else 409s. `unsupported` was accepted before #199 despite " +
+      "always reporting `retryable: false`, and no longer is.",
     tags: ["ingest"],
     request: { params: z.object({ id: Uuid }) },
     responses: {

--- a/src/schemas/v1/ingest.ts
+++ b/src/schemas/v1/ingest.ts
@@ -37,23 +37,52 @@ export const IngestClassification = z
   .openapi("IngestClassification");
 
 // Derived reason bucket (#158) so a client can pick the right affordance
-// without string-parsing `error`:
-//   ok                  → reached `done`, produced a transaction.
-//   in_progress         → still `queued` / `processing`.
-//   transient_actionable→ `error` from auth/timeout/rate-limit/upstream 5xx;
-//                          retrying the same bytes is likely to succeed.
-//   input_problem       → `unsupported`, or an `error` that looks like a
-//                          bad/unreadable input; user should replace/correct.
-//   informational       → `dedup` / `near_dup`; not an error. See `dedup_of`.
+// without string-parsing `error`. `infrastructure_fault` was added in #199 —
+// see the `description` below, which is the contract clients read.
 export const IngestCategory = z
   .enum([
     "ok",
     "in_progress",
     "transient_actionable",
+    "infrastructure_fault",
     "input_problem",
     "informational",
   ])
-  .openapi("IngestCategory");
+  .openapi("IngestCategory", {
+    description: [
+      "Why an ingest ended where it did, so a client picks its affordance from",
+      "an enum instead of string-parsing `error` (which is agent prose).",
+      "",
+      "- `ok` — reached `done` and produced a transaction.",
+      "- `in_progress` — still `queued` / `processing`.",
+      "- `transient_actionable` — our failure, self-clearing: expired auth,",
+      "  timeout, rate limit, upstream 5xx. Retrying the same bytes is likely",
+      "  to succeed once the outage passes. Retryable.",
+      "- `infrastructure_fault` — our failure, not obviously self-clearing: a",
+      "  crash, a bad deploy, a kernel or database fault. Nothing is wrong with",
+      "  the user's document, so do not tell them there is. Retryable, and a",
+      "  retry is how such an incident is normally recovered.",
+      "- `input_problem` — `unsupported`: the pipeline could not find a receipt",
+      "  in this file. The same bytes will fail the same way; the user must",
+      "  supply a different document. Not retryable.",
+      "- `informational` — `dedup` / `near_dup`; not a failure at all. The",
+      "  pre-existing transaction is in `dedup_of`. Not retryable.",
+      "",
+      "ADDED IN #199: `infrastructure_fault`. Additive — no previously-emitted",
+      "value changed meaning, but a client that exhaustively switches on this",
+      "enum must add a branch or it will fall through to its default. Before",
+      "#199 an unrecognized `error` string defaulted to `input_problem`, so",
+      "backend outages were reported to the user as bad documents; the default",
+      "is now `infrastructure_fault`. Rows that previously came back as",
+      "`input_problem` with `status='error'` will now come back as",
+      "`infrastructure_fault` with `retryable: true`.",
+      "",
+      "`retryable` is exactly membership of `transient_actionable` /",
+      "`infrastructure_fault`, and `POST /v1/ingests/{id}/retry` enforces the",
+      "same predicate — a row the API reports as retryable will be accepted,",
+      "and one it does not will 409.",
+    ].join("\n"),
+  });
 
 // ── produced provenance ───────────────────────────────────────────────
 
@@ -84,7 +113,13 @@ export const Ingest = z
     // the pre-existing transaction for a `dedup`/`near_dup` row so the
     // client can deep-link "already in your ledger → view it".
     category: IngestCategory,
-    retryable: z.boolean(),
+    retryable: z.boolean().openapi({
+      description:
+        "Whether `POST /v1/ingests/{id}/retry` will accept this ingest. " +
+        "True exactly for categories `transient_actionable` and " +
+        "`infrastructure_fault`; the endpoint enforces the same predicate, " +
+        "so this field and the endpoint can never disagree (#199).",
+    }),
     dedup_of: Uuid.nullable(),
     created_at: IsoDateTime,
     completed_at: IsoDateTime.nullable(),


### PR DESCRIPTION
Closes #199. Unblocks TINKPA/receipt-assistant-frontend#151.

## The bug

`spawn E2BIG` — a kernel argv-limit fault that took production down for 11 hours (#194) — was reported to the user as **"This file could not be processed."**

The classifier's `error` branch was an allowlist of known-transient prose with `input_problem` as the **default**, so any string it had not seen became the document's fault. #195's much more informative `assertArgvSafe` message fails the same regex — proof that widening it would only delay the next miss.

## Invert the default, and stop deciding blame from prose

An unrecognized failure now lands in a new **`infrastructure_fault`** category. The asymmetry is the whole argument: an error we don't recognize is far more likely ours than the user's, and calling ours theirs is the strictly worse mistake — it blames a document that was never at fault, withholds the retry that would have fixed it, and misdirects the next investigation. Which is exactly what it did during #194.

Blame is now decided by **`status`**, a structural enum our own pipeline writes, not by pattern-matching agent prose. `unsupported` is the only way to say the document was the problem; the extractor's close-out contract already reserves it for that and reserves `error` for INSERT/constraint failures, so every `error` our code writes is a fault on our side. `TRANSIENT_ERROR_RE` survives only to name the self-clearing subset *within* infrastructure — it can no longer decide whose fault anything is, so a miss now costs a vaguer label and nothing else.

## Second defect: two definitions of "retryable"

`retryIngest` guarded on `status !== 'error' && status !== 'unsupported'` while the `retryable` field it contradicted was computed elsewhere. The server therefore **accepted retries the UI refused to offer a button for** — and that mismatch is how #194 was actually recovered. Both now call one exported predicate, `isIngestRetryable`. The API can no longer refuse what the UI offers, or accept what it hides.

Reconciling them narrows one case deliberately: `unsupported` was accepted by the endpoint despite always reporting `retryable: false`, and is now refused. Re-running identical bytes through an identical pipeline lands on `unsupported` again, so the permissive side of the contradiction was the wrong one to keep. Re-running stored `unsupported` rows after the pipeline gains new document support is an operator backfill, not a per-row user affordance.

## No migration

`ingests.status` is untouched and `category`/`retryable` are derived per request in `mapIngestRow`, never stored — so the live `spawn E2BIG` row reclassifies on the next read with zero DML, and the DDL-before-DML ordering rule (PG 55006) never comes into play.

## Verification — the classifier as a pure function, 16/16

```
case                                     status       category              retryable
#194 kernel argv fault (live prod row)   error        infrastructure_fault  true
#195 assertArgvSafe guard                error        infrastructure_fault  true
expired OAuth (the #158 case)            error        transient_actionable  true
extraction timeout                       error        transient_actionable  true
not a receipt (marketing email)          unsupported  input_problem         false
agent never closed out the row           error        infrastructure_fault  true
#125 guard: receipt with no transaction  error        infrastructure_fault  true
ledger constraint rejected the write     error        infrastructure_fault  true
container restarted mid-batch            error        infrastructure_fault  true
an error string nobody has seen yet      error        infrastructure_fault  true
error with no message at all             error        infrastructure_fault  true
succeeded / queued / processing          …            ok / in_progress      false
dedup / near_dup                         …            informational         false
```

The two rows that matter are **"an error string nobody has seen yet"** and **"error with no message at all"** — the previous default sent both to `input_problem`.

`npm run check:ingest-classification` also asserts `isIngestRetryable` agrees with the reported `retryable` on every case, so the two-sources-of-truth defect cannot silently return.

## For the frontend

Switch the needs-attention panel on `category`, not `status`. Retryable set is `transient_actionable` + `infrastructure_fault`. `infrastructure_fault` is **additive** to the enum — exhaustive switches must add a branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ssDbfdur7JHRCLfZSQsyx