### PR TITLE
Expose paid_currency + paid_base_minor on OwnedItemExpanded

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2158,6 +2158,18 @@
                   "null"
                 ]
               },
+              "paid_currency": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "paid_base_minor": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
               "payee": {
                 "type": [
                   "string",

--- a/src/routes/owned-items.ts
+++ b/src/routes/owned-items.ts
@@ -104,6 +104,11 @@ function expandedExtras(row: any) {
       row.paid_minor === null || row.paid_minor === undefined
         ? null
         : Number(row.paid_minor),
+    paid_currency: row.paid_currency ?? null,
+    paid_base_minor:
+      row.paid_base_minor === null || row.paid_base_minor === undefined
+        ? null
+        : Number(row.paid_base_minor),
     payee: row.payee ?? null,
     merchant_brand_id: row.merchant_brand_id ?? null,
   };
@@ -149,6 +154,24 @@ ownedItemsRouter.get(
                   COALESCE(p.custom_name, p.canonical_name) AS product_name,
                   p.item_class AS item_class,
                   COALESCE(ti.effective_total_minor, ti.line_total_minor) AS paid_minor,
+                  ti.currency AS paid_currency,
+                  -- #216: the base-currency equivalent, via the rate the
+                  -- transaction's OWN posting was converted at. Both the FX
+                  -- pass and the points valuation pass write fx_rate with
+                  -- the same "multiply to reach base minor" meaning, so one
+                  -- expression covers a CNY line and a HYATT_PT line alike.
+                  --
+                  -- NULL fx_rate on a non-base line means nobody ever
+                  -- converted it, so the answer is UNKNOWN and this stays
+                  -- NULL. Coalescing to 1 would hand back yuan labelled as
+                  -- dollars, which is the bug being fixed.
+                  CASE
+                    WHEN fx.rate IS NOT NULL
+                      THEN ROUND(COALESCE(ti.effective_total_minor, ti.line_total_minor) * fx.rate)
+                    WHEN ti.currency = w.base_currency
+                      THEN COALESCE(ti.effective_total_minor, ti.line_total_minor)
+                    ELSE NULL
+                  END AS paid_base_minor,
                   t.payee AS payee,
                   m.brand_id AS merchant_brand_id
                 FROM owned_items o
@@ -156,6 +179,15 @@ ownedItemsRouter.get(
                 LEFT JOIN transaction_items ti ON ti.id = o.transaction_item_id
                 LEFT JOIN transactions t ON t.id = ti.transaction_id
                 LEFT JOIN merchants m ON m.id = t.merchant_id
+                LEFT JOIN workspaces w ON w.id = o.workspace_id
+                LEFT JOIN LATERAL (
+                  SELECT po.fx_rate AS rate
+                    FROM postings po
+                   WHERE po.transaction_id = ti.transaction_id
+                     AND po.currency = ti.currency
+                     AND po.fx_rate IS NOT NULL
+                   LIMIT 1
+                ) fx ON TRUE
                 WHERE ${where} ORDER BY o.updated_at DESC, o.id DESC LIMIT ${limit + 1}`
           : sql`SELECT * FROM owned_items o WHERE ${where} ORDER BY o.updated_at DESC, o.id DESC LIMIT ${limit + 1}`,
       );

--- a/src/schemas/v1/owned-item.ts
+++ b/src/schemas/v1/owned-item.ts
@@ -41,7 +41,28 @@ export const OwnedItem = z
 export const OwnedItemExpanded = OwnedItem.extend({
   product_name: z.string().nullable().optional(),
   item_class: z.string().nullable().optional(),
+  /** What the line cost, **in the currency the line was recorded in** —
+   *  which is NOT necessarily the workspace base currency, and is not
+   *  necessarily even cash. Read it with `paid_currency`; on its own it
+   *  is an integer of unknown unit and unknown scale (points are stored
+   *  as whole units, cash as hundredths). For anything that sums or
+   *  divides — a $/day, a portfolio total — use `paid_base_minor`. */
   paid_minor: z.number().int().nullable().optional(),
+  /** Currency of `paid_minor`: an ISO-4217 code, or a points code such as
+   *  `HYATT_PT` for an award-acquired item (#206). Added in #216 — before
+   *  it, clients had no way to tell a CNY line from a USD one and six live
+   *  rows rendered yuan behind a dollar sign. */
+  paid_currency: z.string().nullable().optional(),
+  /** `paid_minor` converted to the workspace base currency at the rate the
+   *  transaction's own posting was converted at, so it is directly
+   *  comparable and summable across items.
+   *
+   *  **Null means the conversion is unknown, not zero** — a non-base line
+   *  whose transaction never got an `fx_rate` (e.g. a zero-total receipt).
+   *  Clients must suppress derived figures rather than fall back to
+   *  `paid_minor`, which is the exact substitution this field exists to
+   *  stop. */
+  paid_base_minor: z.number().int().nullable().optional(),
   payee: z.string().nullable().optional(),
   merchant_brand_id: z.string().nullable().optional(),
 }).openapi("OwnedItemExpanded");


### PR DESCRIPTION
Backend half of the last open AC on TINKPA/receipt-assistant-frontend#161 (`$/day` on an award-acquired durable). Refs #216.

## The AC asked about points; the path is already broken for cash

`paid_minor` is served as a bare integer — `COALESCE(ti.effective_total_minor, ti.line_total_minor)`, in whatever currency the line was recorded in — and **nothing in the payload said which currency that was**. The frontend consumes it as `paid_minor / 100` behind a hard-coded `$`.

That is live today:

| item | actually paid | Things renders |
|---|---|---|
| iPad mini (6th gen) 64GB | CNY 4,499.00 | **$4,499** |
| Pure Gold Earrings (AU99.9) | CNY 2,732.00 | **$2,732** |
| HomePod mini × 2 | CNY 749.00 each | **$749** each |

Six CNY rows, all summed into a dollar portfolio total and a dollar `$/day`. Same class as #184, in a surface #184 never reached. An award-acquired durable would be worse — points are whole units, not hundredths, so it would be off by 100× *and* denominated in something that is not money.

The frontend cannot fix this alone; it has no way to know the unit. Hence a contract change first, per the dependency order in the repo conventions.

## What is added

- **`paid_currency`** — the unit `paid_minor` is in. ISO-4217, or a points code (`HYATT_PT`).
- **`paid_base_minor`** — the same amount in the workspace base currency, converted at the rate the transaction's own posting carries.

One `CASE` covers both currency families, because the FX pass and the points valuation pass both write `fx_rate` with the same *multiply to reach base minor* meaning. Verified against all six live non-USD rows before the expression was written:

```
currency | item_minor |   fx_rate    | computed_base
CNY      |      74900 | 0.1582400000 |         11852
CNY      |      74900 | 0.1398700000 |         10476
CNY      |     449900 | 0.1573900000 |         70810
CNY      |     273200 |    (null)    |        (null)
CNY      |     164700 |    (null)    |        (null)
CNY      |      49900 | 0.1482500000 |          7398
```

## NULL means unknown, and that is load-bearing

Two rows have no rate at all — they hang off a zero-total King Tai Fook receipt whose postings are all `amount_minor = 0` with `fx_rate IS NULL`. `COALESCE(rate, 1)` there would return `273200` as if it were `$2,732.00`, which is precisely the defect being removed. So the expression returns **NULL**, and the schema tells clients to suppress the derived figure rather than fall back to `paid_minor`.

That fallback is the obvious next mistake, so it is documented on the field rather than left to be rediscovered.

## Compatibility

Purely additive — two optional nullable fields on an expanded response. No existing field changes meaning or value. `tsc --noEmit` clean; schema, handler, and regenerated `openapi.json` in one commit per the contract rule.