### PR TITLE
fix(dedup): identifier contract + candidates that exist at $0 (#204, #205)

### DIFF
--- a/scripts/prompt-budget.baseline.json
+++ b/scripts/prompt-budget.baseline.json
@@ -1,16 +1,16 @@
 {
   "_comment": "Rendered size of the extraction prompts with an EMPTY context, in bytes. Regenerate deliberately with `npm run check:prompt-budget -- --update-baseline` in the same commit as the prompt change, so growth arrives as a reviewable diff. See scripts/check-prompt-budget.ts and issue #197.",
-  "generatedAt": "2026-07-31T08:39:35.541Z",
+  "generatedAt": "2026-07-31T08:54:23.802Z",
   "totals": {
-    "ingest": 137635,
-    "reextract": 85260
+    "ingest": 141555,
+    "reextract": 86272
   },
   "modules": {
     "line-item-prompt.ts": 38269,
     "brand-icon-prompt.ts": 14889,
     "prompt-contract.ts": 14411,
     "document-read-prompt.ts": 2458,
-    "items-sql.ts": 5979,
-    "prompt.ts (inline)": 61629
+    "items-sql.ts": 6054,
+    "prompt.ts (inline)": 65474
   }
 }

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -672,19 +672,56 @@ in this order so you can read the output positionally:
 
   -- (4) near-duplicate candidates: Phase 4a.0. Use YOUR extracted
   --     values; the ±3-day window covers settlement-date drift.
-  SELECT t.id, t.payee, t.occurred_on,
-         t.metadata->>'order_number'  AS order_number,
-         t.metadata->>'payment_id'    AS payment_id,
-         t.metadata->>'approval_code' AS approval_code,
-         t.metadata->>'payment'       AS payment
-    FROM transactions t
-    JOIN postings p ON p.transaction_id = t.id AND p.amount_minor > 0
-   WHERE t.workspace_id = '${ctx.workspaceId}'
-     AND t.status IN ('posted','reconciled')
-     AND t.occurred_on BETWEEN DATE '<YYYY-MM-DD>' - 3 AND DATE '<YYYY-MM-DD>' + 3
-   GROUP BY t.id
-  HAVING SUM(p.amount_minor) = <TOTAL_MINOR>
-   LIMIT 5;
+  --
+  --     TWO independent candidate paths, UNIONed. Amount alone is not
+  --     enough: it has zero discriminating power at $0 (#205), and the
+  --     old query's "amount_minor > 0" join meant a zero-total
+  --     transaction produced no rows and could never be a candidate at
+  --     all — so re-uploading a $0 document wrote a new row every time.
+  --     Conversely amount alone over-matches: five distinct $0 Amazon
+  --     orders on one day are five real orders, not duplicates, and only
+  --     the identifier can say so.
+  --
+  --     Substitute <IDENTS> with a comma-separated quoted list of every
+  --     identifier value YOU extracted, or omit branch (b) if you found
+  --     none. Identifier keys are the contract in Phase 4a.0 (#204).
+  SELECT * FROM (
+    -- (a) same amount, near date — the classic re-upload of a priced receipt
+    SELECT t.id, t.payee, t.occurred_on, 'amount' AS matched_on,
+           t.metadata->>'order_number'        AS order_number,
+           t.metadata->>'confirmation_number' AS confirmation_number,
+           t.metadata->>'invoice_number'      AS invoice_number,
+           t.metadata->>'payment_id'          AS payment_id,
+           t.metadata->>'approval_code'       AS approval_code
+      FROM transactions t
+      JOIN postings p ON p.transaction_id = t.id AND p.amount_minor >= 0
+     WHERE t.workspace_id = '${ctx.workspaceId}'
+       AND t.status IN ('posted','reconciled')
+       AND t.deleted_at IS NULL
+       AND t.occurred_on BETWEEN DATE '<YYYY-MM-DD>' - 3 AND DATE '<YYYY-MM-DD>' + 3
+     GROUP BY t.id
+    HAVING SUM(p.amount_minor) FILTER (WHERE p.amount_minor > 0) = <TOTAL_MINOR>
+        OR (<TOTAL_MINOR> = 0 AND SUM(ABS(p.amount_minor)) = 0)
+    UNION
+    -- (b) shared identifier, ANY amount, wider window. An order number is
+    --     stronger evidence than an amount and survives a re-issued or
+    --     partially-refunded document, so it is not date-bounded as tightly.
+    SELECT t.id, t.payee, t.occurred_on, 'identifier' AS matched_on,
+           t.metadata->>'order_number', t.metadata->>'confirmation_number',
+           t.metadata->>'invoice_number', t.metadata->>'payment_id',
+           t.metadata->>'approval_code'
+      FROM transactions t
+     WHERE t.workspace_id = '${ctx.workspaceId}'
+       AND t.status IN ('posted','reconciled')
+       AND t.deleted_at IS NULL
+       AND t.occurred_on BETWEEN DATE '<YYYY-MM-DD>' - 30 AND DATE '<YYYY-MM-DD>' + 30
+       AND (t.metadata->>'order_number' IN (<IDENTS>)
+         OR t.metadata->>'confirmation_number' IN (<IDENTS>)
+         OR t.metadata->>'invoice_number' IN (<IDENTS>)
+         OR t.metadata->>'payment_id' IN (<IDENTS>)
+         OR t.metadata->>'approval_code' IN (<IDENTS>))
+  ) cand
+   LIMIT 10;
   SQL
 
 psql prints the result sets in order. Read them once, then branch:
@@ -764,6 +801,37 @@ The same purchase may already be in the ledger via another copy
 (re-shot photo, re-scanned PDF) or another evidence channel (the email
 for a PDF you're holding, the invoice for a receipt). Inserting again
 double-counts the money. Decide attach-vs-insert as follows.
+
+── Identifier keys — a CLOSED contract, not free choice (#204) ────────
+
+A printed reference number is the single strongest dedup signal there
+is: it survives a re-shot photo, a different evidence channel, a
+partial refund, and a $0 total, none of which an amount survives. It
+only works if the writer and the reader agree on the key, so the key
+set is fixed. Store every identifier you find under EXACTLY one of:
+
+  order_number         Amazon/Newegg order refs, restaurant order or
+                       check numbers, POS transaction numbers
+  confirmation_number  hotel and travel confirmations, booking refs
+  invoice_number       invoices and folios, "Invoice #", Apple's
+                       Invoice Number, contractor bills
+  payment_id           processor ids — Square, Stripe, PayPal
+  approval_code        card auth / approval codes
+
+Rules that make this a contract rather than a suggestion:
+  * NEVER invent a sixth key. A number under a key nobody reads is
+    invisible to dedup, which is the exact failure this replaces —
+    invoice_number was on 61 transactions and confirmation_number on 17,
+    and the query read neither.
+  * When a document prints something that fits none of them, put it in
+    metadata under any name you like, but ALSO copy it to the closest
+    key above. Findable beats tidy.
+  * Never put a SKU, serial number, tracking number, loyalty number or
+    store number in these keys. They identify a product, a shipment or a
+    place — not this purchase — and dedup comparing them silently
+    matches unrelated transactions.
+  * Values are compared as text, verbatim as printed. Do not strip
+    leading zeros, dashes or prefixes.
 
 Perceptually-similar existing documents (pHash, candidate-surfacing
 ONLY — same-app screenshots of DIFFERENT purchases can land here, so


### PR DESCRIPTION
Closes #204. Closes #205. Two halves of one failure: the near-dup check compared **amounts**, and the field that would actually discriminate was neither written to a known key nor read by the query.

## #205 — a $0 document could never be a duplicate candidate

The candidate query joined `postings ON p.amount_minor > 0`. A zero-total transaction has **no positive posting**, so the join produced no rows and the transaction never appeared as a candidate *at all*. Re-uploading the same $0 document wrote a new row every single time.

Fixing only the join isn't enough either: amount-equality has no discriminating power at $0, where every zero-total transaction in the window matches every other one.

## #204 — nothing defined which metadata key holds an identifier

The query read four keys. Measured on prod 2026-07-29:

| key | transactions | read by the query |
|---|---|---|
| `order_number` | 891 | yes |
| `invoice_number` | 61 | **no** |
| `confirmation_number` | 17 | **no** |

Dedup silently degraded to comparing SKUs and serial numbers. Lesson proposals 107, 108, 111 and 114 were four symptoms of this one cause.

## The fix

The candidate query is now a **UNION of two independent paths**: same amount within ±3 days as before, and **shared identifier within ±30 days at any amount**. An order number survives a re-shot photo, a different evidence channel, a partial refund and a $0 total — none of which an amount survives — so it is the stronger signal and isn't date-bounded as tightly.

Phase 4a.0 gains a **closed five-key contract**: `order_number` · `confirmation_number` · `invoice_number` · `payment_id` · `approval_code`. Closed is the point — a number under a key nobody reads is invisible, which is the bug being replaced. It also forbids SKUs, serials, tracking and loyalty numbers in these keys: those identify a product or shipment rather than *this purchase*, and comparing them silently matches unrelated transactions.

## I audited the existing data first — and 30 of the 31 "duplicates" are real

The issue reported 31 suspected-duplicate `(payee, occurred_on)` groups among the 213 zero-total transactions.

| Verdict | Groups |
|---|---|
| Distinct orders — **not** duplicates | **30** |
| Genuinely ambiguous | **1** |

All 30 clean groups are Amazon, and every transaction within each carries a **different** `order_number`. Several $0 Amazon orders on one day is just what Amazon does. The one real question is a Hyatt stay (2022-10-28): two different documents, one with confirmation `59746723` and one with no identifier.

**Per the owner's instruction, nothing was merged.** Full list at `admin/zero-total-dedup-audit-20260731.{md,csv}` in the outer project.

That 30-of-31 result is itself the argument for the identifier branch: at $0 the only thing separating those orders *is* the order number, so the old design could only have flagged all 30 or found none.

## Verification

Read-only against prod — a simulated $0 upload on 2025-07-11:

```
1cdedb26  Amazon  2025-07-11  amount  112-8300689-5491429
40fa6cca  Amazon  2025-07-11  amount  112-9031077-6722631
4277b26a  Amazon  2025-07-10  amount  113-0053255-6080222
462e3f98  Amazon  2025-07-11  amount  112-6015680-6397856
acb25188  Amazon  2025-07-11  amount  112-8817007-2424253
e59643d9  Amazon  2025-07-11  amount  112-5622516-5590667
```

**6 candidates where the old query returned 0**, each carrying its distinct order number so the tree concludes "no identifier match, this is a new order" instead of guessing from the amount.

Prompt budget **+4,932 B** — over the 4,096 B allowance, so #197's gate failed the build and the baseline moves in this diff (`137,635 → 141,555`). That is the mechanism doing exactly what it was built for, on the first change after it landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ssDbfdur7JHRCLfZSQsyx