### PR TITLE
feat(ledger): treat loyalty points as a currency, not a $0 charge (#206)

### DIFF
--- a/docs/points-as-currency.md
+++ b/docs/points-as-currency.md
@@ -1,0 +1,271 @@
+# Loyalty points as a currency (#206)
+
+> 積分房一定要算，積分也是另外一種貨幣。
+> — the owner, 2026-07-30
+
+An award stay is real spend. It is simply denominated in a unit that is
+not dollars. Flattening it to `total_minor = 0` — the rule that used to
+live at `src/ingest/prompt.ts:149` — made a 40,500-point hotel night
+invisible in every report. This document records what replaced it, the
+decisions taken along the way, and the two things that still need the
+owner.
+
+**Read this first if you are about to change a valuation number, migrate
+old zero-total rows, or touch `src/fx/`.**
+
+---
+
+## 1. What a points transaction looks like now
+
+A 40,500-point stay at a Hyatt, written by the extraction agent and then
+valued by the worker:
+
+```
+postings
+  debit   Travel (expense)             40500  HYATT_PT   fx_rate 1.7   base  68850
+  credit  World of Hyatt points (asset) -40500  HYATT_PT   fx_rate 1.7   base -68850
+```
+
+It balances natively — `postings_balance_ck` is untouched and was never
+modified for this feature — and it shows up as $688.50 of Travel spend
+rather than as nothing at all.
+
+A folio that charges points *and* cash (a resort fee) gets two posting
+pairs, one per currency; each balances within itself.
+
+---
+
+## 2. Decision: per-programme currency codes, `<ISSUER>_PT`
+
+`HYATT_PT`, `BONVOY_PT`, `AA_PT`. Cash stays ISO 4217. The two namespaces
+are disjoint **by shape** — `^[A-Z]{3}$` versus
+`^[A-Z][A-Z0-9]{1,12}_PT$` — and enforced by CHECK constraints on
+`postings.currency` and `accounts.currency`
+(`drizzle/0038_points_as_currency.sql`).
+
+*Why not a single generic `POINTS` discriminated by account?* A currency
+code asserts fungibility: any two units of it may be added together.
+40,500 Hyatt points and 12,000 AA miles cannot, and a shared code would
+let every per-currency sum silently add them.
+
+*Why not squat on the ISO X- range (`XHY`)?* It is not free. `XCD`,
+`XOF`, `XAF`, `XPF` are circulating currencies; `XAU`, `XAG`, `XDR` are
+real ISO allocations. It would need a hand-maintained deny-list, and it
+reads as noise.
+
+*Why a suffix rather than a prefix?* Either works; the suffix keeps the
+issuer at the front where it is readable. What matters is the
+underscore, which ISO 4217 cannot produce, so no present or future ISO
+code can ever collide.
+
+`workspaces.base_currency` and `fx_rates.base` / `.quote` were
+deliberately **left** at `char(3)`. That makes "base currency is points"
+and "a points rate in the FX cache" unrepresentable rather than merely
+discouraged.
+
+---
+
+## 3. Decision: points asset accounts, redemption-only
+
+One asset account per programme per workspace: `type='asset'`,
+`subtype='points'`, `currency='HYATT_PT'`, created on first sight by the
+extraction agent's upsert against the partial unique index
+`accounts_points_uq`.
+
+This is forced, not optional: the credit leg of a points redemption has
+to land in an account denominated in points, and crediting the USD
+Credit Card account would be incoherent.
+
+**Only redemption is recorded. Earning is not.** Award nights, card
+spend, promotions and expiry are a separate data source (programme
+statements) that the system does not ingest. So a points account's
+balance is a *tally of points spent*, not a holdings balance —
+consequently **net worth excludes points accounts**, and says so in the
+`points.policy` field of its response. Including them would drag net
+worth down by the value of every award ever redeemed.
+
+Flipping this to full asset tracking later means ingesting earning
+events; the account and the currency code are already in place for it.
+
+---
+
+## 4. Valuation: how `amount_base_minor` is derived
+
+`points_valuations` is workspace-scoped and versioned by
+`effective_from`. The resolver takes the newest row with
+`effective_from <= transactions.occurred_on`, so re-valuing *going
+forward* leaves history at the number it was booked with.
+
+`minor_per_point` is base-currency **minor units per one point** — 1.7
+US cents per Hyatt point is `1.7`. Points have no subunit, so one point
+is one minor unit of its own currency and the conversion is the same
+plain minor→minor multiply that `postings.fx_rate` already means. That
+is why the valuation is written straight into `fx_rate`:
+
+```
+amount_base_minor = round(amount_minor × minor_per_point)
+```
+
+`src/points/valuation.ts` runs from the ingest worker, immediately
+before the FX pass, and stamps provenance on
+`transactions.metadata.points` (which valuation, which effective date,
+what source, and whether it is confirmed).
+
+### This does not touch the `fx_rate IS NULL` path
+
+Four independent reasons, in decreasing order of how hard they are to
+break by accident:
+
+1. **`getRate()` throws on a points code.** `src/fx/rates.ts` refuses
+   outright rather than filtering, so any future caller that forgets to
+   partition fails loudly instead of pricing an award stay off a
+   currency-market feed.
+2. **`fx_rates.base` / `.quote` are `char(3)`.** A points code
+   physically cannot be stored in the FX cache.
+3. **`normalizeTransactionFx` excludes points legs before it ever reads
+   `fx_rate`.** The marker is consulted only for cash legs, so in the
+   cash domain it still means exactly one thing: "needs conversion at a
+   published rate".
+4. **`scripts/backfill-fx.ts` excludes them from its candidate query**
+   for the same reason.
+
+Within the *points* domain `fx_rate` carries its own three-state marker,
+which is separate because the currency shape is: `NULL` = the valuation
+pass has not run (the points backfill marker), `0` = ran and found no
+valuation configured, `> 0` = valued. Zero is always re-tried, so
+configuring a valuation later picks up the stranded rows without
+`force`.
+
+Regression coverage for all of this, including a live CNY→USD conversion
+against the ECB feed, is `scripts/smoke-points.ts`.
+
+---
+
+## 5. ⚠ Numbers the owner must confirm
+
+Exactly one number is currently in the ledger's valuation table, and it
+is **not confirmed**:
+
+| Programme | Value | Source | Status |
+|---|---|---|---|
+| `HYATT_PT` | **1.7 US cents per point** | the example cited in issue #206 itself | `confirmed_at IS NULL` — awaiting the owner |
+
+Nothing else was invented. Any other programme (`BONVOY_PT`, `AA_PT`, …)
+has no valuation row, so its stays are recorded in points, valued at
+zero base, and counted in every report's
+`points.unvalued_transaction_count` — a visible gap, never a silent $0
+of spend.
+
+**What the owner needs to decide:**
+
+1. **Is 1.7 ¢ the right number for Hyatt points?** Every award stay's
+   dollar figure scales linearly with it. Until confirmed, each report
+   states how much of its total depends on it
+   (`points.unconfirmed_base_minor`).
+2. **Which other programmes should be valued, and at what?** Only the
+   ones actually redeemed need a number.
+3. **One valuation for all time, or a schedule?** The table supports
+   dated versions; the seed uses a single row effective from
+   2000-01-01.
+
+To confirm the seeded number as-is:
+
+```sql
+UPDATE points_valuations SET confirmed_at = NOW()
+ WHERE currency = 'HYATT_PT' AND source = 'issue-206-example';
+```
+
+To replace it going forward (history keeps the old number):
+
+```sql
+INSERT INTO points_valuations
+  (workspace_id, currency, quote, effective_from, minor_per_point, source, confirmed_at)
+SELECT id, 'HYATT_PT', 'USD', DATE '2026-08-01', 2.1, 'owner', NOW() FROM workspaces;
+```
+
+To re-value existing transactions after changing a number, run
+`valueTransactionPoints(txId, wsId, { force: true })` over the affected
+ids. Without `force` only unvalued (`fx_rate = 0`) legs are picked up.
+
+---
+
+## 6. Existing data — decision record
+
+The issue reports, measured on prod 2026-07-29: **36** transactions
+carrying points/award metadata and **213** zero-total transactions, 18 of
+them hotel-branded. *(Those counts are from the issue. They have not been
+re-verified here — this branch has no production access.)*
+
+### Decision: nothing is migrated automatically. Neither migration file
+### touches a single existing transaction, posting, or account.
+
+`0038` is DDL only; `0039` inserts into `points_programmes` and
+`points_valuations` and nothing else.
+
+**Why not a bulk UPDATE.** The 213 zero-total rows are not one class:
+
+- genuinely $0 cash events (fully gift-card-funded orders, comped items)
+  — correct as they stand, under both the old rule and the new one;
+- award/points stays wrongly flattened to $0 — wrong, and in scope;
+- documents that should never have become transactions at all.
+
+Only the middle group should change, and **the ledger does not contain
+the information needed to fix it**. The points count lives on the source
+document, not in any column. A SQL migration would have to invent the
+number, which is precisely the failure mode #206 exists to prevent.
+
+**The catch, worth knowing before anyone plans the cleanup.** Re-extract
+will not fix these on its own: it deliberately does not rewrite
+`postings` (see the backend `CLAUDE.md`, "Postings rewrite"). So the
+money stays wrong even after a re-extraction produces the right points
+figure.
+
+**Recommended operation, to be run and reviewed as its own task:**
+
+1. Shortlist candidates — zero-total, hotel-branded or with
+   award/points/redemption wording in `metadata` / `documents.ocr_text`.
+   Expect roughly the 18 hotel-branded rows plus some of the 36
+   metadata-flagged ones; the sets overlap.
+2. Review each one by eye against its source document. Classify as
+   *award stay*, *legitimately $0*, or *should not exist*.
+3. For each confirmed award stay, either soft-delete the $0 transaction
+   and re-upload the document (the new prompt then writes it in points),
+   or correct the postings by hand through the postings endpoints. A
+   soft-deleted row is excluded from the near-dup candidate query
+   (`deleted_at IS NULL`), so the re-upload will not be caught as a
+   duplicate of the row it replaces.
+4. Leave the other two classes alone.
+
+This is deliberately manual. The owner has said existing zero-total data
+must not be merged or rewritten without review, and step 2 is the review.
+
+---
+
+## 7. What reports say
+
+Every `/v1/reports/*` response carries a `points` block
+(`PointsDisclosure` in the OpenAPI spec) with a `policy` sentence stating
+the rule in words, plus the numbers behind it:
+
+| Report | Points treatment |
+|---|---|
+| summary, trends, cashflow | **included** in the base-currency totals; `base_minor` says how much of the total that is, `unconfirmed_base_minor` how much of *that* rests on an unconfirmed valuation, `unvalued_transaction_count` how many contributed nothing |
+| net worth | **excluded** (§3); the block reports the excluded balances so the exclusion is auditable rather than asserted |
+
+---
+
+## 8. Follow-ups not in this change
+
+- **Frontend rendering.** `receipt-assistant-frontend` formats amounts
+  with a currency assumption that predates points codes; a `HYATT_PT`
+  posting needs a display treatment ("40,500 pts ≈ $688.50") and the
+  `points` disclosure block wants surfacing. Separate repo, separate
+  issue.
+- **Points earning.** Turning the redemption-only accounts into real
+  holdings balances (§3).
+- **The existing-data cleanup** of §6.
+- **End-to-end verification on the mini.** Not done here: this branch is
+  local-only by instruction. Everything above is verified against a
+  throwaway Postgres with the real migrations, real constraints and the
+  real ECB feed (`scripts/smoke-points.ts`), which is not the same thing
+  as a real receipt through the real worker.

--- a/drizzle/0038_points_as_currency.sql
+++ b/drizzle/0038_points_as_currency.sql
@@ -1,0 +1,132 @@
+-- ═══════════════════════════════════════════════════════════════════════
+-- #206 — loyalty points become a currency. DDL ONLY.
+--
+-- Owner's decision, 2026-07-30: "積分房一定要算，積分也是另外一種貨幣."
+-- An award stay is real spend denominated in a non-cash unit, so it gets
+-- a currency code and a balanced pair of postings instead of being
+-- flattened to total_minor = 0.
+--
+-- ⚠ This file contains NO DML. The seed rows live in 0039, which sorts
+-- after it, because Drizzle runs every pending migration inside ONE
+-- transaction: a DELETE/UPDATE on transactions/postings queues events for
+-- the DEFERRABLE constraint triggers and a later ALTER TABLE on those
+-- tables then dies with PG 55006 "cannot ALTER TABLE ... has pending
+-- trigger events", rolling back the whole batch and crash-looping the
+-- container on boot (#174, 2026-07-16). Keep DDL and DML in separate,
+-- correctly-ordered files.
+--
+-- ⚠ This migration deliberately does NOT touch a single existing
+-- transaction or posting. The 36 rows carrying points/award metadata and
+-- the 213 zero-total rows keep every value they have today. The decision
+-- record for them is `docs/points-as-currency.md` § "Existing data".
+--
+-- The CREATE TABLE / ALTER COLUMN / FK / index statements are drizzle-kit
+-- generated from `src/schema/{postings,accounts,points_programmes,
+-- points_valuations}.ts`. The CHECK constraints are hand-added, because
+-- Drizzle cannot express them (same arrangement as
+-- `0001_ledger_invariants.sql`).
+-- ═══════════════════════════════════════════════════════════════════════
+
+-- ── Widen the currency columns ─────────────────────────────────────────
+--
+-- char(3) cannot hold `HYATT_PT`. Only the two columns that must carry a
+-- points code are widened:
+--
+--   postings.currency   the leg's own unit
+--   accounts.currency   the per-programme points asset account
+--
+-- Left at char(3) ON PURPOSE, as structural enforcement rather than
+-- convention:
+--
+--   workspaces.base_currency  the base currency must always be cash;
+--                             a narrow column makes "base currency =
+--                             points" unrepresentable.
+--   fx_rates.base / .quote    a points code physically cannot be stored
+--                             in the FX cache, so no points amount can
+--                             ever be derived from a published FX rate.
+--
+-- No values change: every existing code is exactly 3 characters, so the
+-- bpchar → varchar conversion has no padding to strip.
+
+ALTER TABLE "accounts" ALTER COLUMN "currency" SET DATA TYPE varchar(16);--> statement-breakpoint
+ALTER TABLE "postings" ALTER COLUMN "currency" SET DATA TYPE varchar(16);--> statement-breakpoint
+
+-- ── Currency-shape checks: two disjoint namespaces ─────────────────────
+--
+--   cash    ^[A-Z]{3}$                ISO 4217
+--   points  ^[A-Z][A-Z0-9]{1,12}_PT$  underscore, which ISO cannot use
+--
+-- Disjoint by shape, so classifying a code never needs a lookup table and
+-- no future ISO allocation can collide. (Squatting on the X- range would
+-- collide: XCD/XOF/XAF/XPF are circulating currencies and XAU/XAG/XDR are
+-- real ISO allocations.)
+
+ALTER TABLE "postings" DROP CONSTRAINT "postings_currency_shape_ck";--> statement-breakpoint
+ALTER TABLE "postings"
+  ADD CONSTRAINT "postings_currency_shape_ck"
+  CHECK ("currency" ~ '^[A-Z]{3}$' OR "currency" ~ '^[A-Z][A-Z0-9]{1,12}_PT$');--> statement-breakpoint
+ALTER TABLE "accounts" DROP CONSTRAINT "accounts_currency_shape_ck";--> statement-breakpoint
+ALTER TABLE "accounts"
+  ADD CONSTRAINT "accounts_currency_shape_ck"
+  CHECK ("currency" ~ '^[A-Z]{3}$' OR "currency" ~ '^[A-Z][A-Z0-9]{1,12}_PT$');--> statement-breakpoint
+
+-- ── Programme registry (world-level) ───────────────────────────────────
+
+CREATE TABLE "points_programmes" (
+	"code" varchar(16) PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"issuer_brand_id" text,
+	"notes" text,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT NOW() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "points_programmes"
+  ADD CONSTRAINT "points_programmes_code_shape_ck"
+  CHECK ("code" ~ '^[A-Z][A-Z0-9]{1,12}_PT$');--> statement-breakpoint
+
+-- ── Valuations (workspace-scoped, versioned by effective date) ─────────
+--
+-- `minor_per_point` is base-currency MINOR units per one point: 1.7 US
+-- cents per Hyatt point is 1.7. Points have no subunit, so one point is
+-- one minor unit of its own currency and the conversion is the same plain
+-- minor→minor multiply that `postings.fx_rate` already means — which is
+-- why this value is exactly what gets written there.
+--
+-- `confirmed_at IS NULL` marks a number the owner has not signed off on.
+-- Such a valuation is still applied (a stay valued at a marked-provisional
+-- rate is closer to "積分房一定要算" than a stay valued at zero), but every
+-- report discloses how much of its total depends on it.
+
+CREATE TABLE "points_valuations" (
+	"workspace_id" uuid NOT NULL,
+	"currency" varchar(16) NOT NULL,
+	"quote" char(3) NOT NULL,
+	"effective_from" date NOT NULL,
+	"minor_per_point" numeric(20, 10) NOT NULL,
+	"source" text NOT NULL,
+	"confirmed_at" timestamp with time zone,
+	"note" text,
+	"created_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT NOW() NOT NULL,
+	CONSTRAINT "points_valuations_workspace_id_currency_effective_from_pk" PRIMARY KEY("workspace_id","currency","effective_from")
+);
+--> statement-breakpoint
+ALTER TABLE "points_valuations" ADD CONSTRAINT "points_valuations_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "points_valuations" ADD CONSTRAINT "points_valuations_currency_points_programmes_code_fk" FOREIGN KEY ("currency") REFERENCES "public"."points_programmes"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "points_valuations_lookup_idx" ON "points_valuations" USING btree ("workspace_id","currency","effective_from" DESC NULLS LAST);--> statement-breakpoint
+ALTER TABLE "points_valuations"
+  ADD CONSTRAINT "points_valuations_quote_shape_ck"
+  CHECK ("quote" ~ '^[A-Z]{3}$');--> statement-breakpoint
+ALTER TABLE "points_valuations"
+  ADD CONSTRAINT "points_valuations_nonneg_ck"
+  CHECK ("minor_per_point" >= 0);--> statement-breakpoint
+
+-- ── One points asset account per programme per workspace ───────────────
+--
+-- The extraction agent upserts against this partial unique index, so an
+-- award stay for a programme seen for the first time creates its own
+-- credit account inline instead of failing the write for a missing leg.
+
+CREATE UNIQUE INDEX "accounts_points_uq" ON "accounts" USING btree ("workspace_id","currency") WHERE "accounts"."subtype" = 'points';

--- a/drizzle/0039_points_seed.sql
+++ b/drizzle/0039_points_seed.sql
@@ -1,0 +1,52 @@
+-- ═══════════════════════════════════════════════════════════════════════
+-- #206 — seed data. DML ONLY, and it sorts AFTER every DDL statement in
+-- 0038 for the PG 55006 reason documented at the top of that file.
+--
+-- ⚠ Scope of this file, stated so nobody has to infer it from the SQL:
+-- it inserts into `points_programmes` and `points_valuations` and NOTHING
+-- ELSE. It does not read, update, delete, or re-classify any existing
+-- transaction, posting, or account. The 36 transactions carrying
+-- points/award metadata and the 213 zero-total transactions are left
+-- exactly as they are — see `docs/points-as-currency.md` § "Existing
+-- data" for what should happen to them and why that is a separate,
+-- reviewed operation rather than part of this deploy.
+--
+-- ⚠ THE NUMBER BELOW IS NOT CONFIRMED.
+-- 1.7 US cents per Hyatt point is the single example cited in issue #206
+-- itself. It is seeded so the valuation mechanism is exercised end to end
+-- rather than shipped untested, and it is deliberately marked
+-- `confirmed_at = NULL` / `source = 'issue-206-example'` so that:
+--   * every report that includes it discloses how much of its total rests
+--     on an unconfirmed valuation, and
+--   * confirming it is one UPDATE, and changing it is one INSERT with a
+--     later `effective_from` plus a `force` re-run of the valuation pass.
+-- No other programme is seeded. A programme with no valuation row values
+-- its postings at zero base and is counted as `unvalued` in the reports —
+-- a visible gap, never a silent $0 expense.
+-- ═══════════════════════════════════════════════════════════════════════
+
+INSERT INTO "points_programmes" ("code", "name", "issuer_brand_id", "notes")
+VALUES (
+  'HYATT_PT',
+  'World of Hyatt points',
+  'hyatt',
+  'Seeded by #206. The 1.7 cents/point valuation is the example given in the issue and has NOT been confirmed by the owner.'
+)
+ON CONFLICT ("code") DO NOTHING;--> statement-breakpoint
+
+-- effective_from is deliberately the epoch-ish 2000-01-01 rather than the
+-- deploy date: the resolver picks the newest row with
+-- `effective_from <= occurred_on`, so an early date means the seed also
+-- covers any award stay re-ingested from the past. A later re-valuation
+-- is an INSERT with a newer effective_from, which leaves already-valued
+-- history untouched.
+INSERT INTO "points_valuations" (
+  "workspace_id", "currency", "quote", "effective_from",
+  "minor_per_point", "source", "confirmed_at", "note"
+)
+SELECT w."id", 'HYATT_PT', w."base_currency", DATE '2000-01-01',
+       1.7, 'issue-206-example', NULL,
+       'UNCONFIRMED. 1.7 US cents per point, the example cited in #206. Confirm or replace before trusting any total that includes a Hyatt award stay.'
+  FROM "workspaces" w
+ WHERE w."base_currency" = 'USD'
+ON CONFLICT ("workspace_id", "currency", "effective_from") DO NOTHING;

--- a/drizzle/meta/0038_snapshot.json
+++ b/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,4926 @@
+{
+  "id": "4a410bbe-b3d1-43aa-ba56-cf296020d02f",
+  "prevId": "21beb4eb-a8c7-40c7-a04a-df5ae80843a4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_uniq": {
+          "name": "users_email_lower_uniq",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_users_id_fk": {
+          "name": "workspace_members_user_id_users_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_workspace_id_user_id_pk": {
+          "name": "workspace_members_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_owner_id_users_id_fk": {
+          "name": "workspaces_owner_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_balance_minor": {
+          "name": "opening_balance_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "accounts_workspace_idx": {
+          "name": "accounts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_parent_idx": {
+          "name": "accounts_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_workspace_type_idx": {
+          "name": "accounts_workspace_type_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_points_uq": {
+          "name": "accounts_points_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"accounts\".\"subtype\" = 'points'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_workspace_id_workspaces_id_fk": {
+          "name": "accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_parent_id_accounts_id_fk": {
+          "name": "accounts_parent_id_accounts_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narration": {
+          "name": "narration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "txn_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transactions_keyset_idx": {
+          "name": "transactions_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_created_at_keyset_idx": {
+          "name": "transactions_created_at_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_source_ingest_idx": {
+          "name": "transactions_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_trip_idx": {
+          "name": "transactions_trip_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_place_idx": {
+          "name": "transactions_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_merchant_idx": {
+          "name": "transactions_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_workspace_id_workspaces_id_fk": {
+          "name": "transactions_workspace_id_workspaces_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_source_ingest_id_ingests_id_fk": {
+          "name": "transactions_source_ingest_id_ingests_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_place_id_places_id_fk": {
+          "name": "transactions_place_id_places_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_merchant_id_merchants_id_fk": {
+          "name": "transactions_merchant_id_merchants_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_created_by_users_id_fk": {
+          "name": "transactions_created_by_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_assets": {
+      "name": "product_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "agent_relevance": {
+          "name": "agent_relevance",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_notes": {
+          "name": "agent_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uploaded": {
+          "name": "user_uploaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "product_assets_product_hash_uq": {
+          "name": "product_assets_product_hash_uq",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_assets_product_idx": {
+          "name": "product_assets_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_assets_product_id_products_id_fk": {
+          "name": "product_assets_product_id_products_id_fk",
+          "tableFrom": "product_assets",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "product_assets_tier_ck": {
+          "name": "product_assets_tier_ck",
+          "value": "\"product_assets\".\"tier\" IN ('manual_seed','user_upload','agent_fetch')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_purchased_on": {
+          "name": "first_purchased_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_purchased_on": {
+          "name": "last_purchased_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_spent_minor": {
+          "name": "total_spent_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_from_catalog_at": {
+          "name": "retired_from_catalog_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_asset_id": {
+          "name": "preferred_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_asset_chosen_at": {
+          "name": "preferred_asset_chosen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'extraction'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "products_workspace_merchant_key_uq": {
+          "name": "products_workspace_merchant_key_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_class_idx": {
+          "name": "products_workspace_class_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_brand_idx": {
+          "name": "products_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_workspace_merchant_idx": {
+          "name": "products_workspace_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_workspace_id_workspaces_id_fk": {
+          "name": "products_workspace_id_workspaces_id_fk",
+          "tableFrom": "products",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "products_merchant_id_merchants_id_fk": {
+          "name": "products_merchant_id_merchants_id_fk",
+          "tableFrom": "products",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "products_brand_id_brands_brand_id_fk": {
+          "name": "products_brand_id_brands_brand_id_fk",
+          "tableFrom": "products",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "products_item_class_ck": {
+          "name": "products_item_class_ck",
+          "value": "\"products\".\"item_class\" IN ('durable','consumable','food_drink','service','other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transaction_items": {
+      "name": "transaction_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_line_no": {
+          "name": "parent_line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_variant": {
+          "name": "product_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price_minor": {
+          "name": "unit_price_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_total_minor": {
+          "name": "line_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability_tier": {
+          "name": "durability_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_kind": {
+          "name": "food_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'product'"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_minor": {
+          "name": "tax_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tip_share_minor": {
+          "name": "tip_share_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_share_minor": {
+          "name": "discount_share_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_total_minor": {
+          "name": "effective_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "line_total_minor + COALESCE(tax_minor, 0) + COALESCE(tip_share_minor, 0) - COALESCE(discount_share_minor, 0)",
+            "type": "stored"
+          }
+        },
+        "extraction_run": {
+          "name": "extraction_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'extraction'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transaction_items_line_no_run_uq": {
+          "name": "transaction_items_line_no_run_uq",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "extraction_run",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_items_tx_idx": {
+          "name": "transaction_items_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_items_workspace_class_created_idx": {
+          "name": "transaction_items_workspace_class_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_items_workspace_id_workspaces_id_fk": {
+          "name": "transaction_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_items_transaction_id_transactions_id_fk": {
+          "name": "transaction_items_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_items_product_id_products_id_fk": {
+          "name": "transaction_items_product_id_products_id_fk",
+          "tableFrom": "transaction_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.owned_items": {
+      "name": "owned_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_item_id": {
+          "name": "transaction_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_index": {
+          "name": "instance_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_on": {
+          "name": "acquired_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warranty_until": {
+          "name": "warranty_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_days": {
+          "name": "target_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "owned_items_tx_item_instance_uq": {
+          "name": "owned_items_tx_item_instance_uq",
+          "columns": [
+            {
+              "expression": "transaction_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instance_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "owned_items_workspace_product_idx": {
+          "name": "owned_items_workspace_product_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "owned_items_workspace_id_workspaces_id_fk": {
+          "name": "owned_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "owned_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "owned_items_product_id_products_id_fk": {
+          "name": "owned_items_product_id_products_id_fk",
+          "tableFrom": "owned_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "owned_items_transaction_item_id_transaction_items_id_fk": {
+          "name": "owned_items_transaction_item_id_transaction_items_id_fk",
+          "tableFrom": "owned_items",
+          "tableTo": "transaction_items",
+          "columnsFrom": [
+            "transaction_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wish_items": {
+      "name": "wish_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_price_minor": {
+          "name": "target_price_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "planned_days": {
+          "name": "planned_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'someday'"
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "converted_transaction_id": {
+          "name": "converted_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "wish_items_workspace_status_idx": {
+          "name": "wish_items_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wish_items_workspace_id_workspaces_id_fk": {
+          "name": "wish_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "wish_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wish_items_product_id_products_id_fk": {
+          "name": "wish_items_product_id_products_id_fk",
+          "tableFrom": "wish_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wish_items_converted_transaction_id_transactions_id_fk": {
+          "name": "wish_items_converted_transaction_id_transactions_id_fk",
+          "tableFrom": "wish_items",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "converted_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights": {
+      "name": "insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "insights_workspace_dedupe_uq": {
+          "name": "insights_workspace_dedupe_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insights_workspace_active_idx": {
+          "name": "insights_workspace_active_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dismissed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_workspace_id_workspaces_id_fk": {
+          "name": "insights_workspace_id_workspaces_id_fk",
+          "tableFrom": "insights",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_parties": {
+      "name": "transaction_parties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_item_id": {
+          "name": "transaction_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transaction_parties_workspace_brand_idx": {
+          "name": "transaction_parties_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_parties_tx_idx": {
+          "name": "transaction_parties_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_parties_workspace_id_workspaces_id_fk": {
+          "name": "transaction_parties_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_parties",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_parties_transaction_id_transactions_id_fk": {
+          "name": "transaction_parties_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_parties",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_parties_transaction_item_id_transaction_items_id_fk": {
+          "name": "transaction_parties_transaction_item_id_transaction_items_id_fk",
+          "tableFrom": "transaction_parties",
+          "tableTo": "transaction_items",
+          "columnsFrom": [
+            "transaction_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transaction_parties_identity_uq": {
+          "name": "transaction_parties_identity_uq",
+          "nullsNotDistinct": true,
+          "columns": [
+            "transaction_id",
+            "transaction_item_id",
+            "role",
+            "display_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_assets": {
+      "name": "brand_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "agent_relevance": {
+          "name": "agent_relevance",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_notes": {
+          "name": "agent_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uploaded": {
+          "name": "user_uploaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "brand_assets_brand_hash_uq": {
+          "name": "brand_assets_brand_hash_uq",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brand_assets_brand_idx": {
+          "name": "brand_assets_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brand_assets_brand_tier_idx": {
+          "name": "brand_assets_brand_tier_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_assets_brand_id_brands_brand_id_fk": {
+          "name": "brand_assets_brand_id_brands_brand_id_fk",
+          "tableFrom": "brand_assets",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "brand_assets_tier_ck": {
+          "name": "brand_assets_tier_ck",
+          "value": "\"brand_assets\".\"tier\" IN ('itunes','svgl','logo_dev','simple_icons','google_play','user_upload','manual_url')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.brands": {
+      "name": "brands",
+      "schema": "",
+      "columns": {
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_asset_id": {
+          "name": "preferred_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_chose_at": {
+          "name": "user_chose_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "brands_parent_id_brands_brand_id_fk": {
+          "name": "brands_parent_id_brands_brand_id_fk",
+          "tableFrom": "brands",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.postings": {
+      "name": "postings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fx_rate": {
+          "name": "fx_rate",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_base_minor": {
+          "name": "amount_base_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "postings_transaction_idx": {
+          "name": "postings_transaction_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_account_idx": {
+          "name": "postings_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "postings_workspace_idx": {
+          "name": "postings_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "postings_workspace_id_workspaces_id_fk": {
+          "name": "postings_workspace_id_workspaces_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_transaction_id_transactions_id_fk": {
+          "name": "postings_transaction_id_transactions_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postings_account_id_accounts_id_fk": {
+          "name": "postings_account_id_accounts_id_fk",
+          "tableFrom": "postings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of_actual": {
+          "name": "as_of_actual",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_idx": {
+          "name": "fx_rates_pair_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "fx_rates_as_of_base_quote_pk": {
+          "name": "fx_rates_as_of_base_quote_pk",
+          "columns": [
+            "as_of",
+            "base",
+            "quote"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.points_programmes": {
+      "name": "points_programmes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_brand_id": {
+          "name": "issuer_brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.points_valuations": {
+      "name": "points_valuations",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minor_per_point": {
+          "name": "minor_per_point",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "points_valuations_lookup_idx": {
+          "name": "points_valuations_lookup_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "points_valuations_workspace_id_workspaces_id_fk": {
+          "name": "points_valuations_workspace_id_workspaces_id_fk",
+          "tableFrom": "points_valuations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "points_valuations_currency_points_programmes_code_fk": {
+          "name": "points_valuations_currency_points_programmes_code_fk",
+          "tableFrom": "points_valuations",
+          "tableTo": "points_programmes",
+          "columnsFrom": [
+            "currency"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "points_valuations_workspace_id_currency_effective_from_pk": {
+          "name": "points_valuations_workspace_id_currency_effective_from_pk",
+          "columns": [
+            "workspace_id",
+            "currency",
+            "effective_from"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_links": {
+      "name": "document_links",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "document_links_txn_idx": {
+          "name": "document_links_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_links_document_id_documents_id_fk": {
+          "name": "document_links_document_id_documents_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_links_transaction_id_transactions_id_fk": {
+          "name": "document_links_transaction_id_transactions_id_fk",
+          "tableFrom": "document_links",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_links_document_id_transaction_id_pk": {
+          "name": "document_links_document_id_transaction_id_pk",
+          "columns": [
+            "document_id",
+            "transaction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocr_text": {
+          "name": "ocr_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_model_version": {
+          "name": "ocr_model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_meta": {
+          "name": "extraction_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phash": {
+          "name": "phash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_meta": {
+          "name": "source_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "documents_workspace_sha_uniq": {
+          "name": "documents_workspace_sha_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_workspace_message_id_uniq": {
+          "name": "documents_workspace_message_id_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"documents\".\"message_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_kind_idx": {
+          "name": "documents_kind_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_source_ingest_idx": {
+          "name": "documents_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_workspace_live_idx": {
+          "name": "documents_workspace_live_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"documents\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_workspace_id_workspaces_id_fk": {
+          "name": "documents_workspace_id_workspaces_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_source_ingest_id_ingests_id_fk": {
+          "name": "documents_source_ingest_id_ingests_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "ingests",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_events": {
+      "name": "transaction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "txn_events_txn_idx": {
+          "name": "txn_events_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_events_workspace_id_workspaces_id_fk": {
+          "name": "transaction_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_events_transaction_id_transactions_id_fk": {
+          "name": "transaction_events_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transaction_events_actor_id_users_id_fk": {
+          "name": "transaction_events_actor_id_users_id_fk",
+          "tableFrom": "transaction_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "idempotency_keys_uniq": {
+          "name": "idempotency_keys_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_workspace_id_workspaces_id_fk": {
+          "name": "idempotency_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reconcile": {
+          "name": "auto_reconcile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "batches_workspace_created_idx": {
+          "name": "batches_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_status_idx": {
+          "name": "batches_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batches_workspace_id_workspaces_id_fk": {
+          "name": "batches_workspace_id_workspaces_id_fk",
+          "tableFrom": "batches",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingests": {
+      "name": "ingests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ingest_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "produced": {
+          "name": "produced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingests_batch_idx": {
+          "name": "ingests_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_workspace_created_idx": {
+          "name": "ingests_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ingests_status_idx": {
+          "name": "ingests_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingests_workspace_id_workspaces_id_fk": {
+          "name": "ingests_workspace_id_workspaces_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingests_batch_id_batches_id_fk": {
+          "name": "ingests_batch_id_batches_id_fk",
+          "tableFrom": "ingests",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconcile_proposals": {
+      "name": "reconcile_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconcile_proposals_batch_idx": {
+          "name": "reconcile_proposals_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reconcile_proposals_kind_idx": {
+          "name": "reconcile_proposals_kind_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reconcile_proposals_batch_id_batches_id_fk": {
+          "name": "reconcile_proposals_batch_id_batches_id_fk",
+          "tableFrom": "reconcile_proposals",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_photos": {
+      "name": "place_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_photo_name": {
+          "name": "google_photo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width_px": {
+          "name": "width_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_px": {
+          "name": "height_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_attributions": {
+          "name": "author_attributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_extracted": {
+          "name": "ocr_extracted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_reviews": {
+      "name": "place_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_review_name": {
+          "name": "google_review_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_language": {
+          "name": "text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_text": {
+          "name": "original_text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_language": {
+          "name": "original_text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relative_publish_time": {
+          "name": "relative_publish_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_time": {
+          "name": "publish_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_uri": {
+          "name": "author_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_photo_uri": {
+          "name": "author_photo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_taken_at": {
+          "name": "snapshot_taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "google_place_id": {
+          "name": "google_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_name_en": {
+          "name": "display_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh": {
+          "name": "display_name_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_locale": {
+          "name": "display_name_zh_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_source": {
+          "name": "display_name_zh_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_is_native": {
+          "name": "display_name_zh_is_native",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type_display_zh": {
+          "name": "primary_type_display_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maps_type_label_zh": {
+          "name": "maps_type_label_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "types": {
+          "name": "types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_en": {
+          "name": "formatted_address_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_zh": {
+          "name": "formatted_address_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_status": {
+          "name": "business_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_hours": {
+          "name": "business_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_rating_count": {
+          "name": "user_rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "national_phone_number": {
+          "name": "national_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_uri": {
+          "name": "website_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_maps_uri": {
+          "name": "google_maps_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_business_id": {
+          "name": "yelp_business_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_alias": {
+          "name": "yelp_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_price_level": {
+          "name": "yelp_price_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_categories": {
+          "name": "yelp_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_raw_response": {
+          "name": "yelp_raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "places_lat_lng_idx": {
+          "name": "places_lat_lng_idx",
+          "columns": [
+            {
+              "expression": "lat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lng",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "places_google_place_id_unique": {
+          "name": "places_google_place_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_place_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_snapshots": {
+      "name": "place_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "fetched_by_sha": {
+          "name": "fetched_by_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "place_snapshots_place_idx": {
+          "name": "place_snapshots_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "place_snapshots_place_id_places_id_fk": {
+          "name": "place_snapshots_place_id_places_id_fk",
+          "tableFrom": "place_snapshots",
+          "tableTo": "places",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merchants": {
+      "name": "merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_attribution": {
+          "name": "photo_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_status": {
+          "name": "enrichment_status",
+          "type": "merchant_enrichment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enrichment_attempted_at": {
+          "name": "enrichment_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "merchants_workspace_brand_idx": {
+          "name": "merchants_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merchants_workspace_idx": {
+          "name": "merchants_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "merchants_enrichment_pending_idx": {
+          "name": "merchants_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "merchants_workspace_id_workspaces_id_fk": {
+          "name": "merchants_workspace_id_workspaces_id_fk",
+          "tableFrom": "merchants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "merchants_brand_id_brands_brand_id_fk": {
+          "name": "merchants_brand_id_brands_brand_id_fk",
+          "tableFrom": "merchants",
+          "tableTo": "brands",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "merchants_brand_id_format": {
+          "name": "merchants_brand_id_format",
+          "value": "\"merchants\".\"brand_id\" ~ '^[a-z0-9-]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.derivation_events": {
+      "name": "derivation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_git_sha": {
+          "name": "prompt_git_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_keys": {
+          "name": "changed_keys",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "derivation_events_entity_idx": {
+          "name": "derivation_events_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "derivation_events_version_idx": {
+          "name": "derivation_events_version_idx",
+          "columns": [
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "derivation_events_workspace_id_workspaces_id_fk": {
+          "name": "derivation_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "derivation_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "asset",
+        "liability",
+        "equity",
+        "income",
+        "expense"
+      ]
+    },
+    "public.batch_status": {
+      "name": "batch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "extracted",
+        "reconciling",
+        "reconciled",
+        "failed",
+        "reconcile_error"
+      ]
+    },
+    "public.document_kind": {
+      "name": "document_kind",
+      "schema": "public",
+      "values": [
+        "receipt_image",
+        "receipt_email",
+        "receipt_pdf",
+        "statement_pdf",
+        "other"
+      ]
+    },
+    "public.ingest_status": {
+      "name": "ingest_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "done",
+        "error",
+        "unsupported",
+        "dedup",
+        "near_dup"
+      ]
+    },
+    "public.merchant_enrichment_status": {
+      "name": "merchant_enrichment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "not_found",
+        "failed"
+      ]
+    },
+    "public.txn_status": {
+      "name": "txn_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided",
+        "reconciled",
+        "error"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0039_snapshot.json
+++ b/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,4926 @@
+{
+  "id": "6ad3aacb-aa63-41c0-b6ba-b499fcc089ad",
+  "prevId": "4a410bbe-b3d1-43aa-ba56-cf296020d02f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_uniq": {
+          "name": "users_email_lower_uniq",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "workspace_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "workspace_members_user_id_users_id_fk": {
+          "name": "workspace_members_user_id_users_id_fk",
+          "tableFrom": "workspace_members",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_members_workspace_id_user_id_pk": {
+          "name": "workspace_members_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_owner_id_users_id_fk": {
+          "name": "workspaces_owner_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_balance_minor": {
+          "name": "opening_balance_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "accounts_workspace_idx": {
+          "name": "accounts_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "accounts_parent_idx": {
+          "name": "accounts_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "accounts_workspace_type_idx": {
+          "name": "accounts_workspace_type_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "accounts_points_uq": {
+          "name": "accounts_points_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"accounts\".\"subtype\" = 'points'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_workspace_id_workspaces_id_fk": {
+          "name": "accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "accounts",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "accounts_parent_id_accounts_id_fk": {
+          "name": "accounts_parent_id_accounts_id_fk",
+          "tableFrom": "accounts",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "tableTo": "accounts",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narration": {
+          "name": "narration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "txn_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transactions_keyset_idx": {
+          "name": "transactions_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "transactions_created_at_keyset_idx": {
+          "name": "transactions_created_at_keyset_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "transactions_source_ingest_idx": {
+          "name": "transactions_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "transactions_trip_idx": {
+          "name": "transactions_trip_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "transactions_place_idx": {
+          "name": "transactions_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "transactions_merchant_idx": {
+          "name": "transactions_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "transactions_workspace_id_workspaces_id_fk": {
+          "name": "transactions_workspace_id_workspaces_id_fk",
+          "tableFrom": "transactions",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "transactions_source_ingest_id_ingests_id_fk": {
+          "name": "transactions_source_ingest_id_ingests_id_fk",
+          "tableFrom": "transactions",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "tableTo": "ingests",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "transactions_place_id_places_id_fk": {
+          "name": "transactions_place_id_places_id_fk",
+          "tableFrom": "transactions",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "tableTo": "places",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "transactions_merchant_id_merchants_id_fk": {
+          "name": "transactions_merchant_id_merchants_id_fk",
+          "tableFrom": "transactions",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "tableTo": "merchants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "transactions_created_by_users_id_fk": {
+          "name": "transactions_created_by_users_id_fk",
+          "tableFrom": "transactions",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_assets": {
+      "name": "product_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "agent_relevance": {
+          "name": "agent_relevance",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_notes": {
+          "name": "agent_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uploaded": {
+          "name": "user_uploaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "product_assets_product_hash_uq": {
+          "name": "product_assets_product_hash_uq",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "product_assets_product_idx": {
+          "name": "product_assets_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "product_assets_product_id_products_id_fk": {
+          "name": "product_assets_product_id_products_id_fk",
+          "tableFrom": "product_assets",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "product_assets_tier_ck": {
+          "name": "product_assets_tier_ck",
+          "value": "\"product_assets\".\"tier\" IN ('manual_seed','user_upload','agent_fetch')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_purchased_on": {
+          "name": "first_purchased_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_purchased_on": {
+          "name": "last_purchased_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_spent_minor": {
+          "name": "total_spent_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_from_catalog_at": {
+          "name": "retired_from_catalog_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_asset_id": {
+          "name": "preferred_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_asset_chosen_at": {
+          "name": "preferred_asset_chosen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'extraction'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "products_workspace_merchant_key_uq": {
+          "name": "products_workspace_merchant_key_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "products_workspace_class_idx": {
+          "name": "products_workspace_class_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "products_workspace_brand_idx": {
+          "name": "products_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "products_workspace_merchant_idx": {
+          "name": "products_workspace_merchant_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "products_workspace_id_workspaces_id_fk": {
+          "name": "products_workspace_id_workspaces_id_fk",
+          "tableFrom": "products",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "products_merchant_id_merchants_id_fk": {
+          "name": "products_merchant_id_merchants_id_fk",
+          "tableFrom": "products",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "tableTo": "merchants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "products_brand_id_brands_brand_id_fk": {
+          "name": "products_brand_id_brands_brand_id_fk",
+          "tableFrom": "products",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "tableTo": "brands",
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "products_item_class_ck": {
+          "name": "products_item_class_ck",
+          "value": "\"products\".\"item_class\" IN ('durable','consumable','food_drink','service','other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transaction_items": {
+      "name": "transaction_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_no": {
+          "name": "line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_line_no": {
+          "name": "parent_line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_variant": {
+          "name": "product_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price_minor": {
+          "name": "unit_price_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_total_minor": {
+          "name": "line_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_class": {
+          "name": "item_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durability_tier": {
+          "name": "durability_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_kind": {
+          "name": "food_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_type": {
+          "name": "line_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'product'"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_minor": {
+          "name": "tax_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tip_share_minor": {
+          "name": "tip_share_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_share_minor": {
+          "name": "discount_share_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_total_minor": {
+          "name": "effective_total_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "line_total_minor + COALESCE(tax_minor, 0) + COALESCE(tip_share_minor, 0) - COALESCE(discount_share_minor, 0)"
+          }
+        },
+        "extraction_run": {
+          "name": "extraction_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'extraction'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transaction_items_line_no_run_uq": {
+          "name": "transaction_items_line_no_run_uq",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "extraction_run",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "transaction_items_tx_idx": {
+          "name": "transaction_items_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "transaction_items_workspace_class_created_idx": {
+          "name": "transaction_items_workspace_class_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_items_workspace_id_workspaces_id_fk": {
+          "name": "transaction_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_items",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "transaction_items_transaction_id_transactions_id_fk": {
+          "name": "transaction_items_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_items",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "tableTo": "transactions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "transaction_items_product_id_products_id_fk": {
+          "name": "transaction_items_product_id_products_id_fk",
+          "tableFrom": "transaction_items",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.owned_items": {
+      "name": "owned_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_item_id": {
+          "name": "transaction_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_index": {
+          "name": "instance_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_on": {
+          "name": "acquired_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warranty_until": {
+          "name": "warranty_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_days": {
+          "name": "target_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "owned_items_tx_item_instance_uq": {
+          "name": "owned_items_tx_item_instance_uq",
+          "columns": [
+            {
+              "expression": "transaction_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instance_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "owned_items_workspace_product_idx": {
+          "name": "owned_items_workspace_product_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "owned_items_workspace_id_workspaces_id_fk": {
+          "name": "owned_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "owned_items",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "owned_items_product_id_products_id_fk": {
+          "name": "owned_items_product_id_products_id_fk",
+          "tableFrom": "owned_items",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "owned_items_transaction_item_id_transaction_items_id_fk": {
+          "name": "owned_items_transaction_item_id_transaction_items_id_fk",
+          "tableFrom": "owned_items",
+          "columnsFrom": [
+            "transaction_item_id"
+          ],
+          "tableTo": "transaction_items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wish_items": {
+      "name": "wish_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_price_minor": {
+          "name": "target_price_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "planned_days": {
+          "name": "planned_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'someday'"
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "converted_transaction_id": {
+          "name": "converted_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "wish_items_workspace_status_idx": {
+          "name": "wish_items_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "wish_items_workspace_id_workspaces_id_fk": {
+          "name": "wish_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "wish_items",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "wish_items_product_id_products_id_fk": {
+          "name": "wish_items_product_id_products_id_fk",
+          "tableFrom": "wish_items",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "wish_items_converted_transaction_id_transactions_id_fk": {
+          "name": "wish_items_converted_transaction_id_transactions_id_fk",
+          "tableFrom": "wish_items",
+          "columnsFrom": [
+            "converted_transaction_id"
+          ],
+          "tableTo": "transactions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights": {
+      "name": "insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "insights_workspace_dedupe_uq": {
+          "name": "insights_workspace_dedupe_uq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "insights_workspace_active_idx": {
+          "name": "insights_workspace_active_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dismissed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "insights_workspace_id_workspaces_id_fk": {
+          "name": "insights_workspace_id_workspaces_id_fk",
+          "tableFrom": "insights",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_parties": {
+      "name": "transaction_parties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_item_id": {
+          "name": "transaction_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "transaction_parties_workspace_brand_idx": {
+          "name": "transaction_parties_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "transaction_parties_tx_idx": {
+          "name": "transaction_parties_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_parties_workspace_id_workspaces_id_fk": {
+          "name": "transaction_parties_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_parties",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "transaction_parties_transaction_id_transactions_id_fk": {
+          "name": "transaction_parties_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_parties",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "tableTo": "transactions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "transaction_parties_transaction_item_id_transaction_items_id_fk": {
+          "name": "transaction_parties_transaction_item_id_transaction_items_id_fk",
+          "tableFrom": "transaction_parties",
+          "columnsFrom": [
+            "transaction_item_id"
+          ],
+          "tableTo": "transaction_items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transaction_parties_identity_uq": {
+          "name": "transaction_parties_identity_uq",
+          "columns": [
+            "transaction_id",
+            "transaction_item_id",
+            "role",
+            "display_name"
+          ],
+          "nullsNotDistinct": true
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_assets": {
+      "name": "brand_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "agent_relevance": {
+          "name": "agent_relevance",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_notes": {
+          "name": "agent_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_version": {
+          "name": "extraction_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uploaded": {
+          "name": "user_uploaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_notes": {
+          "name": "user_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "brand_assets_brand_hash_uq": {
+          "name": "brand_assets_brand_hash_uq",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brand_assets_brand_idx": {
+          "name": "brand_assets_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "brand_assets_brand_tier_idx": {
+          "name": "brand_assets_brand_tier_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "brand_assets_brand_id_brands_brand_id_fk": {
+          "name": "brand_assets_brand_id_brands_brand_id_fk",
+          "tableFrom": "brand_assets",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "tableTo": "brands",
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "brand_assets_tier_ck": {
+          "name": "brand_assets_tier_ck",
+          "value": "\"brand_assets\".\"tier\" IN ('itunes','svgl','logo_dev','simple_icons','google_play','user_upload','manual_url')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.brands": {
+      "name": "brands",
+      "schema": "",
+      "columns": {
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_asset_id": {
+          "name": "preferred_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_chose_at": {
+          "name": "user_chose_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "brands_parent_id_brands_brand_id_fk": {
+          "name": "brands_parent_id_brands_brand_id_fk",
+          "tableFrom": "brands",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "tableTo": "brands",
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.postings": {
+      "name": "postings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor": {
+          "name": "amount_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fx_rate": {
+          "name": "fx_rate",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_base_minor": {
+          "name": "amount_base_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "postings_transaction_idx": {
+          "name": "postings_transaction_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "postings_account_idx": {
+          "name": "postings_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "postings_workspace_idx": {
+          "name": "postings_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "postings_workspace_id_workspaces_id_fk": {
+          "name": "postings_workspace_id_workspaces_id_fk",
+          "tableFrom": "postings",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "postings_transaction_id_transactions_id_fk": {
+          "name": "postings_transaction_id_transactions_id_fk",
+          "tableFrom": "postings",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "tableTo": "transactions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "postings_account_id_accounts_id_fk": {
+          "name": "postings_account_id_accounts_id_fk",
+          "tableFrom": "postings",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "tableTo": "accounts",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "as_of": {
+          "name": "as_of",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base": {
+          "name": "base",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of_actual": {
+          "name": "as_of_actual",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "fx_rates_pair_idx": {
+          "name": "fx_rates_pair_idx",
+          "columns": [
+            {
+              "expression": "base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "fx_rates_as_of_base_quote_pk": {
+          "name": "fx_rates_as_of_base_quote_pk",
+          "columns": [
+            "as_of",
+            "base",
+            "quote"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.points_programmes": {
+      "name": "points_programmes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(16)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_brand_id": {
+          "name": "issuer_brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.points_valuations": {
+      "name": "points_valuations",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minor_per_point": {
+          "name": "minor_per_point",
+          "type": "numeric(20, 10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "points_valuations_lookup_idx": {
+          "name": "points_valuations_lookup_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "points_valuations_workspace_id_workspaces_id_fk": {
+          "name": "points_valuations_workspace_id_workspaces_id_fk",
+          "tableFrom": "points_valuations",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "points_valuations_currency_points_programmes_code_fk": {
+          "name": "points_valuations_currency_points_programmes_code_fk",
+          "tableFrom": "points_valuations",
+          "columnsFrom": [
+            "currency"
+          ],
+          "tableTo": "points_programmes",
+          "columnsTo": [
+            "code"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "points_valuations_workspace_id_currency_effective_from_pk": {
+          "name": "points_valuations_workspace_id_currency_effective_from_pk",
+          "columns": [
+            "workspace_id",
+            "currency",
+            "effective_from"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_links": {
+      "name": "document_links",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "document_links_txn_idx": {
+          "name": "document_links_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "document_links_document_id_documents_id_fk": {
+          "name": "document_links_document_id_documents_id_fk",
+          "tableFrom": "document_links",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "tableTo": "documents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "document_links_transaction_id_transactions_id_fk": {
+          "name": "document_links_transaction_id_transactions_id_fk",
+          "tableFrom": "document_links",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "tableTo": "transactions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_links_document_id_transaction_id_pk": {
+          "name": "document_links_document_id_transaction_id_pk",
+          "columns": [
+            "document_id",
+            "transaction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocr_text": {
+          "name": "ocr_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_model_version": {
+          "name": "ocr_model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_meta": {
+          "name": "extraction_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phash": {
+          "name": "phash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_meta": {
+          "name": "source_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ingest_id": {
+          "name": "source_ingest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "documents_workspace_sha_uniq": {
+          "name": "documents_workspace_sha_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "documents_workspace_message_id_uniq": {
+          "name": "documents_workspace_message_id_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"documents\".\"message_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "documents_kind_idx": {
+          "name": "documents_kind_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "documents_source_ingest_idx": {
+          "name": "documents_source_ingest_idx",
+          "columns": [
+            {
+              "expression": "source_ingest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "documents_workspace_live_idx": {
+          "name": "documents_workspace_live_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"documents\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "documents_workspace_id_workspaces_id_fk": {
+          "name": "documents_workspace_id_workspaces_id_fk",
+          "tableFrom": "documents",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "documents_source_ingest_id_ingests_id_fk": {
+          "name": "documents_source_ingest_id_ingests_id_fk",
+          "tableFrom": "documents",
+          "columnsFrom": [
+            "source_ingest_id"
+          ],
+          "tableTo": "ingests",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_events": {
+      "name": "transaction_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "txn_events_txn_idx": {
+          "name": "txn_events_txn_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_events_workspace_id_workspaces_id_fk": {
+          "name": "transaction_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "transaction_events",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "transaction_events_transaction_id_transactions_id_fk": {
+          "name": "transaction_events_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_events",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "tableTo": "transactions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "transaction_events_actor_id_users_id_fk": {
+          "name": "transaction_events_actor_id_users_id_fk",
+          "tableFrom": "transaction_events",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "idempotency_keys_uniq": {
+          "name": "idempotency_keys_uniq",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_workspace_id_workspaces_id_fk": {
+          "name": "idempotency_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "idempotency_keys",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reconcile": {
+          "name": "auto_reconcile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "batches_workspace_created_idx": {
+          "name": "batches_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "batches_status_idx": {
+          "name": "batches_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "batches_workspace_id_workspaces_id_fk": {
+          "name": "batches_workspace_id_workspaces_id_fk",
+          "tableFrom": "batches",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingests": {
+      "name": "ingests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ingest_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "produced": {
+          "name": "produced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ingests_batch_idx": {
+          "name": "ingests_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ingests_workspace_created_idx": {
+          "name": "ingests_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "ingests_status_idx": {
+          "name": "ingests_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ingests_workspace_id_workspaces_id_fk": {
+          "name": "ingests_workspace_id_workspaces_id_fk",
+          "tableFrom": "ingests",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "ingests_batch_id_batches_id_fk": {
+          "name": "ingests_batch_id_batches_id_fk",
+          "tableFrom": "ingests",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "tableTo": "batches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reconcile_proposals": {
+      "name": "reconcile_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reconcile_proposals_batch_idx": {
+          "name": "reconcile_proposals_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "reconcile_proposals_kind_idx": {
+          "name": "reconcile_proposals_kind_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "reconcile_proposals_batch_id_batches_id_fk": {
+          "name": "reconcile_proposals_batch_id_batches_id_fk",
+          "tableFrom": "reconcile_proposals",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "tableTo": "batches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_photos": {
+      "name": "place_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_photo_name": {
+          "name": "google_photo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width_px": {
+          "name": "width_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_px": {
+          "name": "height_px",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_attributions": {
+          "name": "author_attributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_extracted": {
+          "name": "ocr_extracted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_reviews": {
+      "name": "place_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_review_name": {
+          "name": "google_review_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_language": {
+          "name": "text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_text": {
+          "name": "original_text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_text_language": {
+          "name": "original_text_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relative_publish_time": {
+          "name": "relative_publish_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_time": {
+          "name": "publish_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_uri": {
+          "name": "author_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_photo_uri": {
+          "name": "author_photo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_taken_at": {
+          "name": "snapshot_taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.places": {
+      "name": "places",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "google_place_id": {
+          "name": "google_place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_name_en": {
+          "name": "display_name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh": {
+          "name": "display_name_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_locale": {
+          "name": "display_name_zh_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_source": {
+          "name": "display_name_zh_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name_zh_is_native": {
+          "name": "display_name_zh_is_native",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type_display_zh": {
+          "name": "primary_type_display_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maps_type_label_zh": {
+          "name": "maps_type_label_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "types": {
+          "name": "types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_en": {
+          "name": "formatted_address_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address_zh": {
+          "name": "formatted_address_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_status": {
+          "name": "business_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_hours": {
+          "name": "business_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_rating_count": {
+          "name": "user_rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "national_phone_number": {
+          "name": "national_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_uri": {
+          "name": "website_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_maps_uri": {
+          "name": "google_maps_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_business_id": {
+          "name": "yelp_business_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_alias": {
+          "name": "yelp_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_price_level": {
+          "name": "yelp_price_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_categories": {
+          "name": "yelp_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yelp_raw_response": {
+          "name": "yelp_raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "places_lat_lng_idx": {
+          "name": "places_lat_lng_idx",
+          "columns": [
+            {
+              "expression": "lat",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lng",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "places_google_place_id_unique": {
+          "name": "places_google_place_id_unique",
+          "columns": [
+            "google_place_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.place_snapshots": {
+      "name": "place_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "fetched_by_sha": {
+          "name": "fetched_by_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "place_snapshots_place_idx": {
+          "name": "place_snapshots_place_idx",
+          "columns": [
+            {
+              "expression": "place_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "place_snapshots_place_id_places_id_fk": {
+          "name": "place_snapshots_place_id_places_id_fk",
+          "tableFrom": "place_snapshots",
+          "columnsFrom": [
+            "place_id"
+          ],
+          "tableTo": "places",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merchants": {
+      "name": "merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_name": {
+          "name": "canonical_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_attribution": {
+          "name": "photo_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "numeric(9, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_status": {
+          "name": "enrichment_status",
+          "type": "merchant_enrichment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enrichment_attempted_at": {
+          "name": "enrichment_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {
+        "merchants_workspace_brand_idx": {
+          "name": "merchants_workspace_brand_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "merchants_workspace_idx": {
+          "name": "merchants_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "merchants_enrichment_pending_idx": {
+          "name": "merchants_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "merchants_workspace_id_workspaces_id_fk": {
+          "name": "merchants_workspace_id_workspaces_id_fk",
+          "tableFrom": "merchants",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "merchants_brand_id_brands_brand_id_fk": {
+          "name": "merchants_brand_id_brands_brand_id_fk",
+          "tableFrom": "merchants",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "tableTo": "brands",
+          "columnsTo": [
+            "brand_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "merchants_brand_id_format": {
+          "name": "merchants_brand_id_format",
+          "value": "\"merchants\".\"brand_id\" ~ '^[a-z0-9-]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.derivation_events": {
+      "name": "derivation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_git_sha": {
+          "name": "prompt_git_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_keys": {
+          "name": "changed_keys",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "derivation_events_entity_idx": {
+          "name": "derivation_events_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "derivation_events_version_idx": {
+          "name": "derivation_events_version_idx",
+          "columns": [
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "derivation_events_workspace_id_workspaces_id_fk": {
+          "name": "derivation_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "derivation_events",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "asset",
+        "liability",
+        "equity",
+        "income",
+        "expense"
+      ]
+    },
+    "public.batch_status": {
+      "name": "batch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "extracted",
+        "reconciling",
+        "reconciled",
+        "failed",
+        "reconcile_error"
+      ]
+    },
+    "public.document_kind": {
+      "name": "document_kind",
+      "schema": "public",
+      "values": [
+        "receipt_image",
+        "receipt_email",
+        "receipt_pdf",
+        "statement_pdf",
+        "other"
+      ]
+    },
+    "public.ingest_status": {
+      "name": "ingest_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "done",
+        "error",
+        "unsupported",
+        "dedup",
+        "near_dup"
+      ]
+    },
+    "public.merchant_enrichment_status": {
+      "name": "merchant_enrichment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "not_found",
+        "failed"
+      ]
+    },
+    "public.txn_status": {
+      "name": "txn_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "posted",
+        "voided",
+        "reconciled",
+        "error"
+      ]
+    },
+    "public.workspace_role": {
+      "name": "workspace_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -267,6 +267,20 @@
       "when": 1785308346391,
       "tag": "0037_faulty_marvel_boy",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1785489375752,
+      "tag": "0038_points_as_currency",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1785489462800,
+      "tag": "0039_points_seed",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -234,7 +234,7 @@
           },
           "currency": {
             "type": "string",
-            "pattern": "^[A-Z]{3}$",
+            "pattern": "^([A-Z]{3}|[A-Z][A-Z0-9]{1,12}_PT)$",
             "example": "USD"
           },
           "institution": {
@@ -327,7 +327,7 @@
           },
           "currency": {
             "type": "string",
-            "pattern": "^[A-Z]{3}$",
+            "pattern": "^([A-Z]{3}|[A-Z][A-Z0-9]{1,12}_PT)$",
             "example": "USD"
           },
           "institution": {
@@ -428,7 +428,7 @@
           },
           "currency": {
             "type": "string",
-            "pattern": "^[A-Z]{3}$",
+            "pattern": "^([A-Z]{3}|[A-Z][A-Z0-9]{1,12}_PT)$",
             "example": "USD"
           },
           "posting_count": {
@@ -528,7 +528,7 @@
           },
           "currency": {
             "type": "string",
-            "pattern": "^[A-Z]{3}$",
+            "pattern": "^([A-Z]{3}|[A-Z][A-Z0-9]{1,12}_PT)$",
             "example": "USD"
           },
           "running_balance_after_minor": {
@@ -615,7 +615,7 @@
           },
           "currency": {
             "type": "string",
-            "pattern": "^[A-Z]{3}$",
+            "pattern": "^([A-Z]{3}|[A-Z][A-Z0-9]{1,12}_PT)$",
             "example": "USD"
           },
           "fx_rate": {
@@ -1309,7 +1309,7 @@
           },
           "currency": {
             "type": "string",
-            "pattern": "^[A-Z]{3}$",
+            "pattern": "^([A-Z]{3}|[A-Z][A-Z0-9]{1,12}_PT)$",
             "example": "USD"
           },
           "item_class": {
@@ -4206,6 +4206,76 @@
           "avg_per_txn_minor"
         ]
       },
+      "PointsProgrammeTotal": {
+        "type": "object",
+        "properties": {
+          "currency": {
+            "type": "string",
+            "example": "HYATT_PT"
+          },
+          "points_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "base_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "valuation_exists": {
+            "type": "boolean"
+          },
+          "valuation_confirmed": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "currency",
+          "points_minor",
+          "base_minor",
+          "valuation_exists",
+          "valuation_confirmed"
+        ]
+      },
+      "PointsDisclosure": {
+        "type": "object",
+        "properties": {
+          "policy": {
+            "type": "string"
+          },
+          "included_in_totals": {
+            "type": "boolean"
+          },
+          "base_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "unconfirmed_base_minor": {
+            "type": "integer",
+            "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
+            "example": 14723
+          },
+          "unvalued_transaction_count": {
+            "type": "integer"
+          },
+          "programmes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PointsProgrammeTotal"
+            }
+          }
+        },
+        "required": [
+          "policy",
+          "included_in_totals",
+          "base_minor",
+          "unconfirmed_base_minor",
+          "unvalued_transaction_count",
+          "programmes"
+        ]
+      },
       "SummaryReport": {
         "type": "object",
         "properties": {
@@ -4250,6 +4320,9 @@
             "type": "integer",
             "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
             "example": 14723
+          },
+          "points": {
+            "$ref": "#/components/schemas/PointsDisclosure"
           }
         },
         "required": [
@@ -4258,7 +4331,8 @@
           "group_by",
           "currency",
           "items",
-          "grand_total_minor"
+          "grand_total_minor",
+          "points"
         ]
       },
       "TrendsItem": {
@@ -4351,6 +4425,9 @@
             "items": {
               "$ref": "#/components/schemas/TrendsBucket"
             }
+          },
+          "points": {
+            "$ref": "#/components/schemas/PointsDisclosure"
           }
         },
         "required": [
@@ -4359,7 +4436,8 @@
           "period",
           "group_by",
           "currency",
-          "buckets"
+          "buckets",
+          "points"
         ]
       },
       "NetWorthAccount": {
@@ -4435,6 +4513,9 @@
             "items": {
               "$ref": "#/components/schemas/NetWorthAccount"
             }
+          },
+          "points": {
+            "$ref": "#/components/schemas/PointsDisclosure"
           }
         },
         "required": [
@@ -4444,7 +4525,8 @@
           "liabilities_minor",
           "equity_minor",
           "net_worth_minor",
-          "by_account"
+          "by_account",
+          "points"
         ]
       },
       "CashflowBucket": {
@@ -4522,6 +4604,9 @@
             "items": {
               "$ref": "#/components/schemas/CashflowBucket"
             }
+          },
+          "points": {
+            "$ref": "#/components/schemas/PointsDisclosure"
           }
         },
         "required": [
@@ -4531,7 +4616,8 @@
           "income_minor",
           "expense_minor",
           "net_minor",
-          "buckets"
+          "buckets",
+          "points"
         ]
       },
       "MerchantDetail": {
@@ -4649,7 +4735,7 @@
           },
           "currency": {
             "type": "string",
-            "pattern": "^[A-Z]{3}$",
+            "pattern": "^([A-Z]{3}|[A-Z][A-Z0-9]{1,12}_PT)$",
             "example": "USD"
           },
           "fx_rate": {
@@ -4901,7 +4987,7 @@
           },
           "currency": {
             "type": "string",
-            "pattern": "^[A-Z]{3}$",
+            "pattern": "^([A-Z]{3}|[A-Z][A-Z0-9]{1,12}_PT)$",
             "example": "USD"
           },
           "fx_rate": {
@@ -5482,7 +5568,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^[A-Z]{3}$",
+              "pattern": "^([A-Z]{3}|[A-Z][A-Z0-9]{1,12}_PT)$",
               "example": "USD"
             },
             "required": false,

--- a/scripts/backfill-fx.ts
+++ b/scripts/backfill-fx.ts
@@ -33,6 +33,7 @@ import "dotenv/config";
 import { sql } from "drizzle-orm";
 import { db, pool } from "../src/db/client.js";
 import { normalizeTransactionFx } from "../src/fx/normalize.js";
+import { POINTS_CURRENCY_SQL_RE } from "../src/points/codes.js";
 
 interface Args {
   dryRun: boolean;
@@ -65,6 +66,11 @@ interface Candidate {
  * Expense-side (positive) foreign-currency postings, one row per
  * transaction — enough to print a meaningful before/after line. The
  * normalize pass itself operates on every leg.
+ *
+ * Points legs are excluded (#206): they also differ from the base
+ * currency but have no published rate, and handing one to `getRate()`
+ * now throws by design. They are backfilled by
+ * `src/points/valuation.ts` instead.
  */
 async function findCandidates(workspaceId: string | null): Promise<Candidate[]> {
   const res = await db.execute(sql`
@@ -81,6 +87,7 @@ async function findCandidates(workspaceId: string | null): Promise<Candidate[]> 
       JOIN transactions t ON t.id = p.transaction_id
       JOIN workspaces  w ON w.id = t.workspace_id
      WHERE p.currency <> w.base_currency
+       AND p.currency !~ ${POINTS_CURRENCY_SQL_RE}
        AND p.amount_minor > 0
        ${workspaceId ? sql`AND t.workspace_id = ${workspaceId}::uuid` : sql``}
      ORDER BY t.occurred_on

--- a/scripts/prompt-budget.baseline.json
+++ b/scripts/prompt-budget.baseline.json
@@ -1,16 +1,16 @@
 {
   "_comment": "Rendered size of the extraction prompts with an EMPTY context, in bytes. Regenerate deliberately with `npm run check:prompt-budget -- --update-baseline` in the same commit as the prompt change, so growth arrives as a reviewable diff. See scripts/check-prompt-budget.ts and issue #197.",
-  "generatedAt": "2026-07-31T08:54:23.802Z",
+  "generatedAt": "2026-07-31T09:33:47.351Z",
   "totals": {
-    "ingest": 141555,
-    "reextract": 86272
+    "ingest": 144545,
+    "reextract": 86752
   },
   "modules": {
     "line-item-prompt.ts": 38269,
     "brand-icon-prompt.ts": 14889,
-    "prompt-contract.ts": 14411,
+    "prompt-contract.ts": 14891,
     "document-read-prompt.ts": 2458,
     "items-sql.ts": 6054,
-    "prompt.ts (inline)": 65474
+    "prompt.ts (inline)": 67984
   }
 }

--- a/scripts/smoke-points.ts
+++ b/scripts/smoke-points.ts
@@ -1,0 +1,338 @@
+/**
+ * smoke-points.ts — end-to-end check of #206 points-as-currency.
+ *
+ * Runs against a real Postgres, so it exercises the real migrations, the
+ * real currency-shape CHECK constraints, the real partial unique index
+ * the extraction agent upserts against, and the real deferred balance
+ * trigger. It writes the ledger exactly the way the extraction prompt
+ * tells the agent to write it, then asserts the worker's valuation pass
+ * turns the placeholder into a real base amount.
+ *
+ * Point it at a THROWAWAY database. It writes into a fixed test workspace
+ * and does not clean up, so the tables can be inspected afterwards.
+ *
+ *   docker run -d --rm --name ra-points-test -e POSTGRES_PASSWORD=postgres \
+ *     -e POSTGRES_DB=receipts -p 55432:5432 docker.io/postgres:16
+ *   DATABASE_URL=postgresql://postgres:postgres@localhost:55432/receipts \
+ *     npx tsx scripts/migrate.ts
+ *   DATABASE_URL=postgresql://postgres:postgres@localhost:55432/receipts \
+ *     npx tsx scripts/smoke-points.ts
+ *
+ * Covered: the namespace CHECK constraints, the agent's inline account
+ * upsert, a 40,500-point award stay valued at the seeded rate, the
+ * unvalued-programme state and its recovery, idempotency, `force`
+ * re-valuation, a mixed points+cash folio, the #184 FX regression check,
+ * and the two structural guarantees that keep the FX marker intact.
+ */
+import "dotenv/config";
+import { sql } from "drizzle-orm";
+import { db, pool } from "../src/db/client.js";
+import {
+  valueTransactionPoints,
+  valuePointsSafely,
+} from "../src/points/valuation.js";
+import { normalizeTransactionFx } from "../src/fx/normalize.js";
+import { getRate } from "../src/fx/rates.js";
+import { getSummaryReport, getNetWorthReport } from "../src/routes/reports.js";
+
+const WS = "00000000-0000-0000-0000-0000000000ef";
+const USER = "00000000-0000-0000-0000-0000000000ee";
+const EXPENSE = "00000000-0000-0000-0000-00000000f001";
+const CARD = "00000000-0000-0000-0000-00000000f002";
+
+async function seed(): Promise<void> {
+  await db.execute(sql`INSERT INTO users (id, email, name) VALUES (${USER}::uuid, 'points@test.local', 'Points Test') ON CONFLICT DO NOTHING`);
+  await db.execute(sql`INSERT INTO workspaces (id, name, base_currency, owner_id) VALUES (${WS}::uuid, 'Points Test WS', 'USD', ${USER}::uuid) ON CONFLICT DO NOTHING`);
+  await db.execute(sql`INSERT INTO accounts (id, workspace_id, name, type, currency) VALUES (${EXPENSE}::uuid, ${WS}::uuid, 'Travel', 'expense', 'USD') ON CONFLICT DO NOTHING`);
+  await db.execute(sql`INSERT INTO accounts (id, workspace_id, name, type, currency) VALUES (${CARD}::uuid, ${WS}::uuid, 'Credit Card', 'liability', 'USD') ON CONFLICT DO NOTHING`);
+  // The 0039 seed only reaches workspaces that existed when it ran, so
+  // give this test workspace the same unconfirmed Hyatt valuation.
+  await db.execute(sql`
+    INSERT INTO points_valuations (workspace_id, currency, quote, effective_from, minor_per_point, source, note)
+    VALUES (${WS}::uuid, 'HYATT_PT', 'USD', DATE '2000-01-01', 1.7, 'issue-206-example', 'UNCONFIRMED')
+    ON CONFLICT DO NOTHING`);
+}
+
+/**
+ * Write a ledger transaction exactly the way the Phase 4a template tells
+ * the agent to: the document's own numbers, `amount_base_minor =
+ * amount_minor` as a placeholder, no `fx_rate`, and the points asset
+ * account created inline by the same upsert the prompt spells out.
+ */
+async function writeLikeAgent(opts: {
+  id: string;
+  occurredOn: string;
+  payee: string;
+  totalMinor: number;
+  currency: string;
+  programmeName?: string;
+  /** Optional second cash leg pair, e.g. a resort fee on an award stay. */
+  cash?: { minor: number; currency: string };
+}): Promise<void> {
+  const isPoints = opts.currency.endsWith("_PT");
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`
+      INSERT INTO transactions (id, workspace_id, occurred_on, payee, status, created_by)
+      VALUES (${opts.id}::uuid, ${WS}::uuid, ${opts.occurredOn}::date, ${opts.payee}, 'posted', ${USER}::uuid)`);
+
+    let creditId = CARD;
+    if (isPoints) {
+      const up = await tx.execute(sql`
+        INSERT INTO accounts (id, workspace_id, name, type, subtype, currency)
+        VALUES (gen_random_uuid(), ${WS}::uuid, ${opts.programmeName ?? opts.currency}, 'asset', 'points', ${opts.currency})
+        ON CONFLICT (workspace_id, currency) WHERE subtype = 'points'
+          DO UPDATE SET updated_at = NOW()
+        RETURNING id`);
+      creditId = (up.rows[0] as { id: string }).id;
+    }
+
+    await tx.execute(sql`
+      INSERT INTO postings (id, transaction_id, workspace_id, account_id, amount_minor, currency, amount_base_minor)
+      VALUES (gen_random_uuid(), ${opts.id}::uuid, ${WS}::uuid, ${EXPENSE}::uuid, ${opts.totalMinor}, ${opts.currency}, ${opts.totalMinor})`);
+    await tx.execute(sql`
+      INSERT INTO postings (id, transaction_id, workspace_id, account_id, amount_minor, currency, amount_base_minor)
+      VALUES (gen_random_uuid(), ${opts.id}::uuid, ${WS}::uuid, ${creditId}::uuid, ${-opts.totalMinor}, ${opts.currency}, ${-opts.totalMinor})`);
+
+    if (opts.cash) {
+      await tx.execute(sql`
+        INSERT INTO postings (id, transaction_id, workspace_id, account_id, amount_minor, currency, amount_base_minor)
+        VALUES (gen_random_uuid(), ${opts.id}::uuid, ${WS}::uuid, ${EXPENSE}::uuid, ${opts.cash.minor}, ${opts.cash.currency}, ${opts.cash.minor})`);
+      await tx.execute(sql`
+        INSERT INTO postings (id, transaction_id, workspace_id, account_id, amount_minor, currency, amount_base_minor)
+        VALUES (gen_random_uuid(), ${opts.id}::uuid, ${WS}::uuid, ${CARD}::uuid, ${-opts.cash.minor}, ${opts.cash.currency}, ${-opts.cash.minor})`);
+    }
+
+    // The prompt makes the agent force the deferred triggers here rather
+    // than at COMMIT; do the same so a failure points at this write.
+    await tx.execute(sql`SET CONSTRAINTS ALL IMMEDIATE`);
+  });
+}
+
+async function legs(
+  id: string,
+): Promise<Array<{ m: string; currency: string; fx: string | null; b: string }>> {
+  const r = await db.execute(sql`
+    SELECT amount_minor::text AS m, currency, fx_rate::text AS fx, amount_base_minor::text AS b
+      FROM postings WHERE transaction_id = ${id}::uuid ORDER BY amount_minor DESC`);
+  return r.rows as unknown as Array<{
+    m: string;
+    currency: string;
+    fx: string | null;
+    b: string;
+  }>;
+}
+
+async function dump(id: string, label: string): Promise<void> {
+  console.log(`  ${label}`);
+  for (const row of await legs(id)) {
+    console.log(
+      `    ${row.currency.padEnd(9)} ${row.m.padStart(10)}  fx=${(row.fx ?? "NULL").padEnd(12)} base=${row.b.padStart(10)}`,
+    );
+  }
+  const meta = await db.execute(
+    sql`SELECT metadata->'points' AS p FROM transactions WHERE id = ${id}::uuid`,
+  );
+  const p = (meta.rows[0] as { p: unknown } | undefined)?.p;
+  if (p) console.log(`    metadata.points = ${JSON.stringify(p)}`);
+}
+
+async function sumBase(id: string): Promise<number> {
+  const r = await db.execute(
+    sql`SELECT COALESCE(SUM(amount_base_minor),0)::text AS s FROM postings WHERE transaction_id = ${id}::uuid`,
+  );
+  return Number((r.rows[0] as { s: string }).s);
+}
+
+async function main(): Promise<void> {
+  await seed();
+  let failures = 0;
+  const check = (name: string, ok: boolean, detail = ""): void => {
+    console.log(`  ${ok ? "✓" : "✗"} ${name}${detail ? ` — ${detail}` : ""}`);
+    if (!ok) failures++;
+  };
+  const rejects = async (label: string, fn: () => Promise<unknown>): Promise<boolean> => {
+    try {
+      await fn();
+      console.log(`  ✗ ${label} — expected a rejection, got success`);
+      failures++;
+      return false;
+    } catch {
+      console.log(`  ✓ ${label}`);
+      return true;
+    }
+  };
+
+  console.log("\n── 1. The currency namespace is enforced by the database ──");
+  await rejects("a lowercase / malformed points code is rejected", () =>
+    db.execute(sql`INSERT INTO accounts (id, workspace_id, name, type, currency) VALUES (gen_random_uuid(), ${WS}::uuid, 'bad', 'asset', 'hyatt_pt')`),
+  );
+  await rejects("a 4-letter cash-shaped code is rejected", () =>
+    db.execute(sql`INSERT INTO accounts (id, workspace_id, name, type, currency) VALUES (gen_random_uuid(), ${WS}::uuid, 'bad', 'asset', 'USDX')`),
+  );
+  await rejects("a points code cannot enter the FX rate cache", () =>
+    db.execute(sql`INSERT INTO fx_rates (as_of, base, quote, rate, as_of_actual, source) VALUES (DATE '2026-07-01', 'HYATT_PT', 'USD', 1.7, DATE '2026-07-01', 'bogus')`),
+  );
+  await rejects("getRate() refuses a points currency outright", () =>
+    getRate("HYATT_PT", "USD", "2026-07-01"),
+  );
+
+  console.log("\n── 2. A 40,500-point award stay, written as the agent writes it ──");
+  const T1 = "00000000-0000-0000-0000-00000000b001";
+  await writeLikeAgent({
+    id: T1, occurredOn: "2026-07-05", payee: "Hyatt Regency Maui",
+    totalMinor: 40500, currency: "HYATT_PT", programmeName: "World of Hyatt points",
+  });
+  await dump(T1, "before (agent placeholder):");
+  const r1 = await valueTransactionPoints(T1, WS);
+  await dump(T1, "after the valuation pass:");
+  const l1 = await legs(T1);
+  check("transaction is denominated in points, not $0", l1[0]!.currency === "HYATT_PT" && l1[0]!.m === "40500");
+  check("base = 40500 × 1.7 = $688.50", l1[0]!.b === "68850", `got ${l1[0]!.b}`);
+  check("fx_rate carries the valuation, not a market rate", Number(l1[0]!.fx) === 1.7);
+  check("still balances (sum base = 0)", (await sumBase(T1)) === 0);
+  check("provenance flags the number as unconfirmed", r1.applied[0]?.confirmed === false);
+
+  console.log("\n── 3. Idempotency and re-valuation ──");
+  await valueTransactionPoints(T1, WS);
+  check("second run is a no-op", (await legs(T1))[0]!.b === "68850");
+  await db.execute(sql`
+    INSERT INTO points_valuations (workspace_id, currency, quote, effective_from, minor_per_point, source, confirmed_at, note)
+    VALUES (${WS}::uuid, 'HYATT_PT', 'USD', DATE '2026-07-01', 2.0, 'owner', NOW(), 'confirmed by owner')
+    ON CONFLICT DO NOTHING`);
+  const r3 = await valueTransactionPoints(T1, WS, { force: true });
+  const l3 = await legs(T1);
+  check("a newer effective valuation wins under force", l3[0]!.b === "81000", `got ${l3[0]!.b}`);
+  check("confirmed valuation is reported as confirmed", r3.applied[0]?.confirmed === true);
+  check("still balances after re-valuation", (await sumBase(T1)) === 0);
+
+  console.log("\n── 4. An unconfigured programme is visible, not a silent $0 ──");
+  await db.execute(sql`INSERT INTO points_programmes (code, name) VALUES ('BONVOY_PT', 'Marriott Bonvoy points') ON CONFLICT DO NOTHING`);
+  const T2 = "00000000-0000-0000-0000-00000000b002";
+  await writeLikeAgent({
+    id: T2, occurredOn: "2026-06-11", payee: "Courtyard Long Beach",
+    totalMinor: 35000, currency: "BONVOY_PT", programmeName: "Marriott Bonvoy points",
+  });
+  const r4 = await valueTransactionPoints(T2, WS);
+  const l4 = await legs(T2);
+  check("the stay is still recorded in points", l4[0]!.m === "35000" && l4[0]!.currency === "BONVOY_PT");
+  check("base is 0 with an explicit 0 rate, not NULL", l4[0]!.b === "0" && Number(l4[0]!.fx) === 0);
+  check("reported as unvalued", r4.unvalued.includes("BONVOY_PT"));
+  await db.execute(sql`
+    INSERT INTO points_valuations (workspace_id, currency, quote, effective_from, minor_per_point, source, confirmed_at)
+    VALUES (${WS}::uuid, 'BONVOY_PT', 'USD', DATE '2000-01-01', 0.8, 'owner', NOW())`);
+  await valueTransactionPoints(T2, WS); // no force — a 0 rate is re-tried
+  check("configuring a valuation later picks it up without force", (await legs(T2))[0]!.b === "28000", `got ${(await legs(T2))[0]!.b}`);
+
+  console.log("\n── 5. Mixed folio: award room + a cash resort fee ──");
+  const T3 = "00000000-0000-0000-0000-00000000b003";
+  await writeLikeAgent({
+    id: T3, occurredOn: "2026-07-20", payee: "Andaz Maui",
+    totalMinor: 30000, currency: "HYATT_PT", programmeName: "World of Hyatt points",
+    cash: { minor: 7500, currency: "USD" },
+  });
+  await valuePointsSafely([T3], WS);
+  await normalizeTransactionFx(T3, WS);
+  await dump(T3, "after both passes:");
+  const l5 = await legs(T3);
+  const pointsLeg = l5.find((x) => x.currency === "HYATT_PT" && Number(x.m) > 0)!;
+  const cashLeg = l5.find((x) => x.currency === "USD" && Number(x.m) > 0)!;
+  check("points leg valued at 2.0 → $600.00", pointsLeg.b === "60000", `got ${pointsLeg.b}`);
+  check("cash leg untouched at $75.00", cashLeg.b === "7500" && cashLeg.fx === null);
+  check("whole transaction balances", (await sumBase(T3)) === 0);
+
+  console.log("\n── 6. #184 REGRESSION: a non-USD cash receipt still converts ──");
+  const T4 = "00000000-0000-0000-0000-00000000b004";
+  await writeLikeAgent({ id: T4, occurredOn: "2026-04-18", payee: "广州金铭物业管理有限公司", totalMinor: 1394880, currency: "CNY" });
+  await valuePointsSafely([T4], WS); // must be a complete no-op
+  const r6 = await normalizeTransactionFx(T4, WS);
+  await dump(T4, "after both passes:");
+  const l6 = await legs(T4);
+  check("FX conversion still happens", r6.changed);
+  check("base ≈ $2,044.62 at the published 2026-04-17 rate", Math.abs(Number(l6[0]!.b) - 204462) <= 2, `got ${l6[0]!.b}`);
+  check("fx_rate came from the ECB feed", r6.applied[0]?.source.includes("frankfurter") === true);
+  check("balances", (await sumBase(T4)) === 0);
+
+  console.log("\n── 7. The FX marker still means exactly one thing ──");
+  const unconverted = await db.execute(sql`
+    SELECT COUNT(*)::int AS n FROM postings p
+      JOIN transactions t ON t.id = p.transaction_id
+     WHERE t.workspace_id = ${WS}::uuid
+       AND p.currency <> 'USD'
+       AND p.currency !~ '^[A-Z][A-Z0-9]{1,12}_PT$'
+       AND p.fx_rate IS NULL`);
+  check(
+    "no cash posting is left with fx_rate NULL",
+    (unconverted.rows[0] as { n: number }).n === 0,
+    `${(unconverted.rows[0] as { n: number }).n} left`,
+  );
+  const pointsNull = await db.execute(sql`
+    SELECT COUNT(*)::int AS n FROM postings p
+      JOIN transactions t ON t.id = p.transaction_id
+     WHERE t.workspace_id = ${WS}::uuid
+       AND p.currency ~ '^[A-Z][A-Z0-9]{1,12}_PT$'
+       AND p.fx_rate IS NULL`);
+  check(
+    "no points posting is left with fx_rate NULL either",
+    (pointsNull.rows[0] as { n: number }).n === 0,
+    `${(pointsNull.rows[0] as { n: number }).n} left`,
+  );
+
+  console.log("\n── 8. Reports state how points and cash combine ──");
+  // Add an unvalued programme so the disclosure has one to report.
+  await db.execute(sql`INSERT INTO points_programmes (code, name) VALUES ('AA_PT', 'American Airlines miles') ON CONFLICT DO NOTHING`);
+  const T5 = "00000000-0000-0000-0000-00000000b005";
+  await writeLikeAgent({ id: T5, occurredOn: "2026-07-22", payee: "American Airlines", totalMinor: 25000, currency: "AA_PT", programmeName: "American Airlines miles" });
+  await valuePointsSafely([T5], WS);
+
+  const summary = await getSummaryReport({ workspaceId: WS });
+  console.log(`  policy: ${summary.points.policy.slice(0, 72)}…`);
+  console.log(`  ${JSON.stringify({ ...summary.points, policy: undefined })}`);
+  check("summary discloses points inside its totals", summary.points.included_in_totals);
+  check(
+    "points spend counted in grand total",
+    summary.points.base_minor === 81000 + 28000 + 60000,
+    `points base ${summary.points.base_minor}, grand total ${summary.grand_total_minor}`,
+  );
+  check("unvalued AA_PT stay is counted, not hidden", summary.points.unvalued_transaction_count === 1);
+  check(
+    "AA_PT reported with no valuation",
+    summary.points.programmes.find((p) => p.currency === "AA_PT")?.valuation_exists === false,
+  );
+  check(
+    "unconfirmed portion is reported",
+    typeof summary.points.unconfirmed_base_minor === "number",
+    `${summary.points.unconfirmed_base_minor}`,
+  );
+
+  // The single safety property that matters most for the owner: money
+  // derived from a valuation nobody has signed off on is reported as
+  // such, not folded anonymously into the total.
+  await db.execute(sql`
+    INSERT INTO points_valuations (workspace_id, currency, quote, effective_from, minor_per_point, source, note)
+    VALUES (${WS}::uuid, 'AA_PT', 'USD', DATE '2000-01-01', 1.4, 'issue-206-example', 'UNCONFIRMED')`);
+  await valueTransactionPoints(T5, WS);
+  const summary2 = await getSummaryReport({ workspaceId: WS });
+  check(
+    "an unconfirmed valuation's contribution is quantified",
+    summary2.points.unconfirmed_base_minor === 35000,
+    `$${(summary2.points.unconfirmed_base_minor / 100).toFixed(2)} of $${(summary2.points.base_minor / 100).toFixed(2)} points spend`,
+  );
+
+  const nw = await getNetWorthReport({ workspaceId: WS });
+  const pointsAcctInBalances = nw.by_account.some((a) => a.name.includes("points"));
+  console.log(`  net worth policy: ${nw.points.policy.slice(0, 72)}…`);
+  check("points accounts excluded from net-worth balances", !pointsAcctInBalances);
+  check("…but reported in the disclosure", nw.points.programmes.length >= 2, `${nw.points.programmes.length} programmes`);
+  check("net worth marks points as NOT included", nw.points.included_in_totals === false);
+
+  console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`);
+  if (failures > 0) process.exitCode = 1;
+}
+
+main()
+  .then(() => pool.end())
+  .catch((e) => {
+    console.error(e);
+    void pool.end();
+    process.exit(1);
+  });

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -144,5 +144,22 @@ export async function seed(): Promise<SeedResult> {
 
   await insertTree(SEED_WORKSPACE_ID, "USD", DEFAULT_CHART);
 
+  // #206 — mirror what `drizzle/0039_points_seed.sql` did for workspaces
+  // that already existed when that migration ran. A fresh install would
+  // otherwise have the programme registered but no valuation, so its
+  // first Hyatt award stay would land `unvalued`.
+  //
+  // ⚠ 1.7 cents/point is the example cited in the issue, NOT a number the
+  // owner has confirmed — hence `confirmed_at` left NULL, which is what
+  // makes every report disclose how much of its total depends on it.
+  await db.execute(sql`
+    INSERT INTO points_valuations
+      (workspace_id, currency, quote, effective_from, minor_per_point, source, note)
+    SELECT ${SEED_WORKSPACE_ID}::uuid, 'HYATT_PT', 'USD', DATE '2000-01-01',
+           1.7, 'issue-206-example',
+           'UNCONFIRMED. 1.7 US cents per point, the example cited in #206.'
+     WHERE EXISTS (SELECT 1 FROM points_programmes WHERE code = 'HYATT_PT')
+    ON CONFLICT DO NOTHING`);
+
   return { userId: SEED_USER_ID, workspaceId: SEED_WORKSPACE_ID, created: true };
 }

--- a/src/fx/normalize.ts
+++ b/src/fx/normalize.ts
@@ -34,12 +34,14 @@
 import { sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { getRate } from "./rates.js";
+import { isPointsCurrency } from "../points/codes.js";
 
 interface PostingRow {
   id: string;
   amount_minor: string;
   currency: string;
   fx_rate: string | null;
+  amount_base_minor: string | null;
 }
 
 export interface NormalizeResult {
@@ -93,7 +95,7 @@ export async function normalizeTransactionFx(
   const onDate = String(occurredOn).slice(0, 10);
 
   const postingsRes = await db.execute(
-    sql`SELECT id, amount_minor, currency, fx_rate
+    sql`SELECT id, amount_minor, currency, fx_rate, amount_base_minor
           FROM postings
          WHERE transaction_id = ${transactionId}::uuid
          ORDER BY id`,
@@ -101,7 +103,15 @@ export async function normalizeTransactionFx(
   const postings = postingsRes.rows as unknown as PostingRow[];
   if (postings.length === 0) return NOOP;
 
-  const foreign = postings.filter((p) => p.currency !== base);
+  // Points legs are not foreign currency — they are a different KIND of
+  // unit, with no published rate to look up (#206). They are excluded
+  // here, before `fx_rate IS NULL` is ever consulted, so that marker
+  // keeps meaning exactly one thing in the cash domain: "needs conversion
+  // at a published rate". `src/points/valuation.ts` owns these legs;
+  // whatever base amount it has already written is respected below.
+  const foreign = postings.filter(
+    (p) => p.currency !== base && !isPointsCurrency(p.currency),
+  );
   if (foreign.length === 0) return NOOP;
   const needsWork = opts.force
     ? foreign
@@ -123,6 +133,16 @@ export async function normalizeTransactionFx(
     const minor = BigInt(p.amount_minor);
     if (p.currency === base) {
       return { id: p.id, baseMinor: minor, rate: null as number | null };
+    }
+    if (isPointsCurrency(p.currency)) {
+      // Not ours to convert, but it still counts toward the residual —
+      // the trigger sums every leg, so measuring against a subset would
+      // settle the wrong number onto a cash leg.
+      return {
+        id: p.id,
+        baseMinor: BigInt(p.amount_base_minor ?? "0"),
+        rate: null as number | null,
+      };
     }
     const r = rates.get(p.currency)!;
     return {

--- a/src/fx/rates.ts
+++ b/src/fx/rates.ts
@@ -21,6 +21,7 @@
  */
 import { sql } from "drizzle-orm";
 import { db } from "../db/client.js";
+import { isPointsCurrency } from "../points/codes.js";
 
 /** Frankfurter base URL. Read per call, not at module load, so a test can
  *  point it at a dead host to exercise the offline fallback path. */
@@ -200,6 +201,22 @@ export async function getRate(
   quote: string,
   onDate: string,
 ): Promise<ResolvedRate> {
+  // Hard stop, not a filter (#206). Loyalty points have no published
+  // rate; what they are worth is the owner's judgement, resolved by
+  // `src/points/valuation.ts`. Callers are expected to have partitioned
+  // their postings by currency shape already — this throws so that a
+  // future caller which forgets fails loudly here rather than quietly
+  // pricing an award stay off a currency-market feed.
+  for (const code of [base, quote]) {
+    if (isPointsCurrency(code)) {
+      throw new Error(
+        `Refusing to resolve an FX rate for points currency ${code}: ` +
+          `points are valued per programme (see src/points/valuation.ts), ` +
+          `never from a published FX rate`,
+      );
+    }
+  }
+
   if (base === quote) {
     return { rate: 1, asOfActual: onDate, source: "identity" };
   }

--- a/src/ingest/lessons.md
+++ b/src/ingest/lessons.md
@@ -46,9 +46,10 @@
 - [unsupported] Packing lists and slips with zero or absent prices (often stamped "DO NOT INCLUDE THIS PACKING SLIP") mean prices were SUPPRESSED, not that the goods were free. Unsupported, not a $0 receipt.
 - [unsupported] Booking confirmations and vouchers whose Total cells are empty (salon appointments, GetYourGuide, "Your Bill Is Ready" emails that only carry a login link) announce a future or unbilled event. Unsupported.
 - [unsupported] Priceless shop printouts (wheel-alignment / CEMB reports, CA Smog Check VIR certificates) are certificates, not receipts, despite the automotive context. Do not invent a service fee.
-- [receipt_pdf] A hotel folio whose charges table is entirely BLANK (not a printed "0.00") has no amount to post: unsupported. But if that same blank folio names an award/points redemption ("World of Hyatt Award"), it IS a real stay and must be recorded, not discarded.
+- [receipt_pdf] A hotel folio whose charges table is entirely BLANK (not a printed "0.00") has no amount to post: unsupported. But if that same blank folio names an award/points redemption ("World of Hyatt Award"), it IS a real stay: record it in POINTS (#206) — total_minor = the points redeemed, currency = the programme code — never as a $0 stay, and never as unsupported.
 
 # Split tender (extends the voucher lesson above)
+- [receipt] Points and miles are the ONE tender that is not "the residual card charge" (#206): they are a currency of their own, so an award redemption is recorded in the programme's own units (total_minor = points redeemed, currency = HYATT_PT / BONVOY_PT / AA_PT), not as a $0 or residual-only charge. Gift cards and store credit still follow the residual rule below.
 - [receipt] The voucher/gift-card rule also covers insurance deductibles ("Amount to collect from Customer"), the PAYMENT column on medical/optometry ledgers, and prepaid account credit ("Applied balance", store credit). total_minor is always the residual card charge. "Amount expected from insurance" is a pending balance that was never charged, so exclude it.
 - [receipt_pdf] The inverse also happens: government payment portals (NICUSA, parking-citation payments) charge MORE than the printed fee. Use the "amount charged" / "NICServices total" line as total_minor and itemize the unlabeled convenience surcharge.
 

--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -145,16 +145,24 @@ For receipt_image / receipt_email / receipt_pdf, pull out:
   total_minor   : the receipt's FINAL "Grand Total" — the amount actually
                   charged — in the currency's minor unit (integer cents for
                   USD, whole units for JPY). Include handwritten tips.
-                  ⚠ Read the GRAND TOTAL line, never the item subtotal. When
-                  Gift Card / Rewards Points / store credit bring the order to
-                  \$0.00, total_minor = 0 — that IS the out-of-pocket amount
-                  charged (the goods still get itemized in items[]; the money
-                  was counted when the card/points were loaded). For a PARTIAL
-                  gift-card order, use the printed residual Grand Total, not
-                  the pre-credit subtotal.
+                  ⚠ Read the GRAND TOTAL line, never the item subtotal.
+                  Gift card / store credit / prepaid balance: total_minor is
+                  the printed residual Grand Total (0 if it covers the whole
+                  order) — that money was counted when the card was loaded.
+                  ⚠ LOYALTY POINTS AND MILES ARE NOT THAT CASE (#206). An
+                  award redemption is real spend in a non-cash currency, so
+                  never zero it: total_minor = the number of points/miles
+                  redeemed (40500, not 0) and \`currency\` = the programme
+                  code. A stay paid with both points and cash gets BOTH: the
+                  points as total_minor/currency, the cash charge as a second
+                  posting pair (see Phase 4a).
   currency      : ISO 4217 code (USD, CNY, EUR, JPY, …). Detect from
                   symbols: \$→USD, €→EUR, £→GBP, ¥ needs context
                   (CNY vs JPY).
+                  For a points/miles redemption use the programme code
+                  instead: uppercase issuer + \`_PT\`, ≤16 chars. World of
+                  Hyatt → HYATT_PT, Marriott Bonvoy → BONVOY_PT, AA miles →
+                  AA_PT. The same programme MUST always get the same code.
   category_hint : one of
                   groceries | dining | retail | cafe | transport | other
                   (vehicle repair / maintenance / parts / fuel / parking →
@@ -622,16 +630,17 @@ Invariants you MUST honor:
     write fx_rate at all — leave that column out of your INSERT so it
     stays NULL. When the receipt is already in the workspace base
     currency (USD here) that is the final, correct answer. When it is
-    NOT (a CNY / JPY / EUR receipt), your value is a placeholder that
-    only exists to satisfy the deferred balance trigger: the worker
-    re-derives both columns straight after your run using the published
-    FX rate for the receipt's own date (#184, src/fx/normalize.ts).
-    \`fx_rate IS NULL\` is precisely the marker it looks for, so a
-    guessed rate from you would suppress the real conversion and leave
-    1 CNY counted as 1 USD in every report. Do not guess a rate, do not
-    convert the total yourself, and do not "helpfully" write USD into
-    the currency column — record the currency actually printed on the
-    receipt.
+    NOT (a CNY / JPY / EUR receipt, or a points redemption), your value
+    is a placeholder that only exists to satisfy the deferred balance
+    trigger: the worker re-derives both columns straight after your run —
+    from the published FX rate for the receipt's own date for cash (#184,
+    src/fx/normalize.ts), from the configured programme valuation for
+    points (#206, src/points/valuation.ts). \`fx_rate IS NULL\` is
+    precisely the marker both look for, so a guessed rate from you would
+    suppress the real conversion and leave 1 CNY (or 1 point) counted as
+    1 USD in every report. Do not guess a rate, do not convert the total
+    yourself, and do not "helpfully" write USD into the currency column —
+    record the currency actually printed on the receipt.
   - Generate UUIDs via gen_random_uuid() inside the SQL.
   - All rows take workspace_id = WORKSPACE_ID.
   - The items[] JSON is embedded via PostgreSQL dollar-quoting
@@ -980,6 +989,20 @@ ${brandFkGuard()}
 ${itemsCte()},
     expense AS (SELECT id FROM accounts WHERE workspace_id = '${ctx.workspaceId}' AND type = 'expense' AND name = '<EXPENSE_NAME>' LIMIT 1),
     credit  AS (SELECT id FROM accounts WHERE workspace_id = '${ctx.workspaceId}' AND type = 'liability' AND name = 'Credit Card' LIMIT 1),
+    -- POINTS ONLY (#206): replace the \`credit\` CTE above with this one
+    -- when <CURRENCY> is a programme code. Points cannot be credited to
+    -- the USD card; they come out of a per-programme asset account, which
+    -- this upsert creates on first sight of the programme.
+    --   credit AS (
+    --     INSERT INTO accounts (id, workspace_id, name, type, subtype, currency)
+    --     VALUES (gen_random_uuid(), '${ctx.workspaceId}', '<PROGRAMME NAME> points', 'asset', 'points', '<CURRENCY>')
+    --     ON CONFLICT (workspace_id, currency) WHERE subtype = 'points'
+    --       DO UPDATE SET updated_at = NOW()
+    --     RETURNING id
+    --   ),
+    -- If the folio ALSO charges cash (resort fee, parking), add a second
+    -- posting pair p3/p4 in that cash currency against the real \`credit\`
+    -- card account. Each currency balances within itself.
     m AS (
       INSERT INTO merchants (workspace_id, brand_id, canonical_name, category)
       VALUES ('${ctx.workspaceId}', '<brand-id>', '<CANONICAL_NAME>', '<7-class CATEGORY>')

--- a/src/ingest/worker.ts
+++ b/src/ingest/worker.ts
@@ -26,6 +26,7 @@ import {
   workspaces,
 } from "../schema/index.js";
 import { normalizeFxSafely } from "../fx/normalize.js";
+import { valuePointsSafely } from "../points/valuation.js";
 import {
   defaultClaudeExtractor,
   type ExtractorResult,
@@ -493,6 +494,13 @@ async function runOne(item: QueueItem): Promise<void> {
   // so the SSE consumer never sees a pre-conversion total. Never throws:
   // an unconvertible posting keeps fx_rate NULL for the backfill pass
   // rather than failing an otherwise good extraction.
+  // #206 — same shape, different authority: a points leg carries the
+  // programme's configured valuation, not a market rate. Runs BEFORE the
+  // FX pass so the agent's placeholder base amount (which equals the raw
+  // points count) is replaced before anything measures a residual against
+  // it. The two passes touch disjoint legs, so the order only matters for
+  // that.
+  await valuePointsSafely(terminal.produced.transaction_ids, workspaceId);
   await normalizeFxSafely(terminal.produced.transaction_ids, workspaceId);
 
   busEmit("job.done", {

--- a/src/points/codes.ts
+++ b/src/points/codes.ts
@@ -1,0 +1,62 @@
+/**
+ * The points-currency namespace (#206).
+ *
+ * The owner's decision — "積分也是另外一種貨幣", points are just another
+ * currency — means a loyalty programme's unit has to be a first-class
+ * currency code in the ledger, not a $0 charge. This module owns the one
+ * question everything else asks: **is this code cash or points?**
+ *
+ * ## Why a `_PT` suffix rather than an ISO-style 3-letter code
+ *
+ * The two namespaces must be *provably* disjoint, because a collision
+ * would either send a points posting into the FX converter (see
+ * `src/fx/rates.ts`, which now refuses points codes outright) or convert
+ * a real currency at a made-up valuation. Shape does that with no lookup
+ * table and no possibility of drift:
+ *
+ *   cash   `^[A-Z]{3}$`                ISO 4217, exactly three letters
+ *   points `^[A-Z][A-Z0-9]{1,12}_PT$`  an underscore, which ISO cannot use
+ *
+ * ISO 4217 codes are three letters and contain no underscore, so no
+ * present or future ISO code can ever match the points pattern. The
+ * alternative — squatting on the X-prefixed range (`XHY` for Hyatt) —
+ * looks free but is not: `XCD`, `XOF`, `XAF`, `XPF` are real circulating
+ * currencies and `XAU`/`XAG`/`XDR` are real ISO allocations, so the range
+ * is already occupied and would need a hand-maintained deny-list. It also
+ * reads as noise in a report.
+ *
+ * ## Why per-programme and not one generic `POINTS`
+ *
+ * A currency code asserts fungibility: any two units of it are
+ * interchangeable and may be added together. 40,500 Hyatt points and
+ * 12,000 AA miles are not interchangeable and must never net against each
+ * other, which is exactly what a shared `POINTS` code would let every
+ * per-currency sum do. One code per programme keeps every currency-scoped
+ * aggregate honest by construction.
+ *
+ * Codes are capped at 16 characters so `postings.currency` /
+ * `accounts.currency` stay narrow (`varchar(16)`, widened from `char(3)`
+ * in `drizzle/0038_points_as_currency.sql`).
+ */
+
+/** Points/miles unit, e.g. `HYATT_PT`, `AA_PT`, `BONVOY_PT`. */
+export const POINTS_CURRENCY_RE = /^[A-Z][A-Z0-9]{1,12}_PT$/;
+
+/** Cash currency, ISO 4217. */
+export const CASH_CURRENCY_RE = /^[A-Z]{3}$/;
+
+/**
+ * The points pattern as a POSIX regex string, for use as a **bound
+ * parameter** in SQL (`WHERE currency ~ ${POINTS_CURRENCY_SQL_RE}`).
+ * Passing it as a parameter rather than inlining it avoids the
+ * backslash-escaping trap that `LIKE '%\_PT'` invites.
+ */
+export const POINTS_CURRENCY_SQL_RE = "^[A-Z][A-Z0-9]{1,12}_PT$";
+
+export function isPointsCurrency(code: string): boolean {
+  return POINTS_CURRENCY_RE.test(code);
+}
+
+export function isCashCurrency(code: string): boolean {
+  return CASH_CURRENCY_RE.test(code);
+}

--- a/src/points/valuation.ts
+++ b/src/points/valuation.ts
@@ -1,0 +1,301 @@
+/**
+ * Value a transaction's loyalty-points postings in the workspace base
+ * currency (#206).
+ *
+ * ## Why this is a separate pass from FX, not a branch inside it
+ *
+ * `src/fx/normalize.ts` and this module do the same *shape* of work —
+ * fill `fx_rate` + `amount_base_minor` after the extraction agent has
+ * written the document's own numbers — but they answer different
+ * questions from different authorities:
+ *
+ *   FX      "what was 1 CNY worth on 2026-04-12?"   ECB publication
+ *   points  "what is 1 Hyatt point worth to me?"    the owner's judgement
+ *
+ * Merging them would put a made-up number and a published number behind
+ * one code path, and the first time someone loosened a filter a points
+ * code would be handed to the FX resolver. Keeping them apart makes the
+ * separation checkable: the two passes select **disjoint sets of
+ * postings** by currency shape (`src/points/codes.ts`), and
+ * `getRate()` in `src/fx/rates.ts` throws outright if it is ever handed a
+ * points code.
+ *
+ * ## The `fx_rate` marker, and why this pass does not reuse it
+ *
+ * In the cash domain `fx_rate IS NULL` means "needs conversion at a
+ * published rate" — it is what `scripts/backfill-fx.ts` looks for. That
+ * meaning is untouched here, because the FX pass never selects a points
+ * leg. Within the *points* domain the column carries its own three-state
+ * marker:
+ *
+ *   NULL      the valuation pass has not run on this leg yet; the base
+ *             amount is still the agent's placeholder and must not be
+ *             trusted (this is the points backfill marker)
+ *   0         the pass ran and found NO valuation configured for the
+ *             programme → base 0, and the leg is reported as `unvalued`
+ *   > 0       base = round(points × rate), with provenance on the
+ *             transaction's `metadata.points`
+ *
+ * Zero is re-tryable: adding a valuation and re-running picks those legs
+ * back up without `force`. Zero is also honest — base *is* 0 for those
+ * legs — and it is unambiguous, which a second NULL state would not be.
+ *
+ * ## Balance safety
+ *
+ * `postings_balance_ck` requires every posting to have a non-null
+ * `amount_base_minor` and the per-transaction sum to be 0 at COMMIT. A
+ * points pair scales by one rate so it stays balanced in exact
+ * arithmetic; independent rounding on 3+ legs can leave a ±1 residual, so
+ * the whole residual is pushed onto the largest points leg before
+ * writing. Cash legs are never touched — the FX pass owns those, and the
+ * residual is measured against their values as they stand.
+ */
+import { sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { isPointsCurrency } from "./codes.js";
+
+interface PostingRow {
+  id: string;
+  amount_minor: string;
+  currency: string;
+  fx_rate: string | null;
+  amount_base_minor: string | null;
+}
+
+export interface ResolvedValuation {
+  /** Points currency, e.g. `HYATT_PT`. */
+  currency: string;
+  /** Base-currency minor units per one point. */
+  minorPerPoint: number;
+  effectiveFrom: string;
+  source: string;
+  /** `false` when the owner has not signed off on the number yet. */
+  confirmed: boolean;
+}
+
+export interface ValuePointsResult {
+  changed: boolean;
+  applied: ResolvedValuation[];
+  /** Programme codes seen on this transaction with no valuation row. */
+  unvalued: string[];
+}
+
+const NOOP: ValuePointsResult = { changed: false, applied: [], unvalued: [] };
+
+async function baseCurrencyFor(workspaceId: string): Promise<string | null> {
+  const res = await db.execute(
+    sql`SELECT base_currency FROM workspaces WHERE id = ${workspaceId}::uuid`,
+  );
+  const row = res.rows[0] as { base_currency: string } | undefined;
+  return row?.base_currency ?? null;
+}
+
+/**
+ * The valuation in force for `currency` on `onDate`: the newest row whose
+ * `effective_from` is on or before that date. Returns `null` when the
+ * programme has no valuation configured at all — the caller must treat
+ * that as a visible `unvalued` state, never as "worth nothing".
+ */
+export async function resolvePointsValuation(
+  workspaceId: string,
+  currency: string,
+  quote: string,
+  onDate: string,
+): Promise<ResolvedValuation | null> {
+  const res = await db.execute(
+    sql`SELECT effective_from, minor_per_point, source, confirmed_at
+          FROM points_valuations
+         WHERE workspace_id = ${workspaceId}::uuid
+           AND currency = ${currency}
+           AND quote = ${quote}
+           AND effective_from <= ${onDate}::date
+         ORDER BY effective_from DESC
+         LIMIT 1`,
+  );
+  const row = res.rows[0] as
+    | {
+        effective_from: string;
+        minor_per_point: string;
+        source: string;
+        confirmed_at: string | null;
+      }
+    | undefined;
+  if (!row) return null;
+  return {
+    currency,
+    minorPerPoint: Number(row.minor_per_point),
+    effectiveFrom: String(row.effective_from).slice(0, 10),
+    source: row.source,
+    confirmed: row.confirmed_at !== null,
+  };
+}
+
+/**
+ * Fill `fx_rate` + `amount_base_minor` for every points posting of
+ * `transactionId`.
+ *
+ * @param force  Re-derive even legs that already carry a rate. Used after
+ *               the owner confirms or changes a valuation, to re-value
+ *               history that was priced at the old number.
+ */
+export async function valueTransactionPoints(
+  transactionId: string,
+  workspaceId: string,
+  opts: { force?: boolean } = {},
+): Promise<ValuePointsResult> {
+  const base = await baseCurrencyFor(workspaceId);
+  if (!base) return NOOP;
+
+  const header = await db.execute(
+    sql`SELECT occurred_on FROM transactions
+         WHERE id = ${transactionId}::uuid
+           AND workspace_id = ${workspaceId}::uuid`,
+  );
+  const occurredOn = (header.rows[0] as { occurred_on: string } | undefined)
+    ?.occurred_on;
+  if (!occurredOn) return NOOP;
+  const onDate = String(occurredOn).slice(0, 10);
+
+  const postingsRes = await db.execute(
+    sql`SELECT id, amount_minor, currency, fx_rate, amount_base_minor
+          FROM postings
+         WHERE transaction_id = ${transactionId}::uuid
+         ORDER BY id`,
+  );
+  const postings = postingsRes.rows as unknown as PostingRow[];
+  if (postings.length === 0) return NOOP;
+
+  const pointsLegs = postings.filter((p) => isPointsCurrency(p.currency));
+  if (pointsLegs.length === 0) return NOOP;
+
+  // `fx_rate = 0` means "ran, no valuation configured" — always re-tried,
+  // so configuring a valuation later picks the leg up without `force`.
+  const needsWork = opts.force
+    ? pointsLegs
+    : pointsLegs.filter((p) => p.fx_rate === null || Number(p.fx_rate) === 0);
+  if (needsWork.length === 0) return NOOP;
+
+  // One valuation lookup per distinct programme, not per posting.
+  const valuations = new Map<string, ResolvedValuation | null>();
+  for (const currency of new Set(pointsLegs.map((p) => p.currency))) {
+    valuations.set(
+      currency,
+      await resolvePointsValuation(workspaceId, currency, base, onDate),
+    );
+  }
+
+  // Cash legs keep whatever they hold (the FX pass owns them); points
+  // legs get the new value. The residual is measured across everything so
+  // the deferred balance trigger sees a clean sum-to-zero.
+  const priced = postings.map((p) => {
+    const minor = BigInt(p.amount_minor);
+    if (!isPointsCurrency(p.currency)) {
+      return {
+        id: p.id,
+        baseMinor: BigInt(p.amount_base_minor ?? "0"),
+        rate: null as number | null,
+        isPoints: false,
+      };
+    }
+    const v = valuations.get(p.currency) ?? null;
+    const rate = v?.minorPerPoint ?? 0;
+    return {
+      id: p.id,
+      baseMinor: BigInt(Math.round(Number(minor) * rate)),
+      rate,
+      isPoints: true,
+    };
+  });
+
+  const abs = (v: bigint): bigint => (v < 0n ? -v : v);
+  const residual = priced.reduce((s, c) => s + c.baseMinor, 0n);
+  if (residual !== 0n) {
+    const pointsPriced = priced.filter((c) => c.isPoints);
+    let target = pointsPriced[0]!;
+    for (const c of pointsPriced) {
+      if (abs(c.baseMinor) > abs(target.baseMinor)) target = c;
+    }
+    target.baseMinor -= residual;
+  }
+
+  const applied: ResolvedValuation[] = [];
+  const unvalued: string[] = [];
+  for (const [currency, v] of valuations) {
+    if (v) applied.push(v);
+    else unvalued.push(currency);
+  }
+
+  // Provenance on the transaction, mirroring `metadata.fx` (#184). This
+  // is what answers "why is this stay $688.50?" a year from now, and it
+  // is where `confirmed: false` is recorded per applied valuation so a
+  // report can say how much of a total rests on an unconfirmed number.
+  const provenance = {
+    applied_at: new Date().toISOString(),
+    base_currency: base,
+    valuations: applied.map((v) => ({
+      currency: v.currency,
+      minor_per_point: v.minorPerPoint,
+      effective_from: v.effectiveFrom,
+      source: v.source,
+      confirmed: v.confirmed,
+    })),
+    unvalued,
+  };
+
+  await db.transaction(async (tx) => {
+    for (const c of priced) {
+      if (!c.isPoints) continue;
+      await tx.execute(
+        sql`UPDATE postings
+               SET fx_rate = ${c.rate}::numeric,
+                   amount_base_minor = ${c.baseMinor.toString()}::bigint
+             WHERE id = ${c.id}::uuid`,
+      );
+    }
+    await tx.execute(
+      sql`UPDATE transactions
+             SET metadata = jsonb_set(
+                   COALESCE(metadata, '{}'::jsonb),
+                   '{points}',
+                   ${JSON.stringify(provenance)}::jsonb,
+                   true)
+           WHERE id = ${transactionId}::uuid
+             AND workspace_id = ${workspaceId}::uuid`,
+    );
+  });
+
+  return { changed: true, applied, unvalued };
+}
+
+/**
+ * Worker-facing wrapper: value a batch of transaction ids, never
+ * throwing. Same contract as `normalizeFxSafely` — valuation is a
+ * correction pass, not a gate. A failure leaves `fx_rate NULL` on the
+ * points legs, which is the marker a re-run looks for.
+ */
+export async function valuePointsSafely(
+  transactionIds: string[],
+  workspaceId: string,
+): Promise<void> {
+  for (const id of transactionIds) {
+    try {
+      const res = await valueTransactionPoints(id, workspaceId);
+      if (!res.changed) continue;
+      const parts = res.applied.map(
+        (v) =>
+          `${v.currency}→base @ ${v.minorPerPoint}/pt` +
+          `${v.confirmed ? "" : " (UNCONFIRMED)"}`,
+      );
+      if (res.unvalued.length > 0) {
+        parts.push(`unvalued: ${res.unvalued.join(", ")}`);
+      }
+      console.log(`[points] valued transaction ${id}: ${parts.join(", ")}`);
+    } catch (err) {
+      console.warn(
+        `[points] could not value transaction ${id}: ` +
+          `${err instanceof Error ? err.message : String(err)} — ` +
+          `leaving fx_rate NULL for a later pass`,
+      );
+    }
+  }
+}

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -28,8 +28,11 @@ import {
   NetWorthReport,
   CashflowQuery,
   CashflowReport,
+  PointsDisclosure,
+  PointsProgrammeTotal,
 } from "../schemas/v1/report.js";
 import { ProblemDetails } from "../schemas/v1/common.js";
+import { POINTS_CURRENCY_SQL_RE } from "../points/codes.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -60,6 +63,182 @@ function toInt(value: unknown): number {
   if (typeof value === "number") return value;
   if (typeof value === "bigint") return Number(value);
   return Number(value);
+}
+
+// ── Points disclosure (#206) ───────────────────────────────────────────
+//
+// Points are a currency, so a redeemed award stay is spend and belongs in
+// the spend totals — that is the owner's decision and the reason #206
+// exists. But a base-currency total that quietly mixes real dollars with
+// a valuation of Hyatt points is not a number anyone can act on, so every
+// report says, in the payload, exactly how the two combine.
+//
+// The rule, stated once here and echoed in each report's `policy` string:
+//
+//   spend reports  points-valued spend IS included in the totals; the
+//                  disclosure says how much of the total it is and how
+//                  much of that rests on an unconfirmed valuation
+//   net worth      points accounts are EXCLUDED, because only redemptions
+//                  are recorded — earning is not ingested, so the balance
+//                  is a running tally of points spent, not points held,
+//                  and adding it would drag net worth down by the value
+//                  of every award ever redeemed
+//   unvalued       a programme with no configured valuation contributes
+//                  nothing to any total and is counted separately, so it
+//                  reads as a gap to fill rather than as $0 of spend
+
+type ProgrammeRow = {
+  currency: string;
+  points_minor: string | number | bigint;
+  base_minor: string | number | bigint;
+  valuation_exists: boolean;
+  valuation_confirmed: boolean;
+};
+
+const SPEND_POLICY =
+  "Loyalty points are a currency (#206): points-denominated spend is " +
+  "converted at the workspace's configured per-programme valuation and " +
+  "IS included in the totals above. `unconfirmed_base_minor` is the part " +
+  "of that resting on a valuation the owner has not confirmed; " +
+  "`unvalued_transaction_count` transactions contributed nothing because " +
+  "their programme has no valuation configured at all.";
+
+const NET_WORTH_POLICY =
+  "Loyalty points accounts are EXCLUDED from the balances above (#206). " +
+  "Only redemptions are recorded — points earning is not ingested — so a " +
+  "points account's balance is a tally of points spent, not points held, " +
+  "and including it would understate net worth by the value of every " +
+  "award redeemed. The programme totals below are that tally.";
+
+function summarize(
+  rows: ProgrammeRow[],
+  policy: string,
+  includedInTotals: boolean,
+  unvaluedTransactionCount: number,
+): z.infer<typeof PointsDisclosure> {
+  const programmes: z.infer<typeof PointsProgrammeTotal>[] = rows.map((r) => ({
+    currency: r.currency,
+    points_minor: toInt(r.points_minor),
+    base_minor: toInt(r.base_minor),
+    valuation_exists: r.valuation_exists,
+    valuation_confirmed: r.valuation_confirmed,
+  }));
+  return {
+    policy,
+    included_in_totals: includedInTotals,
+    base_minor: programmes.reduce((a, p) => a + p.base_minor, 0),
+    unconfirmed_base_minor: programmes
+      .filter((p) => !p.valuation_confirmed)
+      .reduce((a, p) => a + p.base_minor, 0),
+    unvalued_transaction_count: unvaluedTransactionCount,
+    programmes,
+  };
+}
+
+/**
+ * Points contribution to the *expense* rollups (summary / trends /
+ * cashflow). Same posting predicate those reports use — expense-type
+ * accounts, money-counting transactions — restricted to points legs.
+ */
+async function getSpendPointsDisclosure(args: {
+  workspaceId: string;
+  from?: string;
+  to?: string;
+}): Promise<z.infer<typeof PointsDisclosure>> {
+  const fromFilter = args.from
+    ? sql`AND t.occurred_on >= ${args.from}::date`
+    : sql``;
+  const toFilter = args.to ? sql`AND t.occurred_on <= ${args.to}::date` : sql``;
+
+  const res = await db.execute(sql`
+    WITH legs AS (
+      SELECT p.currency,
+             p.amount_minor,
+             COALESCE(p.amount_base_minor, 0) AS base_minor,
+             t.id AS tx_id
+        FROM postings p
+        JOIN transactions t ON t.id = p.transaction_id
+        JOIN accounts a ON a.id = p.account_id
+       WHERE p.workspace_id = ${args.workspaceId}::uuid
+         AND t.status IN ('posted', 'reconciled') AND t.deleted_at IS NULL
+         AND a.type = 'expense'
+         AND p.amount_minor > 0
+         AND p.currency ~ ${POINTS_CURRENCY_SQL_RE}
+         ${fromFilter}
+         ${toFilter}
+    )
+    SELECT l.currency,
+           SUM(l.amount_minor)::bigint AS points_minor,
+           SUM(l.base_minor)::bigint   AS base_minor,
+           COUNT(DISTINCT l.tx_id) FILTER (WHERE l.base_minor = 0)::int
+             AS unvalued_txn_count,
+           (v.currency IS NOT NULL)    AS valuation_exists,
+           (v.confirmed_at IS NOT NULL) AS valuation_confirmed
+      FROM legs l
+      LEFT JOIN LATERAL (
+        SELECT pv.currency, pv.confirmed_at
+          FROM points_valuations pv
+         WHERE pv.workspace_id = ${args.workspaceId}::uuid
+           AND pv.currency = l.currency
+         ORDER BY pv.effective_from DESC
+         LIMIT 1
+      ) v ON TRUE
+     GROUP BY l.currency, v.currency, v.confirmed_at
+     ORDER BY base_minor DESC, l.currency ASC
+  `);
+
+  const rows = res.rows as unknown as Array<
+    ProgrammeRow & { unvalued_txn_count: number }
+  >;
+  const unvalued = rows.reduce((a, r) => a + toInt(r.unvalued_txn_count), 0);
+  return summarize(rows, SPEND_POLICY, true, unvalued);
+}
+
+/**
+ * Points asset accounts, for the net-worth report that excludes them.
+ * Balances are reported so the exclusion is auditable rather than just
+ * asserted.
+ */
+async function getAccountPointsDisclosure(args: {
+  workspaceId: string;
+  asOf: string;
+}): Promise<z.infer<typeof PointsDisclosure>> {
+  const res = await db.execute(sql`
+    SELECT a.currency,
+           COALESCE(SUM(p.amount_minor) FILTER (
+             WHERE t.status IN ('posted','reconciled') AND t.deleted_at IS NULL
+               AND t.occurred_on <= ${args.asOf}::date
+           ), 0)::bigint AS points_minor,
+           COALESCE(SUM(p.amount_base_minor) FILTER (
+             WHERE t.status IN ('posted','reconciled') AND t.deleted_at IS NULL
+               AND t.occurred_on <= ${args.asOf}::date
+           ), 0)::bigint AS base_minor,
+           (v.currency IS NOT NULL)     AS valuation_exists,
+           (v.confirmed_at IS NOT NULL) AS valuation_confirmed
+      FROM accounts a
+      LEFT JOIN postings p ON p.account_id = a.id AND p.workspace_id = a.workspace_id
+      LEFT JOIN transactions t ON t.id = p.transaction_id
+      LEFT JOIN LATERAL (
+        SELECT pv.currency, pv.confirmed_at
+          FROM points_valuations pv
+         WHERE pv.workspace_id = a.workspace_id
+           AND pv.currency = a.currency
+         ORDER BY pv.effective_from DESC
+         LIMIT 1
+      ) v ON TRUE
+     WHERE a.workspace_id = ${args.workspaceId}::uuid
+       AND a.closed_at IS NULL
+       AND a.currency ~ ${POINTS_CURRENCY_SQL_RE}
+     GROUP BY a.currency, v.currency, v.confirmed_at
+     ORDER BY a.currency ASC
+  `);
+
+  return summarize(
+    res.rows as unknown as ProgrammeRow[],
+    NET_WORTH_POLICY,
+    false,
+    0,
+  );
 }
 
 // ── Service: summary ───────────────────────────────────────────────────
@@ -166,6 +345,11 @@ export async function getSummaryReport(
     currency,
     items,
     grand_total_minor: grandTotal,
+    points: await getSpendPointsDisclosure({
+      workspaceId: args.workspaceId,
+      from: args.from,
+      to: args.to,
+    }),
   };
 }
 
@@ -270,6 +454,11 @@ export async function getTrendsReport(
     group_by: groupBy,
     currency,
     buckets,
+    points: await getSpendPointsDisclosure({
+      workspaceId: args.workspaceId,
+      from: args.from,
+      to: args.to,
+    }),
   };
 }
 
@@ -314,6 +503,13 @@ export async function getNetWorthReport(
     WHERE a.workspace_id = ${args.workspaceId}::uuid
       AND a.closed_at IS NULL
       AND a.type IN ('asset', 'liability', 'equity')
+      -- Points accounts are excluded (#206). Only redemptions are
+      -- recorded, so their balance is a tally of points SPENT, not points
+      -- held; including it would understate net worth by the value of
+      -- every award ever redeemed. The points block in the response
+      -- reports the excluded balances, so this is auditable, not just
+      -- asserted.
+      AND a.currency !~ ${POINTS_CURRENCY_SQL_RE}
     GROUP BY a.id, a.name, a.type
     ORDER BY a.type ASC, a.name ASC
   `);
@@ -349,6 +545,10 @@ export async function getNetWorthReport(
     equity_minor: equity,
     net_worth_minor: assets + liabilities + equity,
     by_account: byAccount,
+    points: await getAccountPointsDisclosure({
+      workspaceId: args.workspaceId,
+      asOf,
+    }),
   };
 }
 
@@ -435,6 +635,11 @@ export async function getCashflowReport(
     expense_minor: totalExpense,
     net_minor: totalIncome - totalExpense,
     buckets,
+    points: await getSpendPointsDisclosure({
+      workspaceId: args.workspaceId,
+      from: args.from,
+      to: args.to,
+    }),
   };
 }
 

--- a/src/routes/transactions.service.ts
+++ b/src/routes/transactions.service.ts
@@ -26,6 +26,8 @@ import {
   merchants,
 } from "../schema/index.js";
 import { loadPlacesByIds, type PlaceRow } from "./places.service.js";
+import { isPointsCurrency } from "../points/codes.js";
+import { resolvePointsValuation } from "../points/valuation.js";
 
 import { newId } from "../http/uuid.js";
 import {
@@ -551,13 +553,44 @@ export async function createTransaction(
     memo: string | null;
   };
 
+  // #206 — a points posting has no published rate for the client to
+  // supply, so the server resolves the programme valuation instead of
+  // demanding fx_rate + amount_base_minor from the caller. Resolved up
+  // front, once per programme, because the posting map below is sync.
+  // A programme with no valuation resolves to 0, which is the same
+  // visible `unvalued` state the ingest path produces — never a silent
+  // rejection and never a guessed number.
+  const pointsRates = new Map<string, number>();
+  for (const p of body.postings) {
+    const currency = p.currency ?? acctMap.get(p.account_id)!.currency;
+    if (!isPointsCurrency(currency) || pointsRates.has(currency)) continue;
+    const v = await resolvePointsValuation(
+      workspaceId,
+      currency,
+      baseCurrency,
+      body.occurred_on,
+    );
+    pointsRates.set(currency, v?.minorPerPoint ?? 0);
+  }
+
   const txId = newId();
   const postingInserts: PostingInsert[] = body.postings.map((p, idx) => {
     const acct = acctMap.get(p.account_id)!;
     const currency = p.currency ?? acct.currency;
     let fxRate: string | null = null;
     let amountBaseMinor: bigint;
-    if (currency === baseCurrency) {
+    if (isPointsCurrency(currency)) {
+      // An explicit client-supplied pair still wins — that is how a
+      // correction or an import of already-valued history gets in.
+      if (p.fx_rate !== undefined && p.amount_base_minor !== undefined) {
+        fxRate = p.fx_rate;
+        amountBaseMinor = BigInt(p.amount_base_minor);
+      } else {
+        const rate = pointsRates.get(currency) ?? 0;
+        fxRate = String(rate);
+        amountBaseMinor = BigInt(Math.round(Number(p.amount_minor) * rate));
+      }
+    } else if (currency === baseCurrency) {
       if (p.fx_rate !== undefined && p.fx_rate !== "1" && p.fx_rate !== "1.0") {
         // Allow redundant "1" but otherwise reject.
         const n = Number(p.fx_rate);
@@ -1534,7 +1567,29 @@ export async function addPosting(
   const currency = body.currency ?? acct.currency;
   let fxRate: string | null = null;
   let amountBaseMinor: bigint;
-  if (currency === baseCurrency) {
+  if (isPointsCurrency(currency)) {
+    // Same rule as createTransaction: the server resolves the programme
+    // valuation (#206) rather than making the client know it.
+    if (body.fx_rate !== undefined && body.amount_base_minor !== undefined) {
+      fxRate = body.fx_rate;
+      amountBaseMinor = BigInt(body.amount_base_minor);
+    } else {
+      const header = await db
+        .select({ occurredOn: transactions.occurredOn })
+        .from(transactions)
+        .where(eq(transactions.id, txId));
+      const onDate = header[0]?.occurredOn ?? new Date().toISOString().slice(0, 10);
+      const v = await resolvePointsValuation(
+        workspaceId,
+        currency,
+        baseCurrency,
+        onDate,
+      );
+      const rate = v?.minorPerPoint ?? 0;
+      fxRate = String(rate);
+      amountBaseMinor = BigInt(Math.round(Number(body.amount_minor) * rate));
+    }
+  } else if (currency === baseCurrency) {
     amountBaseMinor = BigInt(body.amount_base_minor ?? body.amount_minor);
   } else {
     if (body.fx_rate === undefined || body.amount_base_minor === undefined) {

--- a/src/schema/accounts.ts
+++ b/src/schema/accounts.ts
@@ -2,11 +2,12 @@ import {
   pgTable,
   uuid,
   text,
-  char,
+  varchar,
   bigint,
   timestamp,
   jsonb,
   index,
+  uniqueIndex,
   type AnyPgColumn,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
@@ -28,7 +29,10 @@ export const accounts = pgTable(
     name: text("name").notNull(),
     type: accountTypeEnum("type").notNull(),
     subtype: text("subtype"),
-    currency: char("currency", { length: 3 }).notNull(),
+    // ISO 4217 for cash accounts, or a points-programme code (`HYATT_PT`)
+    // for the per-programme points asset account (#206, 0038). Disjoint
+    // by shape — see `src/points/codes.ts`.
+    currency: varchar("currency", { length: 16 }).notNull(),
     institution: text("institution"),
     last4: text("last4"),
     openingBalanceMinor: bigint("opening_balance_minor", { mode: "bigint" })
@@ -44,5 +48,13 @@ export const accounts = pgTable(
     index("accounts_workspace_idx").on(t.workspaceId),
     index("accounts_parent_idx").on(t.parentId),
     index("accounts_workspace_type_idx").on(t.workspaceId, t.type),
+    // One points asset account per programme per workspace (#206). The
+    // extraction agent upserts against this index (`ON CONFLICT
+    // (workspace_id, currency) WHERE subtype = 'points'`) so an award
+    // stay for a programme seen for the first time creates its account
+    // inline instead of failing the write for a missing credit leg.
+    uniqueIndex("accounts_points_uq")
+      .on(t.workspaceId, t.currency)
+      .where(sql`${t.subtype} = 'points'`),
   ],
 );

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -12,6 +12,8 @@ export * from "./transaction_parties.js";
 export * from "./brands.js";
 export * from "./postings.js";
 export * from "./fx_rates.js";
+export * from "./points_programmes.js";
+export * from "./points_valuations.js";
 export * from "./documents.js";
 export * from "./audit.js";
 export * from "./idempotency.js";

--- a/src/schema/points_programmes.ts
+++ b/src/schema/points_programmes.ts
@@ -1,0 +1,34 @@
+import { pgTable, varchar, text, jsonb } from "drizzle-orm/pg-core";
+import { createdAt, updatedAt } from "./common.js";
+
+/**
+ * Loyalty-programme registry (#206).
+ *
+ * World-level, like `fx_rates`: "World of Hyatt points are called
+ * HYATT_PT and one point is the whole unit" is a fact about the world,
+ * not about a tenant. What a point is *worth* is emphatically not — that
+ * is a personal judgement and lives per workspace in `points_valuations`.
+ *
+ * The table is a naming registry, not a constraint: `postings.currency`
+ * carries no FK to it, because the currency-shape CHECK already keeps the
+ * cash and points namespaces disjoint (see `src/points/codes.ts`) and a
+ * hard FK would fail an ingest for an unregistered programme rather than
+ * recording the stay and flagging it. An unregistered code is a visible
+ * gap in the reports, not a write error.
+ */
+export const pointsProgrammes = pgTable("points_programmes", {
+  /** Points currency code, e.g. `HYATT_PT`. Matches POINTS_CURRENCY_RE. */
+  code: varchar("code", { length: 16 }).primaryKey(),
+  /** Display name, e.g. "World of Hyatt points". */
+  name: text("name").notNull(),
+  /** Optional link to the issuing brand in `brands.brand_id`. */
+  issuerBrandId: text("issuer_brand_id"),
+  /**
+   * Free-form provenance / caveats, e.g. where a seeded valuation came
+   * from and what still needs the owner's confirmation.
+   */
+  notes: text("notes"),
+  metadata: jsonb("metadata").notNull().default({}),
+  createdAt,
+  updatedAt,
+});

--- a/src/schema/points_valuations.ts
+++ b/src/schema/points_valuations.ts
@@ -1,0 +1,91 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  char,
+  date,
+  text,
+  numeric,
+  timestamp,
+  primaryKey,
+  index,
+} from "drizzle-orm/pg-core";
+import { createdAt, updatedAt } from "./common.js";
+import { workspaces } from "./workspaces.js";
+import { pointsProgrammes } from "./points_programmes.js";
+
+/**
+ * What one point is worth, per workspace, versioned by effective date
+ * (#206).
+ *
+ * This is the deliberate counterpart to `fx_rates`, and the differences
+ * are the whole design:
+ *
+ * | | `fx_rates` | `points_valuations` |
+ * |---|---|---|
+ * | scope | world | **workspace** — a valuation is a judgement, not a fact |
+ * | source | ECB publication | **the owner**, or a marked-provisional seed |
+ * | key | the date asked for | the date range it is **effective** for |
+ * | resolution | exact date match | newest `effective_from <= occurred_on` |
+ *
+ * Versioning by `effective_from` rather than by observation date is what
+ * makes a re-valuation safe: changing what a point is worth *going
+ * forward* leaves last year's stays valued at last year's number, so a
+ * report re-run does not quietly rewrite history. Re-valuing the past is
+ * possible but has to be asked for explicitly (insert a row with an
+ * earlier `effective_from` and re-run the valuation pass with `force`).
+ *
+ * ## `confirmed_at` — provisional numbers are visible, not silent
+ *
+ * A valuation the owner has not signed off on carries `confirmed_at
+ * NULL`. It is still applied (a stay valued at a marked-provisional rate
+ * is closer to the owner's "積分房一定要算" than a stay valued at zero),
+ * but every report that includes it says how much of the total depends
+ * on an unconfirmed number. Confirming is a one-row UPDATE; changing the
+ * number is one INSERT plus a `force` re-run.
+ */
+export const pointsValuations = pgTable(
+  "points_valuations",
+  {
+    workspaceId: uuid("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    /** Points currency being valued, e.g. `HYATT_PT`. */
+    currency: varchar("currency", { length: 16 })
+      .notNull()
+      .references(() => pointsProgrammes.code, { onDelete: "restrict" }),
+    /** Cash currency the valuation is expressed in — the workspace base. */
+    quote: char("quote", { length: 3 }).notNull(),
+    /** First date this valuation applies to (inclusive). */
+    effectiveFrom: date("effective_from").notNull(),
+    /**
+     * Base-currency **minor units** per one point. 1.7 US cents per Hyatt
+     * point is `1.7`, not `0.017`: points have no subunit, so one point
+     * is one minor unit of its own currency and the conversion is a plain
+     * minor→minor multiply — exactly the semantics of
+     * `postings.fx_rate`, which this value is written to. numeric(20,10)
+     * mirrors that column so the number round-trips without loss.
+     */
+    minorPerPoint: numeric("minor_per_point", {
+      precision: 20,
+      scale: 10,
+    }).notNull(),
+    /** Where the number came from, e.g. `owner`, `issue-206-example`. */
+    source: text("source").notNull(),
+    /** NULL until the owner has confirmed the number. */
+    confirmedAt: timestamp("confirmed_at", { withTimezone: true }),
+    note: text("note"),
+    createdAt,
+    updatedAt,
+  },
+  (t) => [
+    primaryKey({ columns: [t.workspaceId, t.currency, t.effectiveFrom] }),
+    // Resolution path: "newest valuation for this pair effective on or
+    // before D".
+    index("points_valuations_lookup_idx").on(
+      t.workspaceId,
+      t.currency,
+      t.effectiveFrom.desc(),
+    ),
+  ],
+);

--- a/src/schema/postings.ts
+++ b/src/schema/postings.ts
@@ -2,7 +2,7 @@ import {
   pgTable,
   uuid,
   text,
-  char,
+  varchar,
   bigint,
   numeric,
   index,
@@ -26,9 +26,14 @@ export const postings = pgTable(
       .notNull()
       .references(() => accounts.id, { onDelete: "restrict" }),
     amountMinor: bigint("amount_minor", { mode: "bigint" }).notNull(),
-    currency: char("currency", { length: 3 }).notNull(),
-    // FX rate from posting currency → workspace base currency at occurrence.
-    // Null when no conversion was needed (same currency).
+    // ISO 4217 for cash, or a points-programme code (`HYATT_PT`) for a
+    // loyalty redemption — widened from char(3) in 0038 (#206). The two
+    // namespaces are disjoint by shape; see `src/points/codes.ts`.
+    currency: varchar("currency", { length: 16 }).notNull(),
+    // Rate from posting currency → workspace base currency at occurrence,
+    // in minor units. Null when no conversion was needed (same currency).
+    // For a points leg this is the programme valuation resolved by
+    // `src/points/valuation.ts`, never a published FX rate.
     fxRate: numeric("fx_rate", { precision: 20, scale: 10 }),
     // Base-currency amount persisted so the balance trigger and reports
     // don't need to re-derive FX. Nullable during insert; app fills it

--- a/src/schemas/v1/account.ts
+++ b/src/schemas/v1/account.ts
@@ -4,7 +4,7 @@
 import { z } from "zod";
 import {
   AmountMinor,
-  CurrencyCode,
+  LedgerCurrencyCode,
   IsoDate,
   IsoDateTime,
   Metadata,
@@ -27,7 +27,7 @@ const baseAccountFields = {
   name: z.string().min(1),
   type: AccountType,
   subtype: z.string().nullable(),
-  currency: CurrencyCode,
+  currency: LedgerCurrencyCode,
   institution: z.string().nullable(),
   last4: z.string().nullable(),
   opening_balance_minor: AmountMinor,
@@ -54,7 +54,7 @@ export const CreateAccountRequest = z
     name: z.string().min(1),
     type: AccountType,
     subtype: z.string().optional(),
-    currency: CurrencyCode.optional(), // inherit from parent if omitted
+    currency: LedgerCurrencyCode.optional(), // inherit from parent if omitted
     institution: z.string().optional(),
     last4: z.string().optional(),
     opening_balance_minor: AmountMinor.optional(),
@@ -80,7 +80,7 @@ export const AccountBalance = z
     account_id: Uuid,
     as_of: IsoDate,
     balance_minor: AmountMinor,
-    currency: CurrencyCode,
+    currency: LedgerCurrencyCode,
     posting_count: z.number().int(),
     includes_children: z.boolean(),
   })
@@ -110,7 +110,7 @@ export const RegisterItem = z
     payee: z.string().nullable(),
     narration: z.string().nullable(),
     amount_minor: AmountMinor,
-    currency: CurrencyCode,
+    currency: LedgerCurrencyCode,
     running_balance_after_minor: AmountMinor,
     counter_postings: z.array(RegisterCounterPosting),
     documents: z.array(RegisterDocumentRef),
@@ -132,7 +132,7 @@ export const ListAccountsQuery = z.object({
 
 export const BalanceQuery = z.object({
   as_of: IsoDate.optional(),
-  currency: CurrencyCode.optional(),
+  currency: LedgerCurrencyCode.optional(),
   include_children: z.coerce.boolean().optional(),
 });
 

--- a/src/schemas/v1/common.ts
+++ b/src/schemas/v1/common.ts
@@ -18,6 +18,26 @@ export const CurrencyCode = z
   .regex(/^[A-Z]{3}$/, "ISO 4217 3-letter code, uppercase")
   .openapi({ example: "USD" });
 
+/**
+ * A currency a posting or account may be denominated in: ISO 4217 cash,
+ * or a loyalty-programme unit (#206).
+ *
+ * The two namespaces are disjoint by shape — ISO codes are three letters
+ * and cannot contain an underscore — which is what lets the FX path and
+ * the points-valuation path select disjoint sets of postings with a
+ * regex instead of a lookup table. See `src/points/codes.ts`.
+ *
+ * `CurrencyCode` (above) stays cash-only on purpose: a workspace base
+ * currency, and therefore a report's reporting currency, must be cash.
+ */
+export const LedgerCurrencyCode = z
+  .string()
+  .regex(
+    /^([A-Z]{3}|[A-Z][A-Z0-9]{1,12}_PT)$/,
+    "ISO 4217 3-letter code, or a points-programme code like HYATT_PT",
+  )
+  .openapi({ example: "USD" });
+
 export const AmountMinor = z
   .number()
   .int()

--- a/src/schemas/v1/report.ts
+++ b/src/schemas/v1/report.ts
@@ -22,6 +22,48 @@ export const SummaryGroupBy = z.enum(["category", "account", "payee"]);
 export const TrendsPeriod = z.enum(["month", "year"]);
 export const TrendsGroupBy = z.enum(["category", "total"]);
 
+// ── Points disclosure (#206) ───────────────────────────────────────────
+
+/**
+ * How loyalty points contributed to the numbers alongside it.
+ *
+ * Every report carries one of these because a base-currency total that
+ * silently mixes cash with a valuation of Hyatt points is not a number
+ * anyone can act on. It answers three questions the total cannot:
+ * how much of it is points rather than cash, how much of it rests on a
+ * valuation the owner has not confirmed, and how many points
+ * transactions were left out entirely for want of a valuation.
+ */
+export const PointsProgrammeTotal = z
+  .object({
+    currency: z.string().openapi({ example: "HYATT_PT" }),
+    /** Points/miles, in the programme's own units. */
+    points_minor: AmountMinor,
+    /** Their value in the report's base currency. */
+    base_minor: AmountMinor,
+    /** A valuation is configured for this programme. */
+    valuation_exists: z.boolean(),
+    /** The owner has signed off on that valuation. */
+    valuation_confirmed: z.boolean(),
+  })
+  .openapi("PointsProgrammeTotal");
+
+export const PointsDisclosure = z
+  .object({
+    /** One sentence stating how points combine with cash in this report. */
+    policy: z.string(),
+    /** Whether `base_minor` is inside the report's own totals. */
+    included_in_totals: z.boolean(),
+    /** Points-derived base-currency amount in scope. */
+    base_minor: AmountMinor,
+    /** Of `base_minor`, how much rests on an unconfirmed valuation. */
+    unconfirmed_base_minor: AmountMinor,
+    /** Transactions whose points could not be valued at all. */
+    unvalued_transaction_count: z.number().int(),
+    programmes: z.array(PointsProgrammeTotal),
+  })
+  .openapi("PointsDisclosure");
+
 // ── Summary ────────────────────────────────────────────────────────────
 
 export const SummaryQuery = z.object({
@@ -48,6 +90,7 @@ export const SummaryReport = z
     currency: CurrencyCode,
     items: z.array(SummaryItem),
     grand_total_minor: AmountMinor,
+    points: PointsDisclosure,
   })
   .openapi("SummaryReport");
 
@@ -85,6 +128,7 @@ export const TrendsReport = z
     group_by: TrendsGroupBy,
     currency: CurrencyCode,
     buckets: z.array(TrendsBucket),
+    points: PointsDisclosure,
   })
   .openapi("TrendsReport");
 
@@ -113,6 +157,7 @@ export const NetWorthReport = z
     equity_minor: AmountMinor,
     net_worth_minor: AmountMinor,
     by_account: z.array(NetWorthAccount),
+    points: PointsDisclosure,
   })
   .openapi("NetWorthReport");
 
@@ -142,5 +187,6 @@ export const CashflowReport = z
     expense_minor: AmountMinor,
     net_minor: AmountMinor,
     buckets: z.array(CashflowBucket),
+    points: PointsDisclosure,
   })
   .openapi("CashflowReport");

--- a/src/schemas/v1/transaction.ts
+++ b/src/schemas/v1/transaction.ts
@@ -4,7 +4,7 @@
 import { z } from "zod";
 import {
   AmountMinor,
-  CurrencyCode,
+  LedgerCurrencyCode,
   IsoDate,
   IsoDateTime,
   Metadata,
@@ -42,7 +42,7 @@ export const Posting = z
     transaction_id: Uuid,
     account_id: Uuid,
     amount_minor: AmountMinor,
-    currency: CurrencyCode,
+    currency: LedgerCurrencyCode,
     fx_rate: z.string().nullable(), // numeric returned as string from pg
     amount_base_minor: AmountMinor.nullable(),
     memo: z.string().nullable(),
@@ -54,7 +54,7 @@ export const NewPosting = z
   .object({
     account_id: Uuid,
     amount_minor: AmountMinor,
-    currency: CurrencyCode.optional(),
+    currency: LedgerCurrencyCode.optional(),
     fx_rate: z.string().optional(),
     amount_base_minor: AmountMinor.optional(),
     memo: z.string().optional(),
@@ -199,7 +199,7 @@ export const NewTransactionItem = z
     line_total_minor: z.number().int(),
     /** Omit to inherit the transaction's posting currency. Required
      *  only when the transaction's postings disagree on currency. */
-    currency: CurrencyCode.optional(),
+    currency: LedgerCurrencyCode.optional(),
     item_class: z.enum([
       "durable",
       "consumable",
@@ -323,7 +323,7 @@ export const UpdatePostingRequest = z
   .object({
     account_id: Uuid.optional(),
     amount_minor: AmountMinor.optional(),
-    currency: CurrencyCode.optional(),
+    currency: LedgerCurrencyCode.optional(),
     fx_rate: z.string().optional(),
     amount_base_minor: AmountMinor.optional(),
     memo: z.string().nullable().optional(),


### PR DESCRIPTION
Closes #206.

> 積分房一定要算，積分也是另外一種貨幣。 — owner, 2026-07-30

Supersedes `prompt.ts`'s rule that a points redemption bringing an order to $0.00 gets `total_minor = 0` because zero "IS the out-of-pocket amount". A 40,500-point stay is real spend denominated in a non-cash unit; zeroing it makes the spend invisible in every report.

## Valuation — the approach the owner chose

**Per-programme configured rate, versioned by effective date.** `points_valuations (workspace_id, currency, effective_from)` holds `minor_per_point`; the resolver picks the newest row with `effective_from <= occurred_on`.

⚠️ **The seeded number is not confirmed.** 1.7¢/Hyatt-point is the single example cited in the issue itself, seeded so the mechanism is exercised end-to-end rather than shipped untested, and marked `confirmed_at = NULL` / `source = 'issue-206-example'`. Reports disclose how much of a total rests on an unconfirmed valuation. **See the checklist at the bottom — these numbers need your sign-off before any total containing an award stay is trustworthy.**

A programme with **no** valuation row values at zero base and is counted as `unvalued` in reports — a visible gap, never a silent $0 expense.

## Cannot collide with the FX path — structurally, not by convention

The instruction was "never reuse the `fx_rate IS NULL` marker". This goes further:

- `postings.currency` and `accounts.currency` widen to `varchar(16)` to hold `HYATT_PT`.
- **`fx_rates.base` / `.quote` stay `char(3)` deliberately** — a points code *physically cannot be stored* in the FX cache, so no points amount can ever be derived from a published FX rate.
- **`workspaces.base_currency` stays `char(3)`** — "base currency = points" is unrepresentable.

Two disjoint namespaces **by shape**, so classification never needs a lookup:

```
cash    ^[A-Z]{3}$
points  ^[A-Z][A-Z0-9]{1,12}_PT$     underscore, which ISO cannot use
```

Squatting on the X- range was rejected: XCD/XOF/XAF/XPF are circulating currencies and XAU/XAG/XDR are real ISO allocations.

`postings_balance_ck` already enforces sum-to-zero **per currency**, so an award stay balances natively — debit Travel 40500 `HYATT_PT` / credit points asset −40500 `HYATT_PT`. The trigger is untouched.

## Migration ordering

`0038` is **DDL only**, `0039` is **DML only** and sorts after it. Drizzle runs every pending migration in one transaction, so DML queuing deferred-trigger events before an `ALTER TABLE` yields PG 55006 and a boot crash-loop (#174).

**Dry-run against production data**, per the repo's own rule:

```
BEGIN; <0038> <0039> SET CONSTRAINTS ALL IMMEDIATE; ROLLBACK;
-> ALTER TABLE / ALTER TABLE / CREATE INDEX / INSERT 0 1 / INSERT 0 1 / SET CONSTRAINTS
-> DRY RUN OK — both migrations applied without error
```

The `SET CONSTRAINTS ALL IMMEDIATE` matters: without it a plain ROLLBACK gives false confidence because the deferred checks never fire.

## Existing data — nothing touched

The 36 transactions carrying points/award metadata and the 213 zero-total rows keep **every value they have today**. Neither migration reads, updates or re-classifies a single one. The decision record for them is `docs/points-as-currency.md` § "Existing data" — re-valuing history is a separate, reviewed operation, consistent with the owner's standing instruction that existing zero-total data is not to be rewritten without review.

## Also in this PR

`prompt.ts` (the `total_minor = 0` rule) and the batch-2 blank-award-folio lesson in `lessons.md`, both updated in the same commit as the behavior change. Prompt budget baseline moved accordingly.

`tsc --noEmit` clean.

## ⚠️ Needs your confirmation before award-stay totals mean anything

- [ ] **Hyatt: 1.7 US cents per point** — seeded from the issue's example, unconfirmed
- [ ] Any other programme you use (airline miles, other hotel chains) — currently unvalued, so they value at zero and report as `unvalued`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ssDbfdur7JHRCLfZSQsyx