### PR TITLE
Serialize production extraction (MAX_CLAUDE_CONCURRENCY=1) to close the same-batch dedup race

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,12 +75,21 @@ services:
       # via its Bash tool (for Phase 3 geocoding during extraction). Empty
       # is fine — the prompt instructs the agent to skip geocoding.
       GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY:-}
-      # Worker concurrency for `claude -p` extraction. Default 3 is fine
-      # for steady-state single-receipt uploads but starves batch evals
-      # (e.g. scripts/eval-dates.ts on a 23-fixture manifest). CPU floor is
-      # ~10% even at concurrency 3 — host has headroom. Bumped to 6 to
-      # halve eval wall-clock without straining Anthropic API rate limits.
-      MAX_CLAUDE_CONCURRENCY: ${MAX_CLAUDE_CONCURRENCY:-6}
+      # Worker concurrency for `claude -p` extraction. PRODUCTION RUNS
+      # SERIALIZED (1) ON PURPOSE — this is a correctness setting, not a
+      # throughput one. Two documents of the same money event uploaded in
+      # one batch cannot see each other while their extractions overlap:
+      # neither one's Turn A candidate query finds the other's not-yet-
+      # written transaction, so both are booked and the ledger double
+      # counts (#225 — two real double counts on 2026-08-19). At 1 the
+      # second extraction starts after the first has committed, so the
+      # existing ±30-day identifier search finds it and the race is gone.
+      # Latency is not the trade it looks like: uploads are fire-and-
+      # forget (users photograph and walk away), so N receipts taking
+      # N×30-60s instead of N/6 costs nobody anything. DO NOT raise this
+      # to speed up an eval — the sandbox (docker-compose.test.yml) keeps
+      # 6 for exactly that, on throwaway data where dedup doesn't matter.
+      MAX_CLAUDE_CONCURRENCY: ${MAX_CLAUDE_CONCURRENCY:-1}
       # logo.dev API keys for #101 Phase 2 brand-icon acquisition. The
       # publishable key (pk_…) is embedded in img.logo.dev URLs the agent
       # follows; the secret key (sk_…) authorizes api.logo.dev/search,

--- a/scripts/smoke-batch.md
+++ b/scripts/smoke-batch.md
@@ -28,7 +28,7 @@ Expected: HTTP 202 + JSON with `batchId`, `status="pending"`, `items[]`, `poll`.
 
 ## Step 2 — Poll for completion
 
-Each file spawns its own `claude -p` (bounded by `MAX_CLAUDE_CONCURRENCY`, default 3). Expect 15–60 seconds per file.
+Each file spawns its own `claude -p` (bounded by `MAX_CLAUDE_CONCURRENCY` — **1 in production**, 6 in the sandbox). Production is serialized on purpose so same-batch dedup can see each preceding write (#225), so expect 15–60 seconds **per file, sequentially**.
 
 ```bash
 while :; do

--- a/src/ingest/worker.ts
+++ b/src/ingest/worker.ts
@@ -8,10 +8,13 @@
  * the agent updated to build the SSE event payload.
  *
  * Design notes
- *   - Concurrency is capped by `MAX_CLAUDE_CONCURRENCY` (default 3).
- *     Claude CLI calls dominate latency (30-60s each with geocoding +
- *     SQL writes) and three in parallel is empirically enough for a
- *     laptop host without starving OAuth refresh.
+ *   - Concurrency is capped by `MAX_CLAUDE_CONCURRENCY` (code default 3;
+ *     production compose pins 1, the sandbox 6). Production is serialized
+ *     for CORRECTNESS, not throughput: overlapping extractions of two
+ *     documents describing one money event cannot see each other's
+ *     not-yet-written transaction, so same-batch dedup misses and the
+ *     ledger double counts (#225). Serial extraction closes that window.
+ *     Uploads are fire-and-forget, so the wall-clock cost is unfelt.
  *   - No resume on restart. On boot we scan for `pending/processing`
  *     batches older than 5 minutes and mark them `failed`; in-flight
  *     ingests of those batches flip to `error`. Durable queuing is a


### PR DESCRIPTION
## Summary

`#225` proposed building a second dedup grouping pass over shared identifier values. Per owner decision, we take the cheaper route instead: **remove the race rather than detect its consequences.**

Two documents of one money event uploaded in the same batch cannot see each other while their extractions overlap — neither one's Turn A candidate query finds the other's not-yet-written transaction, so both are booked. At concurrency 1 the second extraction starts only after the first has committed, so the existing ±30-day identifier search (shipped in #204) finds it. No new engine, no new scoring, no new eval surface.

## What changed

- `docker-compose.yml` — prod default `6` → **`1`**, with the rationale recorded as a correctness constraint so it doesn't get raised for throughput later.
- `docker-compose.test.yml` — **unchanged at 6.** Evals need the wall-clock and run on throwaway data where dedup correctness is irrelevant.
- `src/ingest/worker.ts` — design note said "default 3 … three in parallel is empirically enough". Both halves were wrong; corrected.
- `scripts/smoke-batch.md` — same stale "default 3".

## Two things found while doing this

1. **Production was running at 6, not 3.** The code default is 3 but compose overrode it, so the race was six wide, not three. Every doc describing this setting said 3.
2. **6 is exactly where rate limiting was measured.** `docs/async-pipeline-rewrite.md` Bug #4 recorded 6–7 concurrent `claude -p` calls stalling to 1200–1500s versus 31–93s in isolation. Prod has been sitting on that threshold; serializing should improve tail latency, not just correctness.

## Trade-off

A batch of N receipts now takes N × 30–60s instead of N/6. Uploads are fire-and-forget — users photograph and walk away rather than waiting on a result — so this is not felt. Raising it back for speed reintroduces the double count.

## Not covered

`#225`'s second pair (reCell $470 packing-slip quote vs $400 check, 10 days apart) is not addressed and does not need to be. Different amounts by design, and the issue itself concedes a quote is not a money event at all — already handled by a `lessons.md` entry.

## Verification

Both compose files still parse and still pin `name:` (the #193 invariant that keeps the sandbox from deleting prod). Deploy check is `docker logs receipt-assistant | grep concurrency` reading `concurrency 1`.

Closes #225