### PR TITLE
Stop the prompt lying about the chart of accounts, and stop offering the query that proved it wrong (#233)

### DIFF
--- a/src/ingest/prompt.ts
+++ b/src/ingest/prompt.ts
@@ -112,7 +112,10 @@ ${PSQL_DISCIPLINE}
 
 Optional: if you want to discover schema details, \`\\d\` works:
   psql "\$DATABASE_URL" -c "\\d transactions"
-  psql "\$DATABASE_URL" -c "SELECT id, name, type FROM accounts WHERE workspace_id = '${ctx.workspaceId}' ORDER BY type, name"
+
+Do NOT spend a turn listing \`accounts\`. The names are fixed (Phase 4
+primer) and every id is resolved inline as a CTE in the write, so that
+query cannot tell you anything the prompt has not already told you.
 
 ${agentHygiene({ scratchDir, filePath: ctx.filePath, path: "ingest" })}
 ${renderActiveLessons()}
@@ -651,11 +654,20 @@ transaction as already-up-to-date and skip it.
 v1 schema primer (workspace_id is required on every row):
 
   accounts        — chart of accounts; type IN (asset|liability|equity|income|expense)
-                   seeded for WORKSPACE_ID:
-                     expense: Dining, Groceries, Transport, Utilities,
-                              Entertainment, Other, Expenses (parent)
+                   You never need to query this table. The expense
+                   account name IS the \`merchant.category\` you emit in
+                   Phase 2.5 — the seven canonical names are listed once,
+                   in 4.1 — and every id you need is resolved inline as a
+                   CTE in the write statement itself. The other types are
+                   fixed:
                      liability: Credit Card
-                     asset: Cash, Checking, Savings
+                     asset:     Cash, Checking, Savings
+                     income:    Salary, Other
+                     equity:    Opening Balance
+                   Each type also has a parent row (Expenses, Assets,
+                   Liabilities, Income, Equity) — never post to a parent.
+                   Points accounts ("World of Hyatt points", #206/#215)
+                   are created on demand by the write, not seeded.
   transactions    — one per receipt (or one per statement row)
                    status IN (draft|posted|reconciled|error)
                    set status='posted' for completed receipts.


### PR DESCRIPTION
The primer was only half of it. Line 115 also **offered the agent the exact query** that would settle what the primer had got wrong.

## What was wrong

Migration `0007_align_expense_accounts_to_seven.sql` (#68) renamed `Dining → Food & Drinks`, `Transport → Transportation`, `Utilities → Services`, `Other → Shopping`, merged **and dropped** `Groceries`, and added `Travel` and `Health`. `src/ingest/prompt.ts:655` still described the world before that migration:

```
                   seeded for WORKSPACE_ID:
                     expense: Dining, Groceries, Transport, Utilities,
                              Entertainment, Other, Expenses (parent)
```

Four of those seven do not exist. `Other` exists but as an **income** account. The six that do exist were not listed. `src/db/seed.ts:77-85` and the migration were correct the whole time — only the prompt drifted.

Then, 540 lines earlier:

```
Optional: if you want to discover schema details, `\d` works:
  psql "$DATABASE_URL" -c "\d transactions"
  psql "$DATABASE_URL" -c "SELECT id, name, type FROM accounts WHERE workspace_id = '…' ORDER BY type, name"
```

An agent that reads a primer it cannot trust, is handed the query that would resolve it, and only meets the real rule 350 lines further on in 4.1 — *"the expense account name is **exactly** the `merchant.category` value you emitted in Phase 2.5"* — will run that query. It shows up as **turn 6 of 10** in session `2d8659bf`:

```
  6   108,766 rd   1,755 wr  3,747 out  Bash psql … -c "SELECT id, name, type FROM accounts WHERE workspace_id = '…' ORDER BY t…"
```

At ~110K tokens of context re-read per turn (#227), advertising a query the prompt has already answered is not a small thing.

## The fix

**State the invariant, not a snapshot.** Re-listing the seven names in a second place is precisely what let them drift, so the primer now points at the single canonical list in 4.1 instead of repeating it:

```
  accounts        — chart of accounts; type IN (asset|liability|equity|income|expense)
                   You never need to query this table. The expense
                   account name IS the `merchant.category` you emit in
                   Phase 2.5 — the seven canonical names are listed once,
                   in 4.1 — and every id you need is resolved inline as a
                   CTE in the write statement itself. The other types are
                   fixed:
                     liability: Credit Card
                     asset:     Cash, Checking, Savings
                     income:    Salary, Other
                     equity:    Opening Balance
                   Each type also has a parent row (Expenses, Assets,
                   Liabilities, Income, Equity) — never post to a parent.
                   Points accounts ("World of Hyatt points", #206/#215)
                   are created on demand by the write, not seeded.
```

It now also records three things it never did: the income/equity names, that every type has a parent row you must not post to, and that points accounts are created on demand.

**And stop offering the query.** The accounts line is gone from the discovery hint, replaced by an explicit instruction not to spend a turn on it.

## Verified

On the rendered prompt (`buildExtractorPrompt` with an empty context):

```
rendered chars: 168,510
  stale name "Dining" still present?      no
  stale name "Groceries" still present?   no
  stale name "Transport," still present?  no
  stale name "Utilities" still present?   no
  offers accounts SELECT?                 no
  says do-not-list?                       yes
```

`tsc` clean; prompt budget `+689 B` (well inside the 4,096 B allowance, baseline untouched).

## Not verified yet, and I want to be straight about it

**No end-to-end run on a real receipt.** The project rule is to run the manual flow on a known-hard receipt after any prompt change, and I could not do it without writing to the production ledger:

- The `receipts-test` sandbox is down (4 weeks) and, more to the point, `docker-compose.test.yml:85` bind-mounts **the same** `receipt-assistant-data/claude` directory as production. Two Claude clients on one credentials dir is the Era-2 failure recorded in `CLAUDE.md` — they rotate each other's refresh tokens. Its compose comments also say it bypasses `claude -p`, so it would not exercise the extractor anyway.
- Re-extract cannot test this: `reextract-prompt.ts` has no accounts references at all — it does not write postings.

So both acceptance criteria that need a live run are still open. The change is safe regardless (it removes four provably non-existent names and one redundant query), but "the agent no longer runs the accounts SELECT" is a prediction here, not a measurement. Next real upload settles it:

```bash
npm run measure:turns -- --dir=/tmp/j --last=1 --turns
```

Baseline: the six sessions in `notes/2026-08-31_analysis_ingest-turn-cost.md`, median 1,231,084 billed input over 7–19 turns.

## Found in passing, not fixed here

The same migration left **`scripts/smoke-v1-ingest.ts:257-260` broken**, not merely stale — it does `find(a => a.type === "expense" && a.name === "Groceries", …)` and throws `seeded account missing: Expenses:Groceries` on a correctly seeded database, because 0007 dropped that account. `Dining`, `Transport` and expense-`Other` on the following lines are gone too, and `scripts/smoke-v1-ingest.md:8,35` documents the old names. Out of scope for this issue — flagging rather than fixing.

Fixes #233
