### PR TITLE
fix(reports): pick the spend leg by account type, not by sign (#221)

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -608,6 +608,17 @@
             "format": "uuid",
             "example": "01HXY9F0ABCDEFGHJKMNPQRSTV"
           },
+          "account_type": {
+            "type": "string",
+            "enum": [
+              "asset",
+              "liability",
+              "equity",
+              "income",
+              "expense"
+            ],
+            "description": "Type of this posting's account. Select the spend leg with account_type='expense', then read the sign: positive = purchase, negative = refund. Do NOT select the leg by sign — that inverts refunds."
+          },
           "amount_minor": {
             "type": "integer",
             "description": "Signed integer in the currency's minor unit (cents for USD, 1 for JPY, satoshi for BTC). Never store money as float.",
@@ -647,6 +658,7 @@
           "id",
           "transaction_id",
           "account_id",
+          "account_type",
           "amount_minor",
           "currency",
           "fx_rate",

--- a/src/insights/ask.ts
+++ b/src/insights/ask.ts
@@ -24,7 +24,7 @@ LEDGER SCHEMA (PostgreSQL; amounts in MINOR units — divide by 100 for dollars)
 - owned_items(id, product_id, transaction_item_id, acquired_on, condition, retired_at, target_days)
 - wish_items(id, title, target_price_minor, planned_days, urgency, status)
 - documents(id, kind, ocr_text) + document_links(document_id, transaction_id)
-CONVENTIONS: spending total for a period = SUM(p.amount_base_minor) joined to expense accounts with amount_base_minor > 0 and t.status IN ('posted','reconciled') AND t.deleted_at IS NULL. Dates are local; occurred_on is the receipt date.`;
+CONVENTIONS: spending total for a period = SUM(p.amount_base_minor) joined to expense accounts (a.type = 'expense') with t.status IN ('posted','reconciled') AND t.deleted_at IS NULL. Do NOT add an amount_base_minor > 0 filter: a refund is booked as a negative expense leg against the category it reverses, and excluding it overstates spend. Income sits on a.type = 'income' with a NEGATIVE amount, so report income as -SUM(p.amount_base_minor). Dates are local; occurred_on is the receipt date.`;
 
 export async function askLedger(
   workspaceId: string,

--- a/src/insights/discover.ts
+++ b/src/insights/discover.ts
@@ -14,9 +14,14 @@
  *    or reaching its achievement-plan `target_days` horizon.
  *
  * Money note: the expense side of a posting carries a POSITIVE
- * `amount_base_minor` (the card/cash side is the negative one), so the
- * rules filter on `amount_base_minor > 0` and compare the raw values —
- * no ABS() anywhere in this file.
+ * `amount_base_minor` on a purchase (the card/cash side is the negative
+ * one), so the rules select the spend leg with `a.type = 'expense'` and
+ * compare the raw values — no ABS() anywhere in this file.
+ *
+ * They do NOT also test the sign (#221). A refund posts the same pair
+ * reversed — expense −X, card +X — and that negative expense leg is a
+ * real reduction of the category it reverses. Filtering it out would
+ * make a month that netted out to nothing still register as a spike.
  */
 import { sql } from "drizzle-orm";
 import { db } from "../db/client.js";
@@ -52,7 +57,7 @@ export async function discoverInsights(workspaceId: string): Promise<number> {
       JOIN transactions t ON t.id = p.transaction_id
       JOIN accounts a ON a.id = p.account_id
       WHERE p.workspace_id = ${workspaceId}::uuid
-        AND t.status IN ('posted', 'reconciled') AND t.deleted_at IS NULL AND a.type = 'expense' AND p.amount_base_minor > 0
+        AND t.status IN ('posted', 'reconciled') AND t.deleted_at IS NULL AND a.type = 'expense'
         AND to_char(t.occurred_on, 'YYYY-MM') = ${thisYm}
       GROUP BY 1
     ), prev AS (
@@ -61,7 +66,7 @@ export async function discoverInsights(workspaceId: string): Promise<number> {
       JOIN transactions t ON t.id = p.transaction_id
       JOIN accounts a ON a.id = p.account_id
       WHERE p.workspace_id = ${workspaceId}::uuid
-        AND t.status IN ('posted', 'reconciled') AND t.deleted_at IS NULL AND a.type = 'expense' AND p.amount_base_minor > 0
+        AND t.status IN ('posted', 'reconciled') AND t.deleted_at IS NULL AND a.type = 'expense'
         AND to_char(t.occurred_on, 'YYYY-MM') = ${prevYm}
         AND EXTRACT(DAY FROM t.occurred_on) <= ${dayOfMonth}
       GROUP BY 1

--- a/src/routes/brands.ts
+++ b/src/routes/brands.ts
@@ -600,6 +600,11 @@ brandsRouter.get(
       const currency = ((wsRow.rows[0] as any)?.base_currency as string) ?? "USD";
 
       // 4. Per-merchant stats (money-counting rows only: posted/reconciled, not deleted)
+      //
+      // Spend sums pick the expense leg by account type, not by sign —
+      // see the same rule and its cost in `merchants.ts` / `reports.ts`
+      // (#221). `total_minor` on the recent-transaction rows below is
+      // likewise signed: negative means refund.
       const perMerchantStats = new Map<
         string,
         { txnCount: number; lifetime: number; currentMonth: number; lastDate: string | null }
@@ -614,9 +619,9 @@ brandsRouter.get(
           SELECT
             t.merchant_id::text AS merchant_id,
             COUNT(DISTINCT t.id)::bigint AS txn_count,
-            COALESCE(SUM(CASE WHEN p.amount_minor > 0 THEN p.amount_minor ELSE 0 END), 0)::bigint AS lifetime,
+            COALESCE(SUM(CASE WHEN a.type = 'expense' THEN p.amount_minor ELSE 0 END), 0)::bigint AS lifetime,
             COALESCE(SUM(CASE
-              WHEN p.amount_minor > 0
+              WHEN a.type = 'expense'
                AND t.occurred_on >= date_trunc('month', CURRENT_DATE)::date
                AND t.occurred_on <  (date_trunc('month', CURRENT_DATE) + interval '1 month')::date
               THEN p.amount_minor ELSE 0
@@ -624,6 +629,7 @@ brandsRouter.get(
             MAX(t.occurred_on)::text AS last_date
           FROM transactions t
           JOIN postings p ON p.transaction_id = t.id
+          JOIN accounts a ON a.id = p.account_id
           WHERE t.workspace_id = ${workspaceId}::uuid
             AND t.merchant_id IN (
               SELECT id FROM merchants
@@ -663,9 +669,10 @@ brandsRouter.get(
             m.canonical_name AS merchant_canonical_name,
             m.custom_name AS merchant_custom_name,
             (
-              SELECT COALESCE(SUM(CASE WHEN p.amount_minor > 0 THEN p.amount_minor ELSE 0 END), 0)::bigint
+              SELECT COALESCE(SUM(p.amount_minor), 0)::bigint
               FROM postings p
-              WHERE p.transaction_id = t.id
+              JOIN accounts a ON a.id = p.account_id
+              WHERE p.transaction_id = t.id AND a.type = 'expense'
             ) AS total_minor,
             (
               SELECT p.currency FROM postings p WHERE p.transaction_id = t.id LIMIT 1

--- a/src/routes/merchants.ts
+++ b/src/routes/merchants.ts
@@ -113,6 +113,19 @@ merchantsRouter.use(
  * KPIs (lifetime/current-month spend); they remain visible in the
  * companion `/transactions` endpoint so the merchant page can render
  * them with strikethrough.
+ *
+ * Spend sums pick the expense leg by ACCOUNT TYPE, via the `accounts`
+ * join (#221). They used to pick it by sign (`amount_minor > 0`), which
+ * on a refund selects the wrong leg entirely: a return posts expense −X
+ * / card +X, so the sign test grabbed the card's +X and reported a
+ * refund as if it were a purchase of the same size. Costco's lifetime
+ * spend read $7,320.91 against a true $7,154.59 for that reason. The
+ * type test is also the only correct selector here — unlike the
+ * `reports.ts` rollups this query has no `a.type` predicate to fall
+ * back on, so the join had to be ADDED rather than the sign test
+ * simply deleted. The join stays out of the row filter (the type test
+ * lives in the CASE) so `COUNT(DISTINCT t.id)` keeps counting every
+ * transaction, including any with no expense leg at all.
  */
 merchantsRouter.get(
   "/:id",
@@ -125,9 +138,9 @@ merchantsRouter.get(
       WITH s AS (
         SELECT
           COUNT(DISTINCT t.id)::bigint AS txn_count,
-          COALESCE(SUM(CASE WHEN p.amount_minor > 0 THEN p.amount_minor ELSE 0 END), 0)::bigint AS lifetime_spend,
+          COALESCE(SUM(CASE WHEN a.type = 'expense' THEN p.amount_minor ELSE 0 END), 0)::bigint AS lifetime_spend,
           COALESCE(SUM(CASE
-            WHEN p.amount_minor > 0
+            WHEN a.type = 'expense'
              AND t.occurred_on >= date_trunc('month', CURRENT_DATE)::date
              AND t.occurred_on <  (date_trunc('month', CURRENT_DATE) + interval '1 month')::date
             THEN p.amount_minor ELSE 0
@@ -135,6 +148,7 @@ merchantsRouter.get(
           MAX(t.occurred_on)::text AS last_date
         FROM transactions t
         JOIN postings p ON p.transaction_id = t.id
+        JOIN accounts a ON a.id = p.account_id
         WHERE t.workspace_id = ${req.ctx.workspaceId}::uuid
           AND t.merchant_id = ${merchant.id}::uuid
           AND t.status IN ('posted', 'reconciled') AND t.deleted_at IS NULL
@@ -171,6 +185,10 @@ merchantsRouter.get(
  * detail page. Sort is fixed at `occurred_on DESC, id DESC` (the same
  * keyset the ledger uses) so this can ride the
  * `transactions_merchant_idx` index. Cursor encodes "<date>|<id>".
+ *
+ * `total_minor` is the expense leg, signed (#221): positive for a
+ * purchase, NEGATIVE for a refund. Clients render the sign; they must
+ * not `Math.abs()` it, or a return reads as a second purchase.
  */
 merchantsRouter.get(
   "/:id/transactions",
@@ -196,9 +214,10 @@ merchantsRouter.get(
         t.payee,
         t.status::text AS status,
         (
-          SELECT COALESCE(SUM(CASE WHEN p.amount_minor > 0 THEN p.amount_minor ELSE 0 END), 0)::bigint
+          SELECT COALESCE(SUM(p.amount_minor), 0)::bigint
           FROM postings p
-          WHERE p.transaction_id = t.id
+          JOIN accounts a ON a.id = p.account_id
+          WHERE p.transaction_id = t.id AND a.type = 'expense'
         ) AS total_minor,
         (
           SELECT p.currency FROM postings p WHERE p.transaction_id = t.id LIMIT 1

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -10,6 +10,34 @@
  * user-supplied date range and the number of accounts), so these
  * endpoints return full arrays without keyset pagination.
  *
+ * ── Picking the spend leg: by ACCOUNT TYPE, never by sign (#221) ──────
+ *
+ * Every rollup here used to carry `AND p.amount_minor > 0` next to
+ * `a.type = 'expense'`. On a purchase the two say the same thing — the
+ * expense leg is the positive one, the card leg the negative one — so
+ * the sign test read as harmless belt-and-braces.
+ *
+ * It was not harmless. A refund posts the SAME pair with the signs
+ * reversed (expense −X, card +X), which is the only correct way to
+ * write one in a double-entry ledger: it nets the money back out of the
+ * category it was spent from. `> 0` dropped exactly that leg, so a
+ * refund already sitting correctly in the ledger was invisible to every
+ * report. Measured on production 2026-08-19: five such refunds, and
+ * `/v1/reports/summary` over all time read $312,046.70 against a true
+ * ledger balance of $311,782.44 — overstated by $264.26, the sum of the
+ * five. November 2024 Shopping read $512.75 against a true $441.58.
+ *
+ * `a.type = 'expense'` alone already selects the right leg, so the fix
+ * is to delete the sign test rather than to special-case refunds. The
+ * rule for anything added here later: **the expense leg is the spend
+ * leg regardless of sign.** A negative one is a refund and belongs in
+ * the total; filtering it out does not make the number more
+ * conservative, it makes it wrong.
+ *
+ * `merchants.ts` and `brands.ts` carry the same rule with a different
+ * shape — they had no `accounts` join at all, so there the sign test
+ * was the ONLY leg selector and had to be replaced by a join, not
+ * deleted. See the comments there.
  */
 import { Router, type Request, type Response, type NextFunction } from "express";
 import { sql } from "drizzle-orm";
@@ -162,7 +190,6 @@ async function getSpendPointsDisclosure(args: {
        WHERE p.workspace_id = ${args.workspaceId}::uuid
          AND t.status IN ('posted', 'reconciled') AND t.deleted_at IS NULL
          AND a.type = 'expense'
-         AND p.amount_minor > 0
          AND p.currency ~ ${POINTS_CURRENCY_SQL_RE}
          ${fromFilter}
          ${toFilter}
@@ -306,7 +333,6 @@ export async function getSummaryReport(
       WHERE p.workspace_id = ${args.workspaceId}::uuid
         AND t.status IN ('posted', 'reconciled') AND t.deleted_at IS NULL
         AND a.type = 'expense'
-        AND p.amount_base_minor > 0
         ${fromFilter}
         ${toFilter}
     )
@@ -401,7 +427,6 @@ export async function getTrendsReport(
       WHERE p.workspace_id = ${args.workspaceId}::uuid
         AND t.status IN ('posted', 'reconciled') AND t.deleted_at IS NULL
         AND a.type = 'expense'
-        AND p.amount_base_minor > 0
         ${fromFilter}
         ${toFilter}
     )
@@ -601,7 +626,7 @@ export async function getCashflowReport(
     SELECT
       month,
       COALESCE(-SUM(amount_base_minor) FILTER (WHERE acct_type = 'income'), 0)::bigint AS income_minor,
-      COALESCE(SUM(amount_base_minor)  FILTER (WHERE acct_type = 'expense' AND amount_base_minor > 0), 0)::bigint AS expense_minor
+      COALESCE(SUM(amount_base_minor)  FILTER (WHERE acct_type = 'expense'), 0)::bigint AS expense_minor
     FROM filtered
     GROUP BY month
     ORDER BY month ASC

--- a/src/routes/transactions.service.ts
+++ b/src/routes/transactions.service.ts
@@ -104,6 +104,10 @@ export interface PostingRow {
   id: string;
   transaction_id: string;
   account_id: string;
+  /** The posting's account's `type`, denormalized (#221). Selecting the
+   *  spend leg by type is the only correct way; by sign is wrong on
+   *  refunds. See `mapPostingRow`. */
+  account_type: "asset" | "liability" | "equity" | "income" | "expense";
   amount_minor: number;
   currency: string;
   fx_rate: string | null;
@@ -278,11 +282,25 @@ function bigintToNumberNullable(v: unknown): number | null {
   return bigintToNumber(v);
 }
 
+/**
+ * Coerce a posting row to the `Posting` DTO.
+ *
+ * `account_type` (#221) is denormalized from the posting's account on
+ * every fetch path, which is why each of those queries joins `accounts`.
+ * Without it a posting is not interpretable on its own: a client holding
+ * `{amount_minor: 7117}` cannot tell a $71.17 purchase (expense leg,
+ * positive) from the credit side of a $71.17 REFUND (liability leg,
+ * also positive). Clients used to guess with `amount_minor > 0`, which
+ * is right for purchases and backwards for refunds — the frontend's
+ * `totalMinorFromPostings` showed returns as same-size purchases for
+ * exactly that reason. Select the leg by type, then read the sign.
+ */
 function mapPostingRow(row: any): PostingRow {
   return {
     id: row.id,
     transaction_id: row.transactionId ?? row.transaction_id,
     account_id: row.accountId ?? row.account_id,
+    account_type: row.accountType ?? row.account_type,
     amount_minor: bigintToNumber(row.amountMinor ?? row.amount_minor),
     currency: row.currency,
     fx_rate: row.fxRate ?? row.fx_rate ?? null,
@@ -293,6 +311,21 @@ function mapPostingRow(row: any): PostingRow {
     created_at: toIsoString(row.createdAt ?? row.created_at),
   };
 }
+
+/** Column map for every drizzle posting fetch: the posting's own columns
+ *  plus `accountType` from the joined `accounts` row (#221). */
+const POSTING_COLUMNS = {
+  id: postings.id,
+  transactionId: postings.transactionId,
+  accountId: postings.accountId,
+  accountType: accounts.type,
+  amountMinor: postings.amountMinor,
+  currency: postings.currency,
+  fxRate: postings.fxRate,
+  amountBaseMinor: postings.amountBaseMinor,
+  memo: postings.memo,
+  createdAt: postings.createdAt,
+} as const;
 
 /**
  * Coerce a single row from `transaction_items` or a JSONB object to the
@@ -442,8 +475,9 @@ async function loadTransactionFull(
   if (rows.length === 0) return null;
   const t = rows[0]!;
   const posts = await runner
-    .select()
+    .select(POSTING_COLUMNS)
     .from(postings)
+    .innerJoin(accounts, eq(accounts.id, postings.accountId))
     .where(eq(postings.transactionId, id))
     .orderBy(postings.createdAt);
   const docLinks = await runner
@@ -1092,7 +1126,11 @@ export async function listTransactions(
   // straight back out of the page rows this function just selected.
   const idArrayLiteral = `ARRAY[${ids.map((i) => `'${i}'`).join(",")}]::uuid[]`;
   const postRes = await db.execute(
-    sql`SELECT * FROM postings WHERE transaction_id = ANY(${sql.raw(idArrayLiteral)}) ORDER BY created_at ASC`,
+    sql`SELECT p.*, a.type AS account_type
+          FROM postings p
+          JOIN accounts a ON a.id = p.account_id
+         WHERE p.transaction_id = ANY(${sql.raw(idArrayLiteral)})
+         ORDER BY p.created_at ASC`,
   );
   const postByTx = new Map<string, any[]>();
   for (const p of postRes.rows as any[]) {
@@ -1662,8 +1700,9 @@ export async function addPosting(
       });
 
       const postRows = await tx
-        .select()
+        .select(POSTING_COLUMNS)
         .from(postings)
+        .innerJoin(accounts, eq(accounts.id, postings.accountId))
         .where(eq(postings.id, newPostingId));
       return mapPostingRow(postRows[0]!);
     });
@@ -1728,8 +1767,9 @@ export async function updatePosting(
       });
 
       const postRows = await tx
-        .select()
+        .select(POSTING_COLUMNS)
         .from(postings)
+        .innerJoin(accounts, eq(accounts.id, postings.accountId))
         .where(eq(postings.id, postingId));
       return mapPostingRow(postRows[0]!);
     });
@@ -1832,7 +1872,12 @@ export async function listPostings(
 
   const where = sql.join(conditions, sql` AND `);
   const res = await db.execute(
-    sql`SELECT * FROM postings p WHERE ${where} ORDER BY p.created_at DESC, p.id DESC LIMIT ${limit + 1}`,
+    sql`SELECT p.*, a.type AS account_type
+          FROM postings p
+          JOIN accounts a ON a.id = p.account_id
+         WHERE ${where}
+         ORDER BY p.created_at DESC, p.id DESC
+         LIMIT ${limit + 1}`,
   );
   const rows = res.rows as any[];
   const hasMore = rows.length > limit;
@@ -1855,8 +1900,9 @@ export async function getPosting(
   id: string,
 ): Promise<PostingRow> {
   const rows = await db
-    .select()
+    .select(POSTING_COLUMNS)
     .from(postings)
+    .innerJoin(accounts, eq(accounts.id, postings.accountId))
     .where(
       and(eq(postings.id, id), eq(postings.workspaceId, workspaceId)),
     );

--- a/src/schemas/v1/transaction.ts
+++ b/src/schemas/v1/transaction.ts
@@ -41,6 +41,19 @@ export const Posting = z
     id: Uuid,
     transaction_id: Uuid,
     account_id: Uuid,
+    /** Type of the posting's account, denormalized so a posting is
+     *  interpretable on its own (#221). Pick the spend leg with
+     *  `account_type === 'expense'` and then READ THE SIGN — positive is
+     *  a purchase, negative is a refund of one. Picking the leg by sign
+     *  instead silently inverts every refund. */
+    account_type: z
+      .enum(["asset", "liability", "equity", "income", "expense"])
+      .openapi({
+        description:
+          "Type of this posting's account. Select the spend leg with " +
+          "account_type='expense', then read the sign: positive = purchase, " +
+          "negative = refund. Do NOT select the leg by sign — that inverts refunds.",
+      }),
     amount_minor: AmountMinor,
     currency: LedgerCurrencyCode,
     fx_rate: z.string().nullable(), // numeric returned as string from pg


### PR DESCRIPTION
Closes the reporting half of #221.

## What was wrong

Ten call sites selected the spend leg with `amount_minor > 0`. On a purchase that agrees with `a.type = 'expense'`; on a refund it is backwards. Five refunds are already sitting correctly in the ledger (expense −X, card +X) and every report dropped or inverted them.

Measured on the mini before this change:

| | reported | ledger truth |
|---|---|---|
| `/v1/reports/summary` all-time | $312,046.70 | $311,782.44 |
| `/v1/reports/summary` 2024-11 Shopping | $512.75 / 2 txns | $441.58 / 4 txns |
| `/v1/reports/trends` 2024-11 Shopping | $512.75 | $441.58 |
| `/v1/reports/cashflow` 2024-11 expense | $512.75 | $441.58 |
| merchant Costco `lifetime_spend_minor` | 732091 | 715459 |
| 2024-11-16 return row `total_minor` | +7117 | −7117 |

## What changed

- `reports.ts` ×4, `insights/discover.ts` ×2 — the `a.type = 'expense'` join already selects the leg, so the sign test is deleted outright.
- `merchants.ts` ×3, `brands.ts` ×3 — these had no `accounts` join, so the sign test was the only selector and deleting it would sum both legs to zero. The join is added instead, with the type test inside the `CASE` so `COUNT(DISTINCT t.id)` keeps counting transactions that have no expense leg.
- `insights/ask.ts` — the NL-to-SQL convention text told the model to add the filter. It now tells it not to, and how income signs work.
- `Posting` DTO gains `account_type`. A posting alone was not interpretable: `{amount_minor: 7117}` is either a $71.17 purchase or the credit side of a $71.17 refund. All six posting fetch paths join `accounts` to populate it.

## Verification

`scripts/`-external check script re-run against the mini after deploy; all six rows above must read `truth`. Typecheck clean; `openapi.json` regenerated in the same commit.

## Not in this PR

The extractor still rejects refund documents as `unsupported` (13 stranded, most recent 2026-08-04) and has no income path (12 more). That is the next PR on #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjTM69U9y1uTGySx1PDYub