### PR TITLE
chore: untrack `src/generated/build-info.ts` (#219)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ dist/
 *.db
 .DS_Store
 
+# Build artifact — rewritten by scripts/generate-build-info.mjs on every
+# prebuild. Tracking it dirtied the worktree after every build and swept a
+# stale sha/branch into 12 unrelated commits (#219). Scripts that import it
+# generate it first; the Dockerfile generates it during `npm run build`.
+src/generated/
+
 # Local secrets — use .env.example as the template
 .env
 .env.*

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "db:migrate": "tsx scripts/migrate.ts",
     "db:migrate:prod": "node dist/db/migrate.js",
     "db:seed": "tsx scripts/seed.ts",
-    "openapi:generate": "tsx scripts/generate-openapi.ts",
+    "openapi:generate": "node scripts/generate-build-info.mjs && tsx scripts/generate-openapi.ts",
     "eval:dates": "tsx scripts/eval-dates.ts",
-    "check:prompt-budget": "tsx scripts/check-prompt-budget.ts",
-    "check:ingest-classification": "tsx scripts/check-ingest-classification.ts"
+    "check:prompt-budget": "node scripts/generate-build-info.mjs && tsx scripts/check-prompt-budget.ts",
+    "check:ingest-classification": "node scripts/generate-build-info.mjs && tsx scripts/check-ingest-classification.ts"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.3.4",

--- a/src/generated/build-info.ts
+++ b/src/generated/build-info.ts
@@ -1,8 +1,0 @@
-export const buildInfo = {
-  "service": "receipt-assistant",
-  "version": "1.0.0",
-  "gitSha": "26a87603cd2618dc346b131ac3978c3d80d8025e",
-  "gitShortSha": "26a8760",
-  "gitBranch": "feat/product-images",
-  "builtAt": "2026-06-24T08:45:51.961Z"
-} as const;


### PR DESCRIPTION
Closes #219.

`src/generated/build-info.ts` is rewritten by `scripts/generate-build-info.mjs` on every prebuild, but was tracked and not ignored. Every local build dirtied the worktree, and the file got swept into whatever commit came next — **12 times**, in PRs about products, brands, reconcile, and one that was pure docs. It nearly landed in #218 and had to be reverted by hand.

The committed value wasn't just noise, it was **wrong**. `main` carried:

```jsonc
"gitBranch": "feat/product-images",     // a branch, not main
"builtAt":   "2026-06-24T08:45:51.961Z" // someone's June laptop
```

`buildInfo` feeds the health endpoints (`src/app.ts:66-72`), the startup banner (`src/server.ts:92`), and `metadata.extraction.prompt_git_sha` stamped on **every extracted transaction** (`src/ingest/prompt.ts:594`). Containers regenerate it at image-build time so production was fine, but anyone running from source recorded June's snapshot as extraction provenance.

## Change

`.gitignore` + `git rm --cached`, plus the generator prefixed onto the scripts that need it. Which ones was determined by **walking the transitive import graph**, not guessed:

| npm script | needs `buildInfo` | action |
|---|---|---|
| `prebuild` | yes | already generated first — untouched |
| `openapi:generate` | yes | prefixed |
| `check:prompt-budget` | yes | prefixed |
| `check:ingest-classification` | yes | prefixed |
| `db:migrate` / `db:seed` / `eval:dates` | no | untouched |

## Why not a `prepare` hook

The obvious alternative breaks the image build. The Dockerfile installs before it copies the generator:

```dockerfile
RUN npm ci            # prepare would fire here — scripts/ and .git absent
COPY .git ./.git
COPY scripts/ ./scripts/
RUN npm run build     # prebuild generates here, .git present, sha correct
```

Prefixing individual scripts is the only placement correct in both a fresh clone and the container.

## Verification

With `src/generated/` emptied, simulating a fresh checkout:

- `npm run check:prompt-budget` → regenerates, passes
- `npm run check:ingest-classification` → regenerates, 16/16 pass
- `npm run openapi:generate` → regenerates, 74 paths / 113 schemas, `openapi.json` byte-identical
- `npm run build` → passes
- `docker build` from an **empty** `src/generated/` → image builds, and the baked value is correct:

```
gitSha      c703b1a469093ac3286d079a4050332982df64de   ← matches HEAD
gitBranch   chore/219-untrack-build-info               ← matches actual branch
```

versus the stale `26a8760` / `feat/product-images` that `main` was shipping in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JWW92oRnvhLarayv8aAri