### PR TITLE
fix(extraction): don't stop at a building when the merchant is the point (#203)

### DIFF
--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -290,7 +290,22 @@ Decision tree (stop at first match):
       "Wing Hop Fung(永合丰)Monterey Park Store" instead of plain
       "Wing Hop Fung").
 
-  (c) Address missing but receipt shows merchant + locality → Find-Place-From-Text:
+      QUALITY GATE — geocoding resolves an ADDRESS, not a BUSINESS, and a
+      street address is not a merchant (#203). If the top result's
+      \`types\` contains "premise", "subpremise", "street_address" or
+      "route", you have found the BUILDING the merchant sits in. Do NOT
+      accept it. Fall through to (c) and re-query by name, then:
+        keep the (c) result when it returns a candidate whose
+        formatted_address passes the same locality validation below;
+        keep the (b) premise ONLY if (c) also fails.
+      Symptom this prevents: the transaction links to a place with no
+      business name, no rating, no phone, no photos and no hours — which
+      is every field the place record exists to hold. Reported 10 times
+      independently across hotels, Costco warehouses, restaurants and
+      auto shops, with zero counter-examples.
+
+  (c) Address missing, OR (b) hit the quality gate → Find-Place-From-Text.
+      With a full address in hand, query "<merchant name> <locality>":
 
         Q='Wing Hop Fung Monterey Park'
         QS=\$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.stdin.read().strip()))' <<< "\$Q")


### PR DESCRIPTION
Closes #203.

## The bug

Phase 3a's decision tree **stops at the first match**, and branch (b) fires whenever the receipt prints a street address. So Find-Place-From-Text — branch (c) — was unreachable for exactly the receipts that identify themselves best.

Geocoding resolves an **address**, not a **business**. The transaction ends up linked to the building the merchant sits in: no business name, no rating, no phone, no photos, no hours. Every field the place record exists to hold.

## It is not a tail case

Measured on prod, `places.primary_type`:

```
(null)                44
premise               39   <-- buildings, not businesses
hotel                 16
coffee_shop           14
chinese_restaurant    13
```

`premise` is the **second most common** place type in the table.

## The fix

Branch (b) gains a quality gate: when the top geocode result's `types` contains `premise` / `subpremise` / `street_address` / `route`, it is a building and is not accepted — fall through to (c) and re-query by `<merchant name> <locality>`.

**The premise result is kept only if the name query also fails**, so this can lose nothing: the worst case is exactly today's behavior.

Encoded in the decision tree rather than as a curated lesson, deliberately — a lesson would make the agent work around the tree on every single ingest, which is why this was held back from the batch-2 promotion (#207).

Reported **10 times independently** in the runtime lesson proposals (3, 7, 43, 62, 86, 100, 117, 118, 124) across hotels, Costco warehouses, restaurants and independent auto shops, with **zero counter-examples**.

Prompt budget +928 B, inside the 4,096 B allowance; baseline deliberately not updated so growth keeps accumulating against it (#197).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ssDbfdur7JHRCLfZSQsyx