### PR TITLE
test(eval): add text-layer PDF fixtures, and measure what #181 actually did

### DIFF
--- a/scripts/eval-dates.fixtures.json
+++ b/scripts/eval-dates.fixtures.json
@@ -3,7 +3,13 @@
     "sha256": "8e4239477e236ffa798d742f51c45b7c3e46fc590810de647f735d4e0c288a04",
     "original_filename": "2025-09-30_Receipt_Wilson_wristband_classic_navy_x2_26.28.jpeg",
     "bucket": "hard_date",
-    "ground_truth": { "date": "2025-09-30", "merchant_tokens": ["wilson"], "total_minor": 2628 },
+    "ground_truth": {
+      "date": "2025-09-30",
+      "merchant_tokens": [
+        "wilson"
+      ],
+      "total_minor": 2628
+    },
     "expected_status": "done",
     "notes": "The original #27 case. 09/30 read as 09/03. Deterministic across 3 Phase 2.5 rounds (2026-04-21 comment) — digit-order read error, prompt layer cannot reach."
   },
@@ -11,7 +17,15 @@
     "sha256": "e4756c65fb691e32c4b3235ed46b6b5571bffcf719eafd8adf4811cf89dfe475",
     "original_filename": "2025-09-20_Receipt_WingHopFung_black_pearl_wine_40.99.jpeg",
     "bucket": "hard_all",
-    "ground_truth": { "date": "2025-09-20", "merchant_tokens": ["wing", "hop", "fung"], "total_minor": 4099 },
+    "ground_truth": {
+      "date": "2025-09-20",
+      "merchant_tokens": [
+        "wing",
+        "hop",
+        "fung"
+      ],
+      "total_minor": 4099
+    },
     "expected_status": "done",
     "notes": "Pathological fixture — faded thermal paper. Across 3 rounds (2026-04-21) stressed date, total, AND merchant simultaneously. Non-deterministic. Gold-standard regression marker."
   },
@@ -19,7 +33,13 @@
     "sha256": "56267be6676c0af681b958b29346d8302f312170819ddd6da964e9427befe2b1",
     "original_filename": "2025-12-01_Receipt_Marukai_groceries_97.72.jpeg",
     "bucket": "hard_date",
-    "ground_truth": { "date": "2025-12-01", "merchant_tokens": ["marukai"], "total_minor": 9772 },
+    "ground_truth": {
+      "date": "2025-12-01",
+      "merchant_tokens": [
+        "marukai"
+      ],
+      "total_minor": 9772
+    },
     "expected_status": "done",
     "notes": "Day digit misread (01 → 11)."
   },
@@ -27,7 +47,14 @@
     "sha256": "2bf4026fa87080003a5d212a1e2bf096cb2fb3acc1e8a87d91a01ededec71469",
     "original_filename": "2025-12-07_Receipt_CircleK_fuel_unleaded_70.79.jpeg",
     "bucket": "hard_date",
-    "ground_truth": { "date": "2025-12-07", "merchant_tokens": ["circle", "k"], "total_minor": 7079 },
+    "ground_truth": {
+      "date": "2025-12-07",
+      "merchant_tokens": [
+        "circle",
+        "k"
+      ],
+      "total_minor": 7079
+    },
     "expected_status": "done",
     "notes": "Day digit misread (07 → 27). Common pump-receipt thermal-print artifact."
   },
@@ -35,7 +62,13 @@
     "sha256": "9e02b5d0b97606a1b344d3b65f75bfd5ba05bf531001c7ff4dc146cd2925e9ae",
     "original_filename": "2025-11-29_Receipt_Haidilao_hotpot_dinner_306.49.jpeg",
     "bucket": "hard_date",
-    "ground_truth": { "date": "2025-11-29", "merchant_tokens": ["haidilao"], "total_minor": 30649 },
+    "ground_truth": {
+      "date": "2025-11-29",
+      "merchant_tokens": [
+        "haidilao"
+      ],
+      "total_minor": 30649
+    },
     "expected_status": "done",
     "notes": "Month digit misread (11 → 10). Rare — month misreads are usually a sign of bad print or printer drift."
   },
@@ -43,7 +76,14 @@
     "sha256": "6f152d024a9be528796f5cec8b0a890d7cc711e31fa202f7fd7fd0eba87a8dab",
     "original_filename": "2025-09-29_Receipt_UrthCaffe_brunch_93.03.jpeg",
     "bucket": "hard_total",
-    "ground_truth": { "date": "2025-09-29", "merchant_tokens": ["urth", "caffe"], "total_minor": 9303 },
+    "ground_truth": {
+      "date": "2025-09-29",
+      "merchant_tokens": [
+        "urth",
+        "caffe"
+      ],
+      "total_minor": 9303
+    },
     "expected_status": "done",
     "notes": "Subtotal-vs-final confusion. Reads $98.03 (pre-tip + suggested-tip column) instead of final $93.03."
   },
@@ -51,7 +91,14 @@
     "sha256": "43cd36eb799a7a969b11ffd8593e4d4f549ed6533038ac985cbeda0b205b3731",
     "original_filename": "2026-02-22_Receipt_TraderJoes_groceries_29.36.jpeg",
     "bucket": "hard_total",
-    "ground_truth": { "date": "2026-02-22", "merchant_tokens": ["trader", "joe"], "total_minor": 2936 },
+    "ground_truth": {
+      "date": "2026-02-22",
+      "merchant_tokens": [
+        "trader",
+        "joe"
+      ],
+      "total_minor": 2936
+    },
     "expected_status": "done",
     "notes": "Single-digit total misread (29.36 → 39.36)."
   },
@@ -59,7 +106,13 @@
     "sha256": "23494391be93197175867bd7d35e6e2578cac42f0d32729978b208612c0194f8",
     "original_filename": "2026-02-27_Receipt_Eataly_black_label_ham_13.00.jpeg",
     "bucket": "hard_total",
-    "ground_truth": { "date": "2026-02-27", "merchant_tokens": ["eataly"], "total_minor": 1300 },
+    "ground_truth": {
+      "date": "2026-02-27",
+      "merchant_tokens": [
+        "eataly"
+      ],
+      "total_minor": 1300
+    },
     "expected_status": "done",
     "notes": "Total read as half of correct value (13.00 → 6.50). Likely a unit-price vs line-total confusion."
   },
@@ -67,7 +120,15 @@
     "sha256": "8975c08945295d059a74e37ecea21c32b6641e208a62b9d28c7b16b6302588fb",
     "original_filename": "2025-09-10_Receipt_WingOnMarket_charge_slip_64.85.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-09-10", "merchant_tokens": ["wing", "on", "market"], "total_minor": 6485 },
+    "ground_truth": {
+      "date": "2025-09-10",
+      "merchant_tokens": [
+        "wing",
+        "on",
+        "market"
+      ],
+      "total_minor": 6485
+    },
     "expected_status": "done",
     "notes": "Asian-grocery thermal, lots of Chinese characters — historically extracts cleanly."
   },
@@ -75,7 +136,15 @@
     "sha256": "127a4e07980756252e7a4ee64abf80c9ed1ec926bb54c2fe56b09b2a53c18ff3",
     "original_filename": "2025-09-28_Receipt_DongTingXian_dine_in_135.22.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-09-28", "merchant_tokens": ["dong", "ting", "xian"], "total_minor": 13522 },
+    "ground_truth": {
+      "date": "2025-09-28",
+      "merchant_tokens": [
+        "dong",
+        "ting",
+        "xian"
+      ],
+      "total_minor": 13522
+    },
     "expected_status": "done",
     "notes": "Dine-in receipt with tip line — historically clean."
   },
@@ -83,7 +152,14 @@
     "sha256": "db9ed4575a388b2c1928d97d69f091ebb262f3611129bd243fbc57ac616262a8",
     "original_filename": "2025-10-18_Receipt_99Ranch_san_gabriel_groceries_131.12.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-10-18", "merchant_tokens": ["99", "ranch"], "total_minor": 13112 },
+    "ground_truth": {
+      "date": "2025-10-18",
+      "merchant_tokens": [
+        "99",
+        "ranch"
+      ],
+      "total_minor": 13112
+    },
     "expected_status": "done",
     "notes": "99 Ranch — payee extraction historically resolves to store number; substring match is enough."
   },
@@ -91,7 +167,15 @@
     "sha256": "1c017723268d25781cc4775db86ff66cbb452929f656cbe14a90590a9698bc9a",
     "original_filename": "2025-10-18_Receipt_LeYuenBBQ_bbq_63.91.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-10-18", "merchant_tokens": ["le", "yuen", "bbq"], "total_minor": 6391 },
+    "ground_truth": {
+      "date": "2025-10-18",
+      "merchant_tokens": [
+        "le",
+        "yuen",
+        "bbq"
+      ],
+      "total_minor": 6391
+    },
     "expected_status": "done",
     "notes": ""
   },
@@ -99,7 +183,13 @@
     "sha256": "b6a5fdd1615f0427f4577ad2f495a51df0dd23a2bec711f52cd9777df8919df2",
     "original_filename": "2025-10-22_Receipt_Yoshinoya_beef_combo_bowls_21.03.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-10-22", "merchant_tokens": ["yoshinoya"], "total_minor": 2103 },
+    "ground_truth": {
+      "date": "2025-10-22",
+      "merchant_tokens": [
+        "yoshinoya"
+      ],
+      "total_minor": 2103
+    },
     "expected_status": "done",
     "notes": ""
   },
@@ -107,7 +197,14 @@
     "sha256": "2879a616fd25054e87e7e779d4efe2d6a158e55cb309399cb518f5dd5dbfdc82",
     "original_filename": "2025-10-27_Receipt_TraderJoes_milk_cinnamon_pumpkin_10.58.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-10-27", "merchant_tokens": ["trader", "joe"], "total_minor": 1058 },
+    "ground_truth": {
+      "date": "2025-10-27",
+      "merchant_tokens": [
+        "trader",
+        "joe"
+      ],
+      "total_minor": 1058
+    },
     "expected_status": "done",
     "notes": ""
   },
@@ -115,7 +212,14 @@
     "sha256": "38278bbaf8f85d97cc9d7b74824ebaab869aae73ce1041b1a54782d69cb96514",
     "original_filename": "2025-11-02_Receipt_KellysCoffeeAndFudge_cafe_latte_5.75.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-11-02", "merchant_tokens": ["kelly", "coffee"], "total_minor": 575 },
+    "ground_truth": {
+      "date": "2025-11-02",
+      "merchant_tokens": [
+        "kelly",
+        "coffee"
+      ],
+      "total_minor": 575
+    },
     "expected_status": "done",
     "notes": "Small total — guards against truncation/zero-pad errors."
   },
@@ -123,7 +227,13 @@
     "sha256": "725c65febd2c3d1ccdcb6dff2f74917252dc5b81c4b2d4e125dc67ebbc059d51",
     "original_filename": "2025-11-04_Receipt_Costco_groceries_47.17.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-11-04", "merchant_tokens": ["costco"], "total_minor": 4717 },
+    "ground_truth": {
+      "date": "2025-11-04",
+      "merchant_tokens": [
+        "costco"
+      ],
+      "total_minor": 4717
+    },
     "expected_status": "done",
     "notes": ""
   },
@@ -131,7 +241,14 @@
     "sha256": "1eb3e55795d0dd606fe61ff8131b1a75789e3c2aeb93c00513aacd830c157a67",
     "original_filename": "2025-11-14_Receipt_SunriseNoodleHouse_cantonese_clay_pot_69.94.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-11-14", "merchant_tokens": ["sunrise", "noodle"], "total_minor": 6994 },
+    "ground_truth": {
+      "date": "2025-11-14",
+      "merchant_tokens": [
+        "sunrise",
+        "noodle"
+      ],
+      "total_minor": 6994
+    },
     "expected_status": "done",
     "notes": ""
   },
@@ -139,7 +256,15 @@
     "sha256": "361014b68e7b42d0a4bbebc9d939b0d3dd26299743545794d7937b8defc375a9",
     "original_filename": "2025-11-22_Receipt_WingHopFung_groceries_15.39.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-11-22", "merchant_tokens": ["wing", "hop", "fung"], "total_minor": 1539 },
+    "ground_truth": {
+      "date": "2025-11-22",
+      "merchant_tokens": [
+        "wing",
+        "hop",
+        "fung"
+      ],
+      "total_minor": 1539
+    },
     "expected_status": "done",
     "notes": "Same merchant as the hard_all WingHopFung wine fixture, but a clean print — guards against false-positive prompt fixes that throw the baby out with the bathwater."
   },
@@ -147,7 +272,13 @@
     "sha256": "041098f3b03c9bb19ea4e1de5342e1922cc9f0bfc4a439e99b28e2500e71ba8c",
     "original_filename": "2025-12-01_Receipt_Petco_grooming_bath_97.57.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-12-01", "merchant_tokens": ["petco"], "total_minor": 9757 },
+    "ground_truth": {
+      "date": "2025-12-01",
+      "merchant_tokens": [
+        "petco"
+      ],
+      "total_minor": 9757
+    },
     "expected_status": "done",
     "notes": "Same date as the hard_date Marukai 97.72 fixture — guards against date-fix regressions on receipts with similar timestamps."
   },
@@ -155,7 +286,14 @@
     "sha256": "e5f75d412c4cc3b4b669e5b29c3363395163838d45abaea571703890d4f9a14b",
     "original_filename": "2025-12-08_Receipt_HMart_groceries_107.45.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2025-12-08", "merchant_tokens": ["h", "mart"], "total_minor": 10745 },
+    "ground_truth": {
+      "date": "2025-12-08",
+      "merchant_tokens": [
+        "h",
+        "mart"
+      ],
+      "total_minor": 10745
+    },
     "expected_status": "done",
     "notes": ""
   },
@@ -163,7 +301,13 @@
     "sha256": "6a0f8737fc3c97746600e56baa078d18b1a386d740591a16f493e6aa12abbe86",
     "original_filename": "2026-02-12_Receipt_KFC_zinger_sandwich_15.34.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2026-02-12", "merchant_tokens": ["kfc"], "total_minor": 1534 },
+    "ground_truth": {
+      "date": "2026-02-12",
+      "merchant_tokens": [
+        "kfc"
+      ],
+      "total_minor": 1534
+    },
     "expected_status": "done",
     "notes": ""
   },
@@ -171,7 +315,14 @@
     "sha256": "86c4005c35cbe4a1b779eddc2753aa12be4853091831cc0263d61ca9ff472061",
     "original_filename": "2026-03-06_Receipt_Costco_gas_marina_del_rey_73.78.jpeg",
     "bucket": "good",
-    "ground_truth": { "date": "2026-03-06", "merchant_tokens": ["costco", "gas"], "total_minor": 7378 },
+    "ground_truth": {
+      "date": "2026-03-06",
+      "merchant_tokens": [
+        "costco",
+        "gas"
+      ],
+      "total_minor": 7378
+    },
     "expected_status": "done",
     "notes": "CLAUDE.md-flagged historically-hard fixture (gas pump receipts), but extracts cleanly under current pipeline — guards against regressions if prompt evolves."
   },
@@ -179,8 +330,44 @@
     "sha256": "3a81863b580828192134c22afed6989bac5b9bec0ae010fb6e892ac446a94450",
     "original_filename": "2026-03-25_Receipt_EuclidCoffee_iced_latte_8.00.jpeg",
     "bucket": "hard_total",
-    "ground_truth": { "date": "2026-03-25", "merchant_tokens": ["euclid", "coffee"], "total_minor": 800 },
+    "ground_truth": {
+      "date": "2026-03-25",
+      "merchant_tokens": [
+        "euclid",
+        "coffee"
+      ],
+      "total_minor": 800
+    },
     "expected_status": "done",
     "notes": "Handwritten tip on small cafe receipt; pipeline reads pre-tip $5.59 / $6.59 lines as total instead of the final $8.00. Non-deterministic across runs (2026-04-19 issue comment)."
+  },
+  {
+    "sha256": "13116686efd5219fd0cfd8f5262dbbb823c09ea7aa2f1891fc04912922d7ccec",
+    "original_filename": "2026-07-24_Receipt_DeltaHotelsPhiladelphiaAirport_178.71.pdf",
+    "bucket": "good",
+    "ground_truth": {
+      "date": "2026-07-24",
+      "merchant_tokens": [
+        "delta",
+        "philadelphia"
+      ],
+      "total_minor": 17871
+    },
+    "expected_status": "done",
+    "notes": "TEXT-LAYER PDF (#189). pdftotext -layout yields 1,732 B containing merchant, date and total, so #181 lever A must take the text path and never invoke pdftoppm. Ground truth read off the document itself: 'Fri, Jul 24, 2026 - Sat, Jul 25, 2026 / 178.71 USD', confirmation 93934392. Added because all 23 original fixtures are JPEGs and therefore cannot exercise lever A at all."
+  },
+  {
+    "sha256": "ab93da29a9718dc916d26b0c50551e09dbb8ed57bc3a7a39694b9f7fcc7ca6ae",
+    "original_filename": "2026-07-10_Receipt_ValvolineInstantOilChange_184.25.pdf",
+    "bucket": "hard_total",
+    "ground_truth": {
+      "date": "2026-07-10",
+      "merchant_tokens": [
+        "valvoline"
+      ],
+      "total_minor": 18425
+    },
+    "expected_status": "done",
+    "notes": "TEXT-LAYER PDF (#189), 5,460 B. Deliberately a hard_total: the invoice prints FOUR competing subtotals in one column — Subtotal 176.55, Parts Subtotal 102.29, Labor Subtotal 74.26, Total 184.25 — so a text-layer read that linearizes the column badly picks the wrong one. This is the case that catches lever A degrading accuracy rather than merely skipping a render. Ground truth from the document: Invoice 129724, 07/10/2026, Total 184.25."
   }
 ]


### PR DESCRIPTION
Refs #189, #181, #197, #193.

## Why

All 23 existing fixtures are JPEGs. A JPEG has no text layer, so the harness **could not exercise #181's lever A at all** — the acceptance criterion was unverifiable with the corpus we had.

## Two real production PDFs, ground truth read off the documents

| Fixture | Bucket | Text layer | Ground truth |
|---|---|---|---|
| Delta Hotels Philadelphia Airport | `good` | 1,732 B | 2026-07-24, $178.71 |
| Valvoline Instant Oil Change | `hard_total` | 5,460 B | 2026-07-10, $184.25 |

Valvoline is deliberately `hard_total`: the invoice prints **four competing subtotals in one column** — Subtotal 176.55, Parts 102.29, Labor 74.26, Total 184.25. A text read that linearizes the column badly picks the wrong one. That is the fixture that catches lever A *degrading accuracy* rather than merely skipping a render, which is the actual risk the token work introduced.

## Ran it. Lever A passes; the token AC does not.

Executed end-to-end in the sandbox — safely, now that #193 pinned the compose project names. **Prod was verified untouched before and after**, which incidentally validates that fix under the exact operation that previously deleted production.

**Lever A — PASS**

```
pdftoppm invoked      0     <- the AC
image content blocks  0
pdftotext invoked     1
```

The agent ran `pdftotext`, `Read` the text file, and never rasterized. Worth recording the measurement trap: grepping the session JSONL for `pdftoppm` returns **4** hits, every one of them the *prompt* describing its own fallback branch. Only `tool_use` blocks count.

**Token AC — FAIL, 2,728,016 vs the < ~200,000 target**

Essentially unchanged from the 2,700,355 baseline #181 set out to fix. The breakdown says exactly why:

```
fresh input        53 tokens        <- caching is working perfectly
cache_read      2,727,963
cache_creation    221,327
per turn        18,062 -> 117,782   across 28 turns
```

**The cost was never the images.** It is the 142,483 B prompt — roughly 36K tokens — re-read from cache on every one of 28 turns. Lever B did cut tool calls to 10, but turn count did not follow, and the prompt is a fixed multiplier on all of them.

The floor for the current prompt is about `36K × turns`, so ~200K is unreachable without either ~5 turns or a materially smaller prompt. #181 closed on the strength of the re-extract path (4–11 turns, 250K–875K); the ingest path never got there, and nobody had measured it on a PDF.

## This reframes #197

Prompt bytes are **multiplied by turn count** in the bill. A ratchet on prompt size is therefore a ratchet on cost, not just on crash risk — which makes the gate landed in #197 considerably more valuable than it looked when the argument was only about the argv ceiling.

I've left #189 open with these numbers; the remaining work is a real reduction, not a verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ssDbfdur7JHRCLfZSQsyx