### PR TITLE
feat(api): let `q=` search reach line items (#217)

### DIFF
--- a/src/routes/transactions.service.ts
+++ b/src/routes/transactions.service.ts
@@ -1003,7 +1003,25 @@ export async function listTransactions(
   if (query.trip_id) conditions.push(sql`t.trip_id = ${query.trip_id}::uuid`);
   if (query.source_ingest_id) conditions.push(sql`t.source_ingest_id = ${query.source_ingest_id}::uuid`);
   if (query.payee_contains) conditions.push(sql`t.payee ILIKE ${"%" + query.payee_contains + "%"}`);
-  if (query.q) conditions.push(sql`(COALESCE(t.payee, '') || ' ' || COALESCE(t.narration, '')) ILIKE ${"%" + query.q + "%"}`);
+  // `q` spans the header AND the line items. Header-only search was a
+  // payee-only search in practice — `narration` is populated on 0.4% of rows,
+  // while 98% carry line items — so typing a product name found nothing (#217).
+  // Both name columns are matched: `normalized_name` is the cleaned name,
+  // `raw_name` the original listing title. An accessory bought *for* an iPad
+  // often says so only in `raw_name`, and recall matters more here than tidy
+  // results — a spurious hit is skipped at a glance, a missing one is never
+  // known about.
+  if (query.q) {
+    const needle = `%${query.q}%`;
+    conditions.push(sql`(
+      (COALESCE(t.payee, '') || ' ' || COALESCE(t.narration, '')) ILIKE ${needle}
+      OR EXISTS (
+        SELECT 1 FROM transaction_items ti
+        WHERE ti.transaction_id = t.id
+          AND (ti.raw_name ILIKE ${needle} OR COALESCE(ti.normalized_name, '') ILIKE ${needle})
+      )
+    )`);
+  }
   if (query.account_id) {
     conditions.push(sql`EXISTS (SELECT 1 FROM postings p WHERE p.transaction_id = t.id AND p.account_id = ${query.account_id}::uuid)`);
   }


### PR DESCRIPTION
Closes #217.

Typing a product name into the Ledger search box returned *"No entries match the current filters."* `q=` read only `transactions.payee` and `transactions.narration` — and `narration` is populated on **6 of 1,378 rows (0.4%)**, so it was a payee-only search, while **98%** of transactions carry line items nothing could reach.

## Change

One `EXISTS` over `transaction_items` added to the existing `q=` condition, in the same style as the neighbouring `account_id` and amount filters. No new table, trigger, migration or extension; one file, +19/-1.

## Verified against the production database

```
        before  after
ipad         0     24
airpods      0     19
folio        0      7
```

(Run as a read-only `COUNT` on `receipts` before the code was committed, so these are the real rows the new predicate selects — not an estimate.)

## Why `raw_name` is matched too

`normalized_name` is the cleaned name, `raw_name` the original listing title:

```
raw_name : USB C GaN Charger 30W, Anker 511 (Nano 3), … for iPhone 15/…, Galaxy, iPad (Cable Not…)
norm     : Anker 511 Charger (Nano 3) 30W USB-C GaN Charger
```

Of the 24 `ipad` hits, 15 match `normalized_name` and 9 only `raw_name` — largely accessories bought *for* an iPad whose clean name doesn't say so, which is exactly the case that motivated the issue. Recall beats tidiness here.

## Why no search index

A derived `tsvector` + `pg_trgm` + trigger design was considered and rejected. At 1,378 rows a seq scan is microseconds and `transaction_items.transaction_id` is already indexed. It would also regress Chinese search, which works fine under `ILIKE` substring matching and would need a dedicated parser under `tsvector`. Adding an index later does not require undoing this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JWW92oRnvhLarayv8aAri